### PR TITLE
Rename site to BroWorld and add home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 <h1 align="center">
-  Inspira UI
+  BroWorld
 </h1>
 <p align="center">
   <b>Build beautiful websites using Vue & Nuxt.</b><br>
@@ -30,16 +30,16 @@
 
 ---
 
-Welcome to [**Inspira UI**](https://inspira-ui.com), a community-driven project that brings the beauty and functionality of both [Aceternity UI](https://ui.aceternity.com) and [Magic UI](https://magicui.design) to the [Vue](https://vuejs.org) & [Nuxt](https://nuxt.com) ecosystem! While this project draws inspiration from these sources, it also includes unique custom components contributed by the community and created by us.
+Welcome to **BroWorld**, a community-driven project that brings the beauty and functionality of both [Aceternity UI](https://ui.aceternity.com) and [Magic UI](https://magicui.design) to the [Vue](https://vuejs.org) & [Nuxt](https://nuxt.com) ecosystem! While this project draws inspiration from these sources, it also includes unique custom components contributed by the community and created by us.
 For **Chinese version** visit [here](README_CN.md).
 
-## ✨ About Inspira UI
+## ✨ About BroWorld
 
-Inspira UI is a collection of elegant, ready-to-use Vue components designed to be flexible and easy to integrate. Rather than being a traditional component library, it allows you to pick, customize, and adapt components as needed, giving you the freedom to shape them to fit your unique project requirements.
+BroWorld is a collection of elegant, ready-to-use Vue components designed to be flexible and easy to integrate. Rather than being a traditional component library, it allows you to pick, customize, and adapt components as needed, giving you the freedom to shape them to fit your unique project requirements.
 
-## 🚀 Why Inspira UI?
+## 🚀 Why BroWorld?
 
-Inspira UI was created to fill a gap in the Vue community by providing a set of components with the aesthetics and functionality of both Aceternity UI and Magic UI. Our goal is to empower developers to build beautiful applications more efficiently while adding our own custom and community-driven designs.
+BroWorld was created to fill a gap in the Vue community by providing a set of components with the aesthetics and functionality of both Aceternity UI and Magic UI. Our goal is to empower developers to build beautiful applications more efficiently while adding our own custom and community-driven designs.
 
 ## 🎯 Key Features
 
@@ -51,7 +51,7 @@ Inspira UI was created to fill a gap in the Vue community by providing a set of 
 
 ## 📚 Documentation
 
-For full documentation and usage examples, visit [**Inspira UI Documentation**](https://inspira-ui.com).
+For full documentation and usage examples, visit the BroWorld documentation site.
 
 ## 🙏 Acknowledgments
 
@@ -64,7 +64,7 @@ A special thanks to:
 
 ## 👤 Author
 
-Hi, I'm [Rahul Vashishtha](https://rahulv.dev). I started Inspira UI to bring a similar experience to the Vue ecosystem, inspired by Aceternity UI, Magic UI, and community contributions. I'm continuously working on it to make it better. Feel free to check out my work on [GitHub](https://github.com/rahul-vashishtha) and join me on this journey [here](https://github.com/unovue/inspira-ui)!
+Hi, I'm Rami Aouinti. I started BroWorld to bring a similar experience to the Vue ecosystem, inspired by Aceternity UI, Magic UI, and community contributions. I'm continuously working on it to make it better. Feel free to join me on this journey!
 
 ## 🌟 Contribute
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -6,7 +6,7 @@ import { $t } from "./i18n/locales";
 export default defineAppConfig({
   shadcnDocs: {
     site: {
-      name: "Inspira UI",
+      name: "BroWorld",
       description: "Build beautiful websites using Vue & Nuxt.",
       ogImage: "https://cdn.inspira-ui.com/og-image-v2.1.png",
     },
@@ -24,7 +24,7 @@ export default defineAppConfig({
       border: true,
     },
     header: {
-      title: "Inspira UI",
+      title: "BroWorld",
       showTitle: true,
       darkModeToggle: true,
       logo: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -49,13 +49,13 @@ export default defineNuxtConfig({
     baseURL: process.env.NODE_ENV === "development" ? "/" : "/docs/",
   },
   llms: {
-    domain: "https://inspira-ui.com/",
-    title: "Inspira UI",
+    domain: "https://broworld.com/",
+    title: "BroWorld",
     description:
-      "Inspira UI is a free and open-source Vue.js component library that provides a collection of beautiful and customizable components for building modern web applications.",
+      "BroWorld is a free and open-source Vue.js component library that provides a collection of beautiful and customizable components for building modern web applications.",
     full: {
-      title: "Inspira UI Documentation",
-      description: "The complete Inspira UI documentation.",
+      title: "BroWorld Documentation",
+      description: "The complete BroWorld documentation.",
     },
   },
   i18n: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="flex min-h-screen items-center justify-center text-2xl font-semibold">
+    hello
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- rebrand the Nuxt site configuration from Inspira UI to BroWorld
- refresh the README title and author section to match the new branding
- add a minimal home page that displays a centered "hello" placeholder

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3fa83954883269c6a6f5fc62bb9a1