### PR TITLE
Add browser language detection and header auth dropdown

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -115,9 +115,17 @@ export default defineAppConfig({
       ],
       links: [
         {
-          icon: "lucide:github",
-          to: "https://github.com/bro-world",
-          target: "_blank",
+          icon: "lucide:user",
+          menuItems: [
+            {
+              title: $t("auth.Login"),
+              to: "/login",
+            },
+            {
+              title: $t("auth.Register"),
+              to: "/register",
+            },
+          ],
         },
       ],
     },

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -1,0 +1,144 @@
+<template>
+  <header
+    class="bg-background/80 sticky top-0 z-40 backdrop-blur-lg"
+    :class="{ 'border-b': config.header.border }"
+  >
+    <div
+      class="flex h-14 items-center justify-between gap-2 px-4 md:px-8"
+      :class="{
+        'container max-w-screen-2xl': config.main.padded,
+      }"
+    >
+      <LayoutHeaderLogo class="hidden flex-1 md:flex" />
+      <LayoutMobileNav />
+      <LayoutHeaderLogo
+        v-if="config.header.showTitleInMobile"
+        class="flex md:hidden"
+      />
+      <LayoutHeaderNav class="hidden flex-1 lg:flex" />
+      <div class="flex flex-1 justify-end gap-2">
+        <LayoutSearchButton v-if="!config.search.inAside && config.search.style === 'input'" />
+        <div class="flex">
+          <LayoutSearchButton v-if="!config.search.inAside && config.search.style === 'button'" />
+          <LangSwitcher v-if="i18nEnabled" />
+          <ThemePopover v-if="config.theme.customizable" />
+          <DarkModeToggle v-if="config.header.darkModeToggle" />
+          <template
+            v-for="(link, i) in headerLinks"
+            :key="i"
+          >
+            <UiDropdownMenu v-if="link.menuItems?.length">
+              <UiDropdownMenuTrigger as-child>
+                <UiButton
+                  variant="ghost"
+                  size="icon"
+                  class="flex gap-2"
+                >
+                  <SmartIcon
+                    v-if="link.icon"
+                    :name="link.icon"
+                    :size="18"
+                  />
+                </UiButton>
+              </UiDropdownMenuTrigger>
+              <UiDropdownMenuContent class="w-44">
+                <UiDropdownMenuItem
+                  v-for="item in link.menuItems"
+                  :key="item.title"
+                  @select="handleMenuItemSelect(item)"
+                >
+                  <div class="flex w-full items-center gap-2">
+                    <SmartIcon
+                      v-if="item.icon"
+                      :name="item.icon"
+                      :size="16"
+                    />
+                    <span>{{ $t(item.title) }}</span>
+                  </div>
+                </UiDropdownMenuItem>
+              </UiDropdownMenuContent>
+            </UiDropdownMenu>
+            <NuxtLinkLocale
+              v-else
+              :to="localePath(link?.to)"
+              :target="link?.target"
+            >
+              <UiButton
+                variant="ghost"
+                size="icon"
+                class="flex gap-2"
+              >
+                <SmartIcon
+                  v-if="link?.icon"
+                  :name="link.icon"
+                  :size="18"
+                />
+              </UiButton>
+            </NuxtLinkLocale>
+          </template>
+        </div>
+      </div>
+    </div>
+    <div
+      v-if="baseRouteName !== 'index' && config.aside.levelStyle === 'header'"
+      class="md:mt-2 md:px-8"
+      :class="{
+        'md:container md:max-w-screen-2xl': config.main.padded,
+      }"
+    >
+      <LayoutHeaderTopLevelNav />
+    </div>
+    <div
+      v-if="showToc"
+      class="lg:hidden"
+    >
+      <LayoutToc is-small />
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+type HeaderLinkMenuItem = {
+  title: string;
+  to?: string;
+  icon?: string;
+  target?: string;
+  external?: boolean;
+};
+
+type HeaderLink = {
+  icon?: string;
+  to?: string;
+  target?: string;
+  menuItems?: HeaderLinkMenuItem[];
+};
+
+const config = useConfig();
+const { i18nEnabled, localePath } = useI18nDocs();
+const { page } = useContent();
+
+const headerLinks = computed<HeaderLink[]>(() => config.value.header.links ?? []);
+
+const showToc = computed(() => {
+  return (
+    config.value.toc.enable &&
+    config.value.toc.enableInMobile &&
+    (page.value?._path === "/" ? config.value.toc.enableInHomepage : true)
+  );
+});
+
+const route = useRoute();
+const baseRouteName = computed(() => useRouteBaseName()(route));
+
+function handleMenuItemSelect(item: HeaderLinkMenuItem) {
+  if (!item?.to) return;
+
+  if (item.external) {
+    if (typeof window !== "undefined") window.open(item.to, item.target ?? "_blank");
+
+    return;
+  }
+
+  navigateTo(localePath(item.to));
+}
+</script>

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,11 +1,17 @@
+import ar from "./locales/ar.json";
+import de from "./locales/de.json";
 import en from "./locales/en.json";
-import zhCn from "./locales/zh-cn.json";
+import fr from "./locales/fr.json";
 
 export default defineI18nConfig(() => ({
   legacy: false,
   locale: "en",
+  fallbackLocale: "en",
+  availableLocales: ["en", "fr", "de", "ar"],
   messages: {
-    en: en,
-    "zh-cn": zhCn,
+    en,
+    fr,
+    de,
+    ar,
   },
 }));

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -1,0 +1,55 @@
+{
+  "common": {
+    "InspiraUIPro": "إنسبيرا UI برو"
+  },
+  "banner": {
+    "Content": "للاطلاع على توثيق Tailwind CSS v3، [**اضغط هنا**](https://v1.inspira-ui.com)."
+  },
+  "nav": {
+    "Docs": "التوثيق",
+    "GettingStarted": "البدء",
+    "GettingStartedDescription": "مقدمة عن Inspira UI وأهم مفاهيمه.",
+    "Installation": "التثبيت",
+    "InstallationDescription": "اتبع الدليل خطوة بخطوة لتثبيت Inspira UI في مشروعك.",
+    "Components": "المكوّنات",
+    "ComponentsDescription": "استكشف جميع المكوّنات المتاحة وكيفية استخدامها.",
+    "V1DocsDescription": "توثيق استخدام Inspira UI مع Tailwind CSS v3.",
+    "Community": "المجتمع",
+    "GitHubDescription": "الكود المصدري لـ Inspira UI.",
+    "DiscordDescription": "تواصل مع المجتمع عبر ديسكورد",
+    "Forum": "المنتدى",
+    "ForumDiscord": "انضم إلى المنتدى"
+  },
+  "toc": {
+    "title": "في هذه الصفحة",
+    "StarOnGitHub": "أضف نجمة على GitHub",
+    "CreateIssues": "أنشئ بلاغًا",
+    "JoinDiscord": "انضم إلى ديسكورد",
+    "Forum": "المنتدى",
+    "FollowOnX": "تابعنا على X",
+    "FollowOnBluesky": "تابعنا على Bluesky"
+  },
+  "page": {
+    "home": {
+      "SupportUs": "ادعمنا",
+      "AllComponents": "جميع المكوّنات",
+      "OpenSourceComponentsToBuild": "مكوّنات مفتوحة المصدر لتبني بها",
+      "Stunning": "مذهلة",
+      "Beautiful": "جميلة",
+      "WebsitesUsingVueAndNuxt": "مواقع باستخدام Vue وNuxt",
+      "IntegrateWithYourFavouriteUIframework": "ادمج مع إطار الواجهة المفضل لديك",
+      "Features": "الميزات",
+      "CheckOutSomeExamples": "اطلع على بعض الأمثلة!",
+      "3DCardHoverEffect": "تأثير تحويم بطاقة ثلاثية الأبعاد",
+      "RadiantText": "نص متألق",
+      "LovedByCommunity": "محبوب من المجتمع",
+      "WhatAreYouWaitingFor": "ما الذي تنتظره؟",
+      "GetStartedAndStartBuildingAwesomeUI": "ابدأ واصنع واجهات مدهشة",
+      "GetStarted": "ابدأ الآن"
+    }
+  },
+  "auth": {
+    "Login": "تسجيل الدخول",
+    "Register": "إنشاء حساب"
+  }
+}

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1,0 +1,55 @@
+{
+  "common": {
+    "InspiraUIPro": "Inspira UI Pro"
+  },
+  "banner": {
+    "Content": "Für die Tailwind CSS v3-Dokumentation [**hier klicken**](https://v1.inspira-ui.com)."
+  },
+  "nav": {
+    "Docs": "Dokumentation",
+    "GettingStarted": "Erste Schritte",
+    "GettingStartedDescription": "Einführung in Inspira UI und die wichtigsten Konzepte.",
+    "Installation": "Installation",
+    "InstallationDescription": "Folge der Schritt-für-Schritt-Anleitung, um Inspira UI in deinem Projekt zu installieren.",
+    "Components": "Komponenten",
+    "ComponentsDescription": "Entdecke alle verfügbaren Komponenten und ihre Verwendung.",
+    "V1DocsDescription": "Dokumentation zur Nutzung von Inspira UI mit Tailwind CSS v3.",
+    "Community": "Community",
+    "GitHubDescription": "Quellcode für Inspira UI.",
+    "DiscordDescription": "Vernetze dich mit der Community auf Discord",
+    "Forum": "Forum",
+    "ForumDiscord": "Dem Forum beitreten"
+  },
+  "toc": {
+    "title": "Auf dieser Seite",
+    "StarOnGitHub": "Auf GitHub markieren",
+    "CreateIssues": "Issues erstellen",
+    "JoinDiscord": "Discord beitreten",
+    "Forum": "Forum",
+    "FollowOnX": "Auf X folgen",
+    "FollowOnBluesky": "Auf Bluesky folgen"
+  },
+  "page": {
+    "home": {
+      "SupportUs": "Unterstütze uns",
+      "AllComponents": "Alle Komponenten",
+      "OpenSourceComponentsToBuild": "Open-Source-Komponenten zum Erstellen",
+      "Stunning": "beeindruckende",
+      "Beautiful": "schöne",
+      "WebsitesUsingVueAndNuxt": "Websites mit Vue & Nuxt",
+      "IntegrateWithYourFavouriteUIframework": "Integriere dein bevorzugtes UI-Framework",
+      "Features": "Funktionen",
+      "CheckOutSomeExamples": "Sieh dir einige Beispiele an!",
+      "3DCardHoverEffect": "3D-Karten-Hover-Effekt",
+      "RadiantText": "Leuchtender Text",
+      "LovedByCommunity": "Geliebt von der Community",
+      "WhatAreYouWaitingFor": "Worauf wartest du?",
+      "GetStartedAndStartBuildingAwesomeUI": "Leg los und baue beeindruckende Benutzeroberflächen",
+      "GetStarted": "Jetzt starten"
+    }
+  },
+  "auth": {
+    "Login": "Anmelden",
+    "Register": "Registrieren"
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -47,5 +47,9 @@
       "GetStartedAndStartBuildingAwesomeUI": "Get started and start building awesome UI",
       "GetStarted": "Get Started"
     }
+  },
+  "auth": {
+    "Login": "Log in",
+    "Register": "Register"
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1,0 +1,55 @@
+{
+  "common": {
+    "InspiraUIPro": "Inspira UI Pro"
+  },
+  "banner": {
+    "Content": "Pour la documentation Tailwind CSS v3, [**cliquez ici**](https://v1.inspira-ui.com)."
+  },
+  "nav": {
+    "Docs": "Docs",
+    "GettingStarted": "Bien démarrer",
+    "GettingStartedDescription": "Présentation d'Inspira UI et de ses concepts clés.",
+    "Installation": "Installation",
+    "InstallationDescription": "Suivez le guide étape par étape pour installer Inspira UI dans votre projet.",
+    "Components": "Composants",
+    "ComponentsDescription": "Explorez tous les composants disponibles et leur utilisation.",
+    "V1DocsDescription": "Documentation pour utiliser Inspira UI avec Tailwind CSS v3.",
+    "Community": "Communauté",
+    "GitHubDescription": "Code source d'Inspira UI.",
+    "DiscordDescription": "Rejoignez la communauté sur Discord",
+    "Forum": "Forum",
+    "ForumDiscord": "Rejoindre le forum"
+  },
+  "toc": {
+    "title": "Sur cette page",
+    "StarOnGitHub": "Mettre une étoile sur GitHub",
+    "CreateIssues": "Créer des issues",
+    "JoinDiscord": "Rejoindre Discord",
+    "Forum": "Forum",
+    "FollowOnX": "Suivre sur X",
+    "FollowOnBluesky": "Suivre sur Bluesky"
+  },
+  "page": {
+    "home": {
+      "SupportUs": "Soutenez-nous",
+      "AllComponents": "Tous les composants",
+      "OpenSourceComponentsToBuild": "Des composants open source pour créer",
+      "Stunning": "étonnantes",
+      "Beautiful": "magnifiques",
+      "WebsitesUsingVueAndNuxt": "sites web avec Vue & Nuxt",
+      "IntegrateWithYourFavouriteUIframework": "Intégrez votre framework UI préféré",
+      "Features": "Fonctionnalités",
+      "CheckOutSomeExamples": "Découvrez quelques exemples !",
+      "3DCardHoverEffect": "Effet de survol carte 3D",
+      "RadiantText": "Texte lumineux",
+      "LovedByCommunity": "Apprécié par la communauté",
+      "WhatAreYouWaitingFor": "Qu'attendez-vous ?",
+      "GetStartedAndStartBuildingAwesomeUI": "Commencez et créez une interface incroyable",
+      "GetStarted": "Commencer"
+    }
+  },
+  "auth": {
+    "Login": "Connexion",
+    "Register": "Inscription"
+  }
+}

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -47,5 +47,9 @@
       "GetStartedAndStartBuildingAwesomeUI": "开始构建出色的 UI 吧",
       "GetStarted": "开始"
     }
+  },
+  "auth": {
+    "Login": "登录",
+    "Register": "注册"
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -61,6 +61,13 @@ export default defineNuxtConfig({
   },
   i18n: {
     defaultLocale: "en",
+    strategy: "prefix_except_default",
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: "i18n_redirected",
+      redirectOn: "root",
+      fallbackLocale: "en",
+    },
     locales: [
       {
         code: "en",
@@ -68,11 +75,22 @@ export default defineNuxtConfig({
         language: "en-US",
       },
       {
-        code: "zh-cn",
-        name: "中文简体",
-        language: "zh-CN",
+        code: "fr",
+        name: "Français",
+        language: "fr-FR",
+      },
+      {
+        code: "de",
+        name: "Deutsch",
+        language: "de-DE",
+      },
+      {
+        code: "ar",
+        name: "العربية",
+        language: "ar-SA",
       },
     ],
+    vueI18n: "./i18n/i18n.config.ts",
   },
   fonts: {
     processCSSVariables: true,


### PR DESCRIPTION
## Summary
- enable browser language detection and expose English, French, German, and Arabic locales with updated message catalogs
- add localized authentication actions in app config and translate login/register labels across locales
- override the header layout to render a user icon dropdown for the new authentication links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d40870848c832690e8e3a944643805