### PR TITLE
Affiche les aperçus de commentaires en une colonne

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -128,7 +128,7 @@
                     {{ formatNumber(post.comments_preview.length) }} aperçus
                   </p>
                 </div>
-                <div class="mt-4 grid gap-4 md:grid-cols-2">
+                <div class="mt-4 space-y-4">
                   <article
                     v-for="comment in post.comments_preview.slice(0, 4)"
                     :key="comment.id"


### PR DESCRIPTION
## Summary
- ajuste la disposition des aperçus de commentaires pour les afficher sur une seule colonne

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d40c6b58a483269990765f12250d97