### PR TITLE
feat: load blog posts from API store

### DIFF
--- a/composables/usePostsStore.ts
+++ b/composables/usePostsStore.ts
@@ -1,0 +1,54 @@
+import { computed } from "vue";
+import type { BlogApiResponse, BlogPost } from "~/lib/mock/blog";
+
+interface FetchOptions {
+  force?: boolean;
+}
+
+export function usePostsStore() {
+  const postsState = useState<BlogPost[]>("posts", () => []);
+  const pendingState = useState<boolean>("posts-pending", () => false);
+  const errorState = useState<string | null>("posts-error", () => null);
+  const lastFetchedState = useState<number | null>("posts-last-fetched", () => null);
+
+  async function fetchPosts(options: FetchOptions = {}) {
+    if (pendingState.value) {
+      return postsState.value;
+    }
+
+    if (!options.force && postsState.value.length > 0) {
+      return postsState.value;
+    }
+
+    pendingState.value = true;
+    errorState.value = null;
+
+    try {
+      const response = await $fetch<BlogApiResponse>("/api/posts", {
+        method: "GET",
+      });
+
+      if (response && Array.isArray(response.data)) {
+        postsState.value = response.data;
+      } else {
+        throw new Error("Format de réponse inattendu");
+      }
+    } catch (error) {
+      errorState.value = error instanceof Error ? error.message : String(error ?? "");
+      postsState.value = [];
+    } finally {
+      pendingState.value = false;
+      lastFetchedState.value = Date.now();
+    }
+
+    return postsState.value;
+  }
+
+  return {
+    posts: computed(() => postsState.value),
+    pending: computed(() => pendingState.value),
+    error: computed(() => errorState.value),
+    lastFetched: computed(() => lastFetchedState.value),
+    fetchPosts,
+  };
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
     public: {
       NUXT_CLARITY_ID: process.env.NUXT_CLARITY_ID,
       NUXT_ADSENSE_ACCOUNT: process.env.NUXT_ADSENSE_ACCOUNT,
-      blogApiEndpoint: process.env.NUXT_PUBLIC_BLOG_API_ENDPOINT ?? "",
+      blogApiEndpoint: process.env.NUXT_PUBLIC_BLOG_API_ENDPOINT ?? "http://localhost/public/post",
     },
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -205,17 +205,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
-import {
-  blogSampleResponse,
-  type BlogApiResponse,
-  type BlogPost,
-  type ReactionType,
-} from "~/lib/mock/blog";
+import { callOnce } from "#imports";
+import { usePostsStore } from "~/composables/usePostsStore";
+import type { ReactionType } from "~/lib/mock/blog";
 
-const runtimeConfig = useRuntimeConfig();
 const defaultAvatar = "https://bro-world-space.com/img/person.png";
-const fallbackPosts = blogSampleResponse.data;
 
 const reactionEmojis: Record<ReactionType, string> = {
   like: "👍",
@@ -246,27 +240,7 @@ function formatNumber(value: number | null | undefined) {
   return new Intl.NumberFormat("fr-FR").format(value ?? 0);
 }
 
-async function fetchPosts(): Promise<BlogPost[]> {
-  if (runtimeConfig.public.blogApiEndpoint) {
-    try {
-      const response = await $fetch<BlogApiResponse>(runtimeConfig.public.blogApiEndpoint, {
-        query: { limit: 10 },
-      });
+const { posts, pending, fetchPosts } = usePostsStore();
 
-      if (Array.isArray(response?.data) && response.data.length > 0) {
-        return response.data;
-      }
-    } catch (error) {
-      console.error("Impossible de charger les articles du blog", error);
-    }
-  }
-
-  return fallbackPosts;
-}
-
-const { data: postsData, pending } = await useAsyncData("blog-posts", fetchPosts, {
-  default: () => fallbackPosts,
-});
-
-const posts = computed(() => postsData.value ?? fallbackPosts);
+await callOnce(() => fetchPosts());
 </script>

--- a/server/api/posts.get.ts
+++ b/server/api/posts.get.ts
@@ -1,0 +1,29 @@
+import { createError } from "h3";
+import type { BlogApiResponse } from "~/lib/mock/blog";
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  const endpoint = config.public.blogApiEndpoint || "http://localhost/public/post";
+
+  try {
+    const response = await $fetch<BlogApiResponse>(endpoint, {
+      method: "GET",
+    });
+
+    if (!response || !Array.isArray(response.data)) {
+      throw new Error("Format de réponse inattendu");
+    }
+
+    return response;
+  } catch (error) {
+    console.error("Erreur lors de la récupération des articles du blog", error);
+
+    throw createError({
+      statusCode: 502,
+      statusMessage: "Impossible de récupérer les articles du blog.",
+      data: {
+        message: error instanceof Error ? error.message : String(error ?? ""),
+      },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add a Nuxt composable store that retrieves blog posts from the new server endpoint
- expose a server API route that proxies http://localhost/public/post and configure the default runtime endpoint
- update the landing page to consume the store instead of static mock data

## Testing
- pnpm exec eslint pages/index.vue composables/usePostsStore.ts server/api/posts.get.ts nuxt.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68d405730e608326944c912731047c4b