### PR TITLE
feat: redesign home page with blog feed

### DIFF
--- a/lib/mock/blog.ts
+++ b/lib/mock/blog.ts
@@ -1,0 +1,492 @@
+export type ReactionType = "like" | "love" | "wow" | "haha" | "sad" | "angry";
+
+export interface BlogUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  username: string;
+  email: string;
+  enabled: boolean;
+  photo: string | null;
+}
+
+export interface BlogReactionPreview {
+  id: string;
+  type: ReactionType;
+  user: BlogUser;
+}
+
+export interface BlogCommentPreview {
+  id: string;
+  content: string;
+  user: BlogUser;
+  isReacted: boolean | null;
+  totalComments: number;
+  reactions_count: number;
+  publishedAt: string;
+  reactions_preview: BlogReactionPreview[];
+  likes_count: number;
+}
+
+export interface BlogPost {
+  id: string;
+  title: string;
+  summary: string;
+  content: string;
+  url: string | null;
+  slug: string;
+  medias: unknown[];
+  isReacted: boolean | null;
+  publishedAt: string;
+  sharedFrom: unknown;
+  reactions_count: number;
+  totalComments: number;
+  user: BlogUser;
+  reactions_preview: BlogReactionPreview[];
+  comments_preview: BlogCommentPreview[];
+}
+
+export interface BlogApiResponse {
+  data: BlogPost[];
+  page: number;
+  limit: number;
+  count: number;
+}
+
+export const blogSampleResponse: BlogApiResponse = {
+  data: [
+    {
+      id: "cff647ac-98f1-11f0-b42d-0242ac120008",
+      title: "Lorem ipsum dolor sit amet consectetur adipiscing elit",
+      summary: "Et non culpa reiciendis ut similique fugiat qui in eos sed et aut quia tempore.",
+      content:
+        "Minus asperiores aut error perferendis. Enim vitae itaque numquam iusto aliquid ratione voluptas. Dolore ea repellat temporibus quas ullam.\n\nIste consequuntur sed eos molestias. Id consequatur sint exercitationem fugit cupiditate quia.\n\nHic ut nam consectetur fuga. Harum blanditiis a ab aut odio facilis aut. Eum voluptas officia aperiam asperiores eos quibusdam autem tenetur. Explicabo culpa culpa recusandae et temporibus.\n\nMinus aut impedit magni et consequatur ut non labore. Quia cupiditate corporis vel hic temporibus numquam quis. Omnis quis eveniet beatae et.\n\nFacere ex itaque quam accusantium culpa minus. Nam exercitationem esse id velit est.",
+      url: null,
+      slug: "lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit",
+      medias: [],
+      isReacted: null,
+      publishedAt: "2025-09-24T14:30:00+00:00",
+      sharedFrom: null,
+      reactions_count: 5,
+      totalComments: 5,
+      user: {
+        id: "20000000-0000-1000-8000-000000000001",
+        firstName: "Sebastien",
+        lastName: "Doe",
+        username: "john",
+        email: "john.doe@test.com",
+        enabled: false,
+        photo: "https://bro-world-space.com/img/person.png",
+      },
+      reactions_preview: [
+        {
+          id: "cffbf594-98f1-11f0-a698-0242ac120008",
+          type: "wow",
+          user: {
+            id: "20000000-0000-1000-8000-000000000003",
+            firstName: "Sara",
+            lastName: "Doe",
+            username: "john-api",
+            email: "john.doe-api@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+        {
+          id: "cffc0534-98f1-11f0-874c-0242ac120008",
+          type: "like",
+          user: {
+            id: "20000000-0000-1000-8000-000000000001",
+            firstName: "Sebastien",
+            lastName: "Doe",
+            username: "john",
+            email: "john.doe@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+      ],
+      comments_preview: [
+        {
+          id: "cffa67d8-98f1-11f0-a2e8-0242ac120008",
+          content:
+            "Et numquam occaecati hic aut nostrum tempore distinctio hic doloribus voluptas.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000001",
+            firstName: "Sebastien",
+            lastName: "Doe",
+            username: "john",
+            email: "john.doe@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 6,
+          publishedAt: "2025-09-24T02:54:44+00:00",
+          reactions_preview: [
+            {
+              id: "cffb3bfe-98f1-11f0-b52a-0242ac120008",
+              type: "sad",
+              user: {
+                id: "20000000-0000-1000-8000-000000000002",
+                firstName: "Julien",
+                lastName: "Doe",
+                username: "john-logged",
+                email: "john.doe-logged@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+            {
+              id: "cffb4b4e-98f1-11f0-9c67-0242ac120008",
+              type: "like",
+              user: {
+                id: "20000000-0000-1000-8000-000000000001",
+                firstName: "Sebastien",
+                lastName: "Doe",
+                username: "john",
+                email: "john.doe@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+          ],
+          likes_count: 4,
+        },
+        {
+          id: "cff91a36-98f1-11f0-b049-0242ac120008",
+          content: "Qui consequatur fugiat assumenda est error sit.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000003",
+            firstName: "Sara",
+            lastName: "Doe",
+            username: "john-api",
+            email: "john.doe-api@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 3,
+          publishedAt: "2025-09-24T02:54:43+00:00",
+          reactions_preview: [
+            {
+              id: "cff9e678-98f1-11f0-977f-0242ac120008",
+              type: "angry",
+              user: {
+                id: "20000000-0000-1000-8000-000000000005",
+                firstName: "Admin",
+                lastName: "Doe",
+                username: "john-admin",
+                email: "john.doe-admin@test.com",
+                enabled: false,
+                photo: "https://bro-world.org/uploads/avatar/team-4-68763f1b4e9728.49066840.jpg",
+              },
+            },
+            {
+              id: "cffa0fae-98f1-11f0-ac19-0242ac120008",
+              type: "love",
+              user: {
+                id: "20000000-0000-1000-8000-000000000001",
+                firstName: "Sebastien",
+                lastName: "Doe",
+                username: "john",
+                email: "john.doe@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+          ],
+          likes_count: 3,
+        },
+      ],
+    },
+    {
+      id: "cffc5a16-98f1-11f0-b4ec-0242ac120008",
+      title: "Pellentesque vitae velit ex",
+      summary:
+        "Quia facere minus ducimus rerum et aut et pariatur qui ut modi aspernatur in aut porro sit.",
+      content:
+        "Cupiditate et illo sunt incidunt corporis itaque soluta. Necessitatibus omnis est fugiat quo debitis at et. Suscipit quod quaerat voluptatem voluptatem nesciunt.\n\nQui nulla fuga provident voluptatibus corrupti cupiditate. Sequi non ea optio alias vel provident mollitia voluptas. Excepturi velit rerum et. Consequatur eligendi nobis praesentium nam sunt.\n\nRecusandae quis quae fugiat excepturi. Veritatis ut autem aut nesciunt possimus a illum perferendis. Iure sit ipsa veritatis esse et sit maiores. Laboriosam commodi suscipit pariatur officia saepe.\n\nRepudiandae quia est dolor dolores. Sequi cum vero possimus qui laborum beatae. Cupiditate nihil quae et voluptatem cum laborum quisquam fugiat. Cum libero nam qui architecto sunt cupiditate eveniet.\n\nQuidem sit ab animi iusto. Optio nisi quidem maiores eum repellat. Voluptatibus sint odit omnis. Minus vel reiciendis velit eaque iusto veniam autem.",
+      url: null,
+      slug: "pellentesque-vitae-velit-ex",
+      medias: [],
+      isReacted: null,
+      publishedAt: "2025-09-23T08:27:00+00:00",
+      sharedFrom: null,
+      reactions_count: 3,
+      totalComments: 7,
+      user: {
+        id: "20000000-0000-1000-8000-000000000003",
+        firstName: "Sara",
+        lastName: "Doe",
+        username: "john-api",
+        email: "john.doe-api@test.com",
+        enabled: false,
+        photo: "https://bro-world-space.com/img/person.png",
+      },
+      reactions_preview: [
+        {
+          id: "d00289c2-98f1-11f0-a673-0242ac120008",
+          type: "angry",
+          user: {
+            id: "20000000-0000-1000-8000-000000000004",
+            firstName: "Nina",
+            lastName: "Doe",
+            username: "john-user",
+            email: "john.doe-user@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+        {
+          id: "d0029ba6-98f1-11f0-bf6f-0242ac120008",
+          type: "love",
+          user: {
+            id: "20000000-0000-1000-8000-000000000003",
+            firstName: "Sara",
+            lastName: "Doe",
+            username: "john-api",
+            email: "john.doe-api@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+      ],
+      comments_preview: [
+        {
+          id: "d001ac14-98f1-11f0-aa8d-0242ac120008",
+          content:
+            "Quo ut consequatur fugit saepe voluptate qui exercitationem voluptas architecto praesentium ratione.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000001",
+            firstName: "Sebastien",
+            lastName: "Doe",
+            username: "john",
+            email: "john.doe@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 3,
+          publishedAt: "2025-09-24T02:54:46+00:00",
+          reactions_preview: [
+            {
+              id: "d001e62a-98f1-11f0-b04a-0242ac120008",
+              type: "haha",
+              user: {
+                id: "20000000-0000-1000-8000-000000000005",
+                firstName: "Admin",
+                lastName: "Doe",
+                username: "john-admin",
+                email: "john.doe-admin@test.com",
+                enabled: false,
+                photo: "https://bro-world.org/uploads/avatar/team-4-68763f1b4e9728.49066840.jpg",
+              },
+            },
+            {
+              id: "d001fa7a-98f1-11f0-97df-0242ac120008",
+              type: "love",
+              user: {
+                id: "20000000-0000-1000-8000-000000000006",
+                firstName: "Bro",
+                lastName: "World",
+                username: "john-root",
+                email: "john.doe-root@test.com",
+                enabled: false,
+                photo: "https://bro-world.org/uploads/avatar/team-4-686c002aeab759.31816587.jpg",
+              },
+            },
+          ],
+          likes_count: 2,
+        },
+        {
+          id: "d00104e4-98f1-11f0-a9ff-0242ac120008",
+          content:
+            "Inventore recusandae qui totam perspiciatis eos cumque harum voluptas sed perspiciatis pariatur id quos rerum.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000004",
+            firstName: "Nina",
+            lastName: "Doe",
+            username: "john-user",
+            email: "john.doe-user@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 4,
+          publishedAt: "2025-09-24T02:54:45+00:00",
+          reactions_preview: [
+            {
+              id: "d0016970-98f1-11f0-9a1f-0242ac120008",
+              type: "haha",
+              user: {
+                id: "20000000-0000-1000-8000-000000000001",
+                firstName: "Sebastien",
+                lastName: "Doe",
+                username: "john",
+                email: "john.doe@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+            {
+              id: "d0017ca8-98f1-11f0-91cc-0242ac120008",
+              type: "like",
+              user: {
+                id: "20000000-0000-1000-8000-000000000004",
+                firstName: "Nina",
+                lastName: "Doe",
+                username: "john-user",
+                email: "john.doe-user@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+          ],
+          likes_count: 2,
+        },
+      ],
+    },
+    {
+      id: "d0030712-98f1-11f0-a7f6-0242ac120008",
+      title: "Mauris dapibus risus quis suscipit vulputate",
+      summary:
+        "Perspiciatis esse quae non voluptas quidem quia exercitationem rerum officia corrupti voluptatem suscipit voluptatem.",
+      content:
+        "Aut asperiores facilis numquam quas officia ad molestiae vero. Veniam voluptates qui ex voluptas. At commodi voluptate animi doloremque voluptate provident.\n\nQuos eius maiores dolore blanditiis molestiae. Est consequatur voluptas ab facere et eos nihil. Sint quod architecto eveniet iste iusto.\n\nQuibusdam sint explicabo consequuntur iusto. In corrupti quo praesentium quia. Sit atque voluptates ipsam est a molestiae eius.\n\nSunt repellat aut est. Quidem sint et a voluptatum repellat eos iusto. Labore et sequi nostrum dolorum temporibus omnis. In ea non tempore ipsam id accusamus est.\n\nSint rerum occaecati quia. Ratione laboriosam harum ducimus. Maxime rerum culpa aliquam vel ullam perspiciatis accusantium.",
+      url: null,
+      slug: "mauris-dapibus-risus-quis-suscipit-vulputate",
+      medias: [],
+      isReacted: null,
+      publishedAt: "2025-09-22T10:23:00+00:00",
+      sharedFrom: null,
+      reactions_count: 6,
+      totalComments: 5,
+      user: {
+        id: "20000000-0000-1000-8000-000000000004",
+        firstName: "Nina",
+        lastName: "Doe",
+        username: "john-user",
+        email: "john.doe-user@test.com",
+        enabled: false,
+        photo: "https://bro-world-space.com/img/person.png",
+      },
+      reactions_preview: [
+        {
+          id: "d005b1b0-98f1-11f0-a222-0242ac120008",
+          type: "sad",
+          user: {
+            id: "20000000-0000-1000-8000-000000000004",
+            firstName: "Nina",
+            lastName: "Doe",
+            username: "john-user",
+            email: "john.doe-user@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+        {
+          id: "d005ccea-98f1-11f0-81be-0242ac120008",
+          type: "love",
+          user: {
+            id: "20000000-0000-1000-8000-000000000002",
+            firstName: "Julien",
+            lastName: "Doe",
+            username: "john-logged",
+            email: "john.doe-logged@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+        },
+      ],
+      comments_preview: [
+        {
+          id: "d004e85c-98f1-11f0-85bb-0242ac120008",
+          content: "Aliquam accusamus a praesentium eum vitae tenetur praesentium.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000004",
+            firstName: "Nina",
+            lastName: "Doe",
+            username: "john-user",
+            email: "john.doe-user@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 3,
+          publishedAt: "2025-09-24T02:54:44+00:00",
+          reactions_preview: [
+            {
+              id: "d0053b7c-98f1-11f0-9e56-0242ac120008",
+              type: "sad",
+              user: {
+                id: "20000000-0000-1000-8000-000000000001",
+                firstName: "Sebastien",
+                lastName: "Doe",
+                username: "john",
+                email: "john.doe@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+            {
+              id: "d005612e-98f1-11f0-af05-0242ac120008",
+              type: "love",
+              user: {
+                id: "20000000-0000-1000-8000-000000000004",
+                firstName: "Nina",
+                lastName: "Doe",
+                username: "john-user",
+                email: "john.doe-user@test.com",
+                enabled: false,
+                photo: "https://bro-world-space.com/img/person.png",
+              },
+            },
+          ],
+          likes_count: 3,
+        },
+        {
+          id: "d0047368-98f1-11f0-9ca9-0242ac120008",
+          content: "Facere nisi fuga neque voluptatum molestiae consequatur perspiciatis.",
+          user: {
+            id: "20000000-0000-1000-8000-000000000002",
+            firstName: "Julien",
+            lastName: "Doe",
+            username: "john-logged",
+            email: "john.doe-logged@test.com",
+            enabled: false,
+            photo: "https://bro-world-space.com/img/person.png",
+          },
+          isReacted: null,
+          totalComments: 0,
+          reactions_count: 1,
+          publishedAt: "2025-09-24T02:54:43+00:00",
+          reactions_preview: [
+            {
+              id: "d004d3ee-98f1-11f0-a8da-0242ac120008",
+              type: "haha",
+              user: {
+                id: "20000000-0000-1000-8000-000000000006",
+                firstName: "Bro",
+                lastName: "World",
+                username: "john-root",
+                email: "john.doe-root@test.com",
+                enabled: false,
+                photo: "https://bro-world.org/uploads/avatar/team-4-686c002aeab759.31816587.jpg",
+              },
+            },
+          ],
+          likes_count: 2,
+        },
+      ],
+    },
+  ],
+  page: 1,
+  limit: 10,
+  count: 300,
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,7 @@ export default defineNuxtConfig({
     public: {
       NUXT_CLARITY_ID: process.env.NUXT_CLARITY_ID,
       NUXT_ADSENSE_ACCOUNT: process.env.NUXT_ADSENSE_ACCOUNT,
+      blogApiEndpoint: process.env.NUXT_PUBLIC_BLOG_API_ENDPOINT ?? "",
     },
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,272 @@
 <template>
-  <div class="flex min-h-screen items-center justify-center text-2xl font-semibold">
-    hello
+  <div
+    class="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-50"
+  >
+    <div class="pointer-events-none absolute inset-0 overflow-hidden">
+      <div class="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-emerald-500/20 blur-3xl" />
+      <div
+        class="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-sky-500/10 blur-3xl"
+      />
+      <div
+        class="absolute left-1/3 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/5 blur-2xl"
+      />
+    </div>
+
+    <div class="relative z-10">
+      <section class="mx-auto max-w-4xl px-6 pb-16 pt-20 text-center md:pt-28">
+        <span
+          class="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1 text-sm font-medium text-emerald-200 ring-1 ring-inset ring-emerald-500/30"
+        >
+          <span class="h-2 w-2 rounded-full bg-emerald-400" />
+          Blog
+        </span>
+        <h1 class="mt-6 text-4xl font-semibold tracking-tight text-white md:text-5xl">
+          L'actualité de la communauté BroWorld
+        </h1>
+        <p class="mx-auto mt-4 max-w-2xl text-lg text-slate-300">
+          Explorez les dernières histoires, réactions et commentaires des membres de la communauté.
+          Chaque post révèle une énergie différente, prenez le temps de les découvrir.
+        </p>
+      </section>
+
+      <section class="mx-auto max-w-5xl space-y-10 px-6 pb-24">
+        <div
+          v-if="pending"
+          class="grid gap-8 md:grid-cols-2"
+        >
+          <div
+            v-for="index in 4"
+            :key="index"
+            class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
+          >
+            <div class="flex items-center gap-4">
+              <div class="h-14 w-14 rounded-2xl bg-white/10" />
+              <div class="space-y-3">
+                <div class="h-3 w-32 rounded-full bg-white/10" />
+                <div class="h-3 w-24 rounded-full bg-white/10" />
+              </div>
+            </div>
+            <div class="space-y-3">
+              <div class="h-3 w-3/4 rounded-full bg-white/10" />
+              <div class="h-3 w-2/3 rounded-full bg-white/10" />
+              <div class="h-3 w-full rounded-full bg-white/10" />
+            </div>
+            <div class="mt-auto flex gap-3">
+              <div class="h-7 w-28 rounded-full bg-white/5" />
+              <div class="h-7 w-28 rounded-full bg-white/5" />
+            </div>
+          </div>
+        </div>
+
+        <template v-else>
+          <article
+            v-for="post in posts"
+            :key="post.id"
+            class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-emerald-400/50 hover:bg-white/15 hover:shadow-emerald-500/20"
+          >
+            <div
+              class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-emerald-500/10 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+            />
+            <div class="relative flex flex-col gap-8 p-8 sm:p-10">
+              <header class="flex flex-wrap items-center gap-6">
+                <div class="flex items-center gap-4">
+                  <div
+                    class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
+                  >
+                    <img
+                      :src="post.user.photo ?? defaultAvatar"
+                      :alt="`${post.user.firstName} ${post.user.lastName}`"
+                      class="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div>
+                    <p class="text-sm font-medium text-slate-200">
+                      {{ post.user.firstName }} {{ post.user.lastName }}
+                    </p>
+                    <p class="text-xs text-slate-400">
+                      Publié le {{ formatDateTime(post.publishedAt) }}
+                    </p>
+                  </div>
+                </div>
+                <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
+                  <span
+                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+                  >
+                    <span class="text-base">{{ reactionEmojis.like }}</span>
+                    {{ formatNumber(post.reactions_count) }} réactions
+                  </span>
+                  <span
+                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+                  >
+                    <span class="text-base">💬</span>
+                    {{ formatNumber(post.totalComments) }} commentaires
+                  </span>
+                </div>
+              </header>
+
+              <div class="space-y-4">
+                <h2
+                  class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-emerald-200"
+                >
+                  {{ post.title }}
+                </h2>
+                <p class="text-base text-slate-200/80">
+                  {{ post.summary }}
+                </p>
+              </div>
+
+              <div
+                v-if="post.comments_preview.length"
+                class="rounded-2xl border border-white/10 bg-black/20 p-6"
+              >
+                <div class="flex items-center justify-between">
+                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
+                    Commentaires récents
+                  </p>
+                  <p class="text-xs text-slate-400">
+                    {{ formatNumber(post.comments_preview.length) }} aperçus
+                  </p>
+                </div>
+                <div class="mt-4 grid gap-4 md:grid-cols-2">
+                  <article
+                    v-for="comment in post.comments_preview.slice(0, 4)"
+                    :key="comment.id"
+                    class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4"
+                  >
+                    <div class="flex items-center gap-3">
+                      <div
+                        class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10"
+                      >
+                        <img
+                          :src="comment.user.photo ?? defaultAvatar"
+                          :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+                          class="h-full w-full object-cover"
+                          loading="lazy"
+                        />
+                      </div>
+                      <div>
+                        <p class="text-sm font-medium text-slate-200">
+                          {{ comment.user.firstName }} {{ comment.user.lastName }}
+                        </p>
+                        <p class="text-[11px] uppercase tracking-wide text-slate-400">
+                          {{ formatDateTime(comment.publishedAt) }}
+                        </p>
+                      </div>
+                    </div>
+                    <p class="text-sm leading-relaxed text-slate-200/80">
+                      {{ comment.content }}
+                    </p>
+                    <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
+                      <span
+                        class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
+                      >
+                        <span class="text-base">{{ reactionEmojis.like }}</span>
+                        {{ formatNumber(comment.reactions_count) }} réactions
+                      </span>
+                      <span
+                        class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
+                      >
+                        <span class="text-base">💬</span>
+                        {{ formatNumber(comment.totalComments) }} réponses
+                      </span>
+                    </div>
+                  </article>
+                </div>
+              </div>
+
+              <footer
+                v-if="post.reactions_preview.length"
+                class="flex flex-wrap items-center gap-3 text-sm"
+              >
+                <span class="text-xs uppercase tracking-wide text-slate-400"
+                  >Réactions coup de cœur</span
+                >
+                <div class="flex flex-wrap gap-3">
+                  <div
+                    v-for="reaction in post.reactions_preview.slice(0, 4)"
+                    :key="reaction.id"
+                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
+                  >
+                    <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
+                    <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
+                    <span class="text-[11px] uppercase tracking-wide text-slate-400">{{
+                      reactionLabels[reaction.type]
+                    }}</span>
+                  </div>
+                </div>
+              </footer>
+            </div>
+          </article>
+        </template>
+      </section>
+    </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  blogSampleResponse,
+  type BlogApiResponse,
+  type BlogPost,
+  type ReactionType,
+} from "~/lib/mock/blog";
+
+const runtimeConfig = useRuntimeConfig();
+const defaultAvatar = "https://bro-world-space.com/img/person.png";
+const fallbackPosts = blogSampleResponse.data;
+
+const reactionEmojis: Record<ReactionType, string> = {
+  like: "👍",
+  love: "❤️",
+  wow: "😮",
+  haha: "😂",
+  sad: "😢",
+  angry: "😡",
+};
+
+const reactionLabels: Record<ReactionType, string> = {
+  like: "Like",
+  love: "Love",
+  wow: "Wow",
+  haha: "Haha",
+  sad: "Sad",
+  angry: "Angry",
+};
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("fr-FR", {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatNumber(value: number | null | undefined) {
+  return new Intl.NumberFormat("fr-FR").format(value ?? 0);
+}
+
+async function fetchPosts(): Promise<BlogPost[]> {
+  if (runtimeConfig.public.blogApiEndpoint) {
+    try {
+      const response = await $fetch<BlogApiResponse>(runtimeConfig.public.blogApiEndpoint, {
+        query: { limit: 10 },
+      });
+
+      if (Array.isArray(response?.data) && response.data.length > 0) {
+        return response.data;
+      }
+    } catch (error) {
+      console.error("Impossible de charger les articles du blog", error);
+    }
+  }
+
+  return fallbackPosts;
+}
+
+const { data: postsData, pending } = await useAsyncData("blog-posts", fetchPosts, {
+  default: () => fallbackPosts,
+});
+
+const posts = computed(() => postsData.value ?? fallbackPosts);
+</script>


### PR DESCRIPTION
## Summary
- replace the minimal home screen with a rich blog feed that showcases authors, reactions, and recent comments using the existing design language
- add strongly typed mock blog data to mirror the API contract while providing local fallbacks for the UI
- expose a public runtime config entry so the blog feed can load data from a remote endpoint when available

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d40022db6483268fcf697b797dd18f