### PR TITLE
Remove legacy banner and update project ownership info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui">
     <img src="./logo.png" alt="Logo" width="150" />
   </a>
 </p>
@@ -12,10 +12,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/unovue/inspira-ui?style=social">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/bro-world/bro-world-frontend-ui?style=social">
   </a>
-  <a href="https://github.com/unovue/inspira-ui/blob/main/LICENSE.md">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/License-MIT-yellow.svg">
   </a>  
 </p>
@@ -43,7 +43,7 @@ BroWorld was created to fill a gap in the Vue community by providing a set of co
 
 ## 🎯 Key Features
 
-- **Free and Open Source**: Completely [open source](https://github.com/unovue/inspira-ui) under the MIT license.
+- **Free and Open Source**: Completely [open source](https://github.com/bro-world/bro-world-frontend-ui) under the MIT license.
 - **Highly Configurable**: Tailor components to your specific design needs. Check out our [configuration guide](/api/configuration).
 - **Diverse Component Range**: A broad selection of [components](/components), inspired by Aceternity UI, Magic UI, and custom contributions, to help you build anything you imagine.
 - **Mobile Optimized**: Designed to look great on all devices.
@@ -64,24 +64,20 @@ A special thanks to:
 
 ## 👤 Author
 
-Hi, I'm Rami Aouinti. I started BroWorld to bring a similar experience to the Vue ecosystem, inspired by Aceternity UI, Magic UI, and community contributions. I'm continuously working on it to make it better. Feel free to join me on this journey!
+Hi, I'm **BroWorld**. I maintain this project to bring a polished, ready-to-use experience to the Vue ecosystem, inspired by Aceternity UI, Magic UI, and the creativity of the community. I'm continuously working on it to make it better. Feel free to join me on this journey and connect with me on [GitHub](https://github.com/bro-world)!
 
 ## 🌟 Contribute
 
-We welcome contributions! If you want to suggest features, report bugs, or help improve the project, feel free to open an issue or submit a pull request on [GitHub](https://github.com/unovue/inspira-ui).
+We welcome contributions! If you want to suggest features, report bugs, or help improve the project, feel free to open an issue or submit a pull request on [GitHub](https://github.com/bro-world/bro-world-frontend-ui).
 
 You can also follow this [Contribution Guide](https://inspira-ui.com/getting-started/contribution).
 
 ## Sponsorship
 
-You can also support the development of the project by sponsoring the developer.
+You can also support the development of the project by sponsoring the maintainer.
 
-Support and sponsor the maintainer here: [Support Inspira UI](https://github.com/sponsors/rahul-vashishtha)
+Support the project here: [Sponsor BroWorld](https://github.com/sponsors/bro-world)
 
 ## Repo Stats
 
 ![Repo Stats](https://repobeats.axiom.co/api/embed/da99e5e9c8ddaaff68b7f57b56ae21d5e0ea2ed2.svg "Repobeats analytics image")
-
-## Thanks to all the contributors 🙏
-
-[![Contributors](https://contrib.rocks/image?repo=unovue/inspira-ui)](https://github.com/unovue/inspira-ui/graphs/contributors)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui">
     <img src="./logo.png" alt="Logo" width="150" />
   </a>
 </p>
@@ -12,10 +12,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/unovue/inspira-ui?style=social">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/bro-world/bro-world-frontend-ui?style=social">
   </a>
-  <a href="https://github.com/unovue/inspira-ui/blob/main/LICENSE.md">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/License-MIT-yellow.svg">
   </a>  
 </p>
@@ -42,7 +42,7 @@ Inspira UI 的出道旨在填补 Vue 社区生态的一个空白，它提供了�
 
 ## 🎯 关键特性
 
-- **免费且开源**: 完全于MIT协议开源于： [此处](https://github.com/unovue/inspira-ui)
+- **免费且开源**: 完全于MIT协议开源于： [此处](https://github.com/bro-world/bro-world-frontend-ui)
 - **高度个性化**: 根据您的具体设计需求设计组件。可参考我们的 [设计指南](/api/configuration).
 - **组件多样化**: 我们有来自于 Aceternity UI，Magic UI与社区贡献的许多 [组件](/components) 来帮助你实现你想呈现的内容
 - **移动端支持**: 我们的设计在移动端设备上依旧美观
@@ -63,11 +63,11 @@ Inspira UI 的出道旨在填补 Vue 社区生态的一个空白，它提供了�
 
 ## 👤 作者的话
 
-你好呀，这里是作者 [Rahul Vashishtha](https://rahulv.dev)。受Aceternity UI、Magic UI和社区贡献的启发，我创建了Inspira UI项目，为Vue生态系统带来类似的体验。 为了让这个项目越来越好，我正在努力地完善项目内容。如果你感兴趣的话，你可以在 [GitHub](https://github.com/rahul-vashishtha) 这里查看我的进度。有能力的话，你还可以选择在 [这里](https://github.com/unovue/inspira-ui) 加入我们共同的旅途。海内存知己，天涯若比邻。Coding的路上有你便不孤单。
+你好呀，这里是项目维护者 [BroWorld](https://github.com/bro-world)。受 Aceternity UI、Magic UI 和社区贡献的启发，我持续维护这个项目，为 Vue 生态系统带来类似的体验。为了让这个项目越来越好，我正在努力完善各项内容，欢迎你加入这个旅程，与我一起让 BroWorld 成长！
 
 ## 🌟 贡献
 
-我们接受任何形式的贡献！如果你想建议我们添加更多内容、报告bug、或帮助我们优化这个项目，请随时开一个issue或者提交任意Pull Request(PR)在 [这里](https://github.com/unovue/inspira-ui).
+我们接受任何形式的贡献！如果你想建议我们添加更多内容、报告 bug、或帮助我们优化这个项目，请随时开一个 issue 或者提交任意 Pull Request (PR) 在 [这里](https://github.com/bro-world/bro-world-frontend-ui)。
 
 为了保证项目的合理运行，请您在发布贡献时参照我们的 [贡献手册](https://inspira-ui.com/getting-started/contribution).
 
@@ -118,10 +118,5 @@ Inspira UI 的出道旨在填补 Vue 社区生态的一个空白，它提供了�
 
 如果您想支持我们的开发进程，您可以请我们喝杯咖啡：
 
-支持与赞助请访问 [此链接](https://github.com/sponsors/rahul-vashishtha) 。
+支持与赞助请访问 [此链接](https://github.com/sponsors/bro-world) 。
 
-## 感谢所有当前贡献者 🙏
-
-<a href="https://github.com/unovue/inspira-ui/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=unovue/inspira-ui" />
-</a>

--- a/README_IT.md
+++ b/README_IT.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui">
     <img src="./logo.png" alt="Logo" width="150" />
   </a>
 </p>
@@ -12,10 +12,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/unovue/inspira-ui/stargazers">
-    <img alt="GitHub stars" src="https://img.shields.io/github/stars/unovue/inspira-ui?style=social">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/stargazers">
+    <img alt="GitHub stars" src="https://img.shields.io/github/stars/bro-world/bro-world-frontend-ui?style=social">
   </a>
-  <a href="https://github.com/unovue/inspira-ui/blob/main/LICENSE.md">
+  <a href="https://github.com/bro-world/bro-world-frontend-ui/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/License-MIT-yellow.svg">
   </a>  
 </p>
@@ -48,7 +48,7 @@ Inspira UI è stato creato per colmare una lacuna nella comunità Vue fornendo u
 
 ## 🎯 Caratteristiche Principali
 
-- **Gratuito e Open Source**: Completamente [open source](https://github.com/unovue/inspira-ui) sotto licenza MIT.
+- **Gratuito e Open Source**: Completamente [open source](https://github.com/bro-world/bro-world-frontend-ui) sotto licenza MIT.
 - **Altamente Configurabile**: Adatta i componenti alle tue esigenze di design specifiche. Dai un'occhiata alla nostra [guida alla configurazione](/api/configuration).
 - **Ampia Gamma di Componenti**: Un'ampia selezione di [componenti](/components), ispirati a Aceternity UI, Magic UI e contributi personalizzati, per aiutarti a costruire tutto ciò che immagini.
 - **Ottimizzato per Dispositivi Mobili**: Progettato per avere un aspetto fantastico su tutti i dispositivi.
@@ -75,13 +75,13 @@ Un ringraziamento speciale a:
 
 ## 👤 Autore
 
-Ciao, sono [Rahul Vashishtha](https://rahulv.dev). Ho iniziato Inspira UI per portare un'esperienza simile nell'ecosistema Vue, ispirato da Aceternity UI, Magic UI e dai contributi della comunità. Sto lavorando continuamente per migliorarlo. Sentiti libero di dare un'occhiata al mio lavoro su [GitHub](https://github.com/rahul-vashishtha) e unisciti a me in questo viaggio [qui](https://github.com/unovue/inspira-ui)!
+Ciao, sono [BroWorld](https://github.com/bro-world). Mantengo questo progetto per offrire un'esperienza pronta all'uso nell'ecosistema Vue, ispirato da Aceternity UI, Magic UI e dai contributi della comunità. Sto lavorando continuamente per migliorarlo. Dai un'occhiata al mio lavoro su GitHub e unisciti a me in questo viaggio [qui](https://github.com/bro-world/bro-world-frontend-ui)!
 
 ---
 
 ## 🌟 Contribuisci
 
-Accogliamo con piacere i contributi! Se vuoi suggerire funzionalità, segnalare bug o aiutare a migliorare il progetto, sentiti libero di aprire un'issue o inviare una pull request su [GitHub](https://github.com/unovue/inspira-ui).
+Accogliamo con piacere i contributi! Se vuoi suggerire funzionalità, segnalare bug o aiutare a migliorare il progetto, sentiti libero di aprire un'issue o inviare una pull request su [GitHub](https://github.com/bro-world/bro-world-frontend-ui).
 
 Puoi anche seguire questa [Guida ai Contributi](https://inspira-ui.com/getting-started/contribution).
 
@@ -89,6 +89,6 @@ Puoi anche seguire questa [Guida ai Contributi](https://inspira-ui.com/getting-s
 
 ## 💖 Sponsorizzazioni
 
-Puoi anche supportare lo sviluppo del progetto sponsorizzando lo sviluppatore.
+Puoi anche supportare lo sviluppo del progetto sponsorizzando il manutentore.
 
-Sostieni e sponsorizza il manutentore qui: [Supporta Inspira UI](https://github.com/sponsors/rahul-vashishtha)
+Sostieni il progetto qui: [Supporta BroWorld](https://github.com/sponsors/bro-world)

--- a/app.config.ts
+++ b/app.config.ts
@@ -16,12 +16,12 @@ export default defineAppConfig({
       radius: 0.75,
     },
     banner: {
-      enable: true,
+      enable: false,
       showClose: false,
-      content: "For Tailwind CSS v3 docs, [**click here**](https://v1.inspira-ui.com).",
-      to: "https://v1.inspira-ui.com",
-      target: "_blank",
-      border: true,
+      content: "",
+      to: "",
+      target: "_self",
+      border: false,
     },
     header: {
       title: "BroWorld",
@@ -94,7 +94,7 @@ export default defineAppConfig({
           links: [
             {
               title: "GitHub",
-              to: "https://github.com/unovue/inspira-ui",
+              to: "https://github.com/bro-world/bro-world-frontend-ui",
               description: $t("nav.GitHubDescription"),
               target: "_blank",
             },
@@ -106,7 +106,7 @@ export default defineAppConfig({
             },
             {
               title: $t("nav.Forum"),
-              to: "https://github.com/unovue/inspira-ui/discussions",
+              to: "https://github.com/bro-world/bro-world-frontend-ui/discussions",
               target: "_blank",
               description: $t("nav.ForumDiscord"),
             },
@@ -116,22 +116,7 @@ export default defineAppConfig({
       links: [
         {
           icon: "lucide:github",
-          to: "https://github.com/unovue/inspira-ui",
-          target: "_blank",
-        },
-        {
-          icon: "prime:twitter",
-          to: "https://x.com/rahulv_dev",
-          target: "_blank",
-        },
-        {
-          icon: "ri:discord-line",
-          to: "https://discord.gg/Xbh5DwJRc9",
-          target: "_blank",
-        },
-        {
-          icon: "ri:bluesky-line",
-          to: "http://bsky.app/profile/inspira-ui.com",
+          to: "https://github.com/bro-world",
           target: "_blank",
         },
       ],
@@ -153,14 +138,14 @@ export default defineAppConfig({
       links: [
         {
           icon: "lucide:globe",
-          to: "https://rahulv.dev",
-          title: "Maintained by rahulv.dev",
+          to: "https://github.com/bro-world",
+          title: "Maintained by BroWorld",
           target: "_blank",
         },
         {
           icon: "lucide:github",
-          title: "Github",
-          to: "https://github.com/unovue/inspira-ui",
+          title: "GitHub",
+          to: "https://github.com/bro-world/bro-world-frontend-ui",
           target: "_blank",
         },
       ],
@@ -178,13 +163,13 @@ export default defineAppConfig({
         {
           title: $t("toc.StarOnGitHub"),
           icon: "lucide:star",
-          to: "https://github.com/unovue/inspira-ui",
+          to: "https://github.com/bro-world/bro-world-frontend-ui",
           target: "_blank",
         },
         {
           title: $t("toc.CreateIssues"),
           icon: "lucide:circle-dot",
-          to: "https://github.com/unovue/inspira-ui/issues",
+          to: "https://github.com/bro-world/bro-world-frontend-ui/issues",
           target: "_blank",
         },
         {
@@ -196,19 +181,7 @@ export default defineAppConfig({
         {
           title: $t("toc.Forum"),
           icon: "lucide:newspaper",
-          to: "https://github.com/unovue/inspira-ui/discussions",
-          target: "_blank",
-        },
-        {
-          title: $t("toc.FollowOnX"),
-          icon: "prime:twitter",
-          to: "https://x.com/rahulv_dev",
-          target: "_blank",
-        },
-        {
-          title: $t("toc.FollowOnBluesky"),
-          icon: "ri:bluesky-line",
-          to: "http://bsky.app/profile/inspira-ui.com",
+          to: "https://github.com/bro-world/bro-world-frontend-ui/discussions",
           target: "_blank",
         },
       ],


### PR DESCRIPTION
## Summary
- disable the Tailwind CSS v3 banner and point community links at the BroWorld GitHub organisation
- refresh the README files to remove legacy contributor references and highlight the BroWorld maintainer across languages

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3ff840e008326ab2842d44578a327