### PR TITLE
feat: add right sidebar widgets to blog layout

### DIFF
--- a/components/layout/RightSidebar.vue
+++ b/components/layout/RightSidebar.vue
@@ -1,0 +1,130 @@
+<template>
+  <aside class="sticky top-24 flex flex-col gap-6">
+    <section
+      class="rounded-3xl border border-white/5 bg-white/5 p-6 text-slate-200 shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] backdrop-blur-xl"
+    >
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-primary/80">{{ weather.badge }}</p>
+          <h3 class="mt-3 text-2xl font-semibold text-white">{{ weather.title }}</h3>
+          <p class="mt-2 text-sm text-slate-300">{{ weather.subtitle }}</p>
+        </div>
+        <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-3xl">
+          {{ weather.icon }}
+        </div>
+      </div>
+      <dl class="mt-6 space-y-3 text-sm text-slate-300">
+        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+          <dt class="uppercase tracking-wide text-xs text-slate-400">Localisation</dt>
+          <dd class="font-medium text-white">{{ weather.location }}</dd>
+        </div>
+        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+          <dt class="uppercase tracking-wide text-xs text-slate-400">Température</dt>
+          <dd class="font-medium text-white">{{ weather.temperature }}</dd>
+        </div>
+        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+          <dt class="uppercase tracking-wide text-xs text-slate-400">Conseil</dt>
+          <dd class="max-w-[10rem] text-right text-sm leading-snug">{{ weather.tip }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
+      <header class="flex items-center justify-between text-slate-200">
+        <h3 class="text-lg font-semibold text-white">Top 3 in Quiz</h3>
+        <span class="text-xs uppercase tracking-[0.3em] text-primary/70">live</span>
+      </header>
+      <ul class="mt-5 space-y-4">
+        <li
+          v-for="(participant, index) in topParticipants"
+          :key="participant.name"
+          class="flex items-center gap-3 rounded-2xl border border-white/5 bg-black/20 px-4 py-3 text-sm text-slate-300"
+        >
+          <span
+            class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/15 text-base font-semibold text-primary"
+          >
+            {{ index + 1 }}
+          </span>
+          <div class="flex-1">
+            <p class="font-medium text-white">{{ participant.name }}</p>
+            <p class="text-xs uppercase tracking-wide text-slate-400">{{ participant.role }}</p>
+          </div>
+          <span class="rounded-full bg-primary/15 px-3 py-1 text-xs font-medium text-primary">{{
+            participant.score
+          }}</span>
+        </li>
+      </ul>
+    </section>
+
+    <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
+      <header class="flex items-start justify-between">
+        <div>
+          <h3 class="text-lg font-semibold text-white">Rating overview</h3>
+          <p class="text-sm text-slate-300">Commentaires des membres pour la semaine</p>
+        </div>
+        <div class="text-right text-white">
+          <p class="text-3xl font-bold">{{ rating.average }}</p>
+          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">/ {{ rating.total }}</p>
+        </div>
+      </header>
+      <div class="mt-6 flex items-center gap-3 text-primary">
+        <span class="text-2xl">{{ rating.icon }}</span>
+        <div class="flex gap-1 text-xl">
+          <span
+            v-for="star in 5"
+            :key="star"
+            >{{ star <= rating.stars ? "★" : "☆" }}</span
+          >
+        </div>
+      </div>
+      <ul class="mt-6 space-y-4 text-sm text-slate-300">
+        <li
+          v-for="category in rating.categories"
+          :key="category.label"
+          class="space-y-2"
+        >
+          <div class="flex items-center justify-between">
+            <span class="font-medium text-white">{{ category.label }}</span>
+            <span class="text-xs text-slate-400">{{ category.value }}%</span>
+          </div>
+          <div class="h-2 w-full overflow-hidden rounded-full bg-black/20">
+            <div
+              class="h-full rounded-full bg-gradient-to-r from-primary/60 to-primary"
+              :style="{ width: `${category.value}%` }"
+            />
+          </div>
+        </li>
+      </ul>
+    </section>
+  </aside>
+</template>
+
+<script setup lang="ts">
+const weather = {
+  badge: "News",
+  title: "Rain ahead",
+  subtitle: "Préparez-vous pour une journée humide avec des vents légers.",
+  icon: "🌧️",
+  location: "Berlin, Allemagne",
+  temperature: "18°C",
+  tip: "N'oubliez pas votre parapluie pour rester au sec.",
+};
+
+const topParticipants = [
+  { name: "Bro World", role: "Product Team", score: "982 pts" },
+  { name: "Adam Don", role: "Community", score: "953 pts" },
+  { name: "Nina Ko", role: "Marketing", score: "917 pts" },
+];
+
+const rating = {
+  average: "4.7",
+  total: 5,
+  icon: "⭐",
+  stars: 5,
+  categories: [
+    { label: "Engagement", value: 92 },
+    { label: "Contenu", value: 88 },
+    { label: "Réactivité", value: 84 },
+  ],
+};
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,176 +29,186 @@
         </p>
       </section>
 
-      <section class="mx-auto max-w-5xl space-y-10 px-6 pb-24">
+      <section class="mx-auto max-w-7xl px-6 pb-24">
         <div
-          v-if="pending"
-          class="grid gap-8 md:grid-cols-2"
+          class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]"
         >
-          <div
-            v-for="index in 4"
-            :key="index"
-            class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
-          >
-            <div class="flex items-center gap-4">
-              <div class="h-14 w-14 rounded-2xl bg-white/10" />
-              <div class="space-y-3">
-                <div class="h-3 w-32 rounded-full bg-white/10" />
-                <div class="h-3 w-24 rounded-full bg-white/10" />
-              </div>
-            </div>
-            <div class="space-y-3">
-              <div class="h-3 w-3/4 rounded-full bg-white/10" />
-              <div class="h-3 w-2/3 rounded-full bg-white/10" />
-              <div class="h-3 w-full rounded-full bg-white/10" />
-            </div>
-            <div class="mt-auto flex gap-3">
-              <div class="h-7 w-28 rounded-full bg-white/5" />
-              <div class="h-7 w-28 rounded-full bg-white/5" />
-            </div>
-          </div>
-        </div>
-
-        <template v-else>
-          <article
-            v-for="post in posts"
-            :key="post.id"
-            class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
-          >
+          <div class="space-y-10">
             <div
-              class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
-            />
-            <div class="relative flex flex-col gap-8 p-8 sm:p-10">
-              <header class="flex flex-wrap items-center gap-6">
-                <div class="flex items-center gap-4">
-                  <div
-                    class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
-                  >
-                    <img
-                      :src="post.user.photo ?? defaultAvatar"
-                      :alt="`${post.user.firstName} ${post.user.lastName}`"
-                      class="h-full w-full object-cover"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div>
-                    <p class="text-sm font-medium text-slate-200">
-                      {{ post.user.firstName }} {{ post.user.lastName }}
-                    </p>
-                    <p class="text-xs text-slate-400">
-                      Publié le {{ formatDateTime(post.publishedAt) }}
-                    </p>
-                  </div>
-                </div>
-                <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
-                  <span
-                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                  >
-                    <span class="text-base">{{ reactionEmojis.like }}</span>
-                    {{ formatNumber(post.reactions_count) }} réactions
-                  </span>
-                  <span
-                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                  >
-                    <span class="text-base">💬</span>
-                    {{ formatNumber(post.totalComments) }} commentaires
-                  </span>
-                </div>
-              </header>
-
-              <div class="space-y-4">
-                <h2
-                  class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
-                >
-                  {{ post.title }}
-                </h2>
-                <p class="text-base text-slate-200/80">
-                  {{ post.summary }}
-                </p>
-              </div>
-
+              v-if="pending"
+              class="grid gap-8 md:grid-cols-2"
+            >
               <div
-                v-if="post.comments_preview.length"
-                class="rounded-2xl border border-white/10 bg-black/20 p-6"
+                v-for="index in 4"
+                :key="index"
+                class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
               >
-                <div class="flex items-center justify-between">
-                  <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
-                    Commentaires récents
-                  </p>
-                  <p class="text-xs text-slate-400">
-                    {{ formatNumber(post.comments_preview.length) }} aperçus
-                  </p>
+                <div class="flex items-center gap-4">
+                  <div class="h-14 w-14 rounded-2xl bg-white/10" />
+                  <div class="space-y-3">
+                    <div class="h-3 w-32 rounded-full bg-white/10" />
+                    <div class="h-3 w-24 rounded-full bg-white/10" />
+                  </div>
                 </div>
-                <div class="mt-4 space-y-4">
-                  <article
-                    v-for="comment in post.comments_preview.slice(0, 4)"
-                    :key="comment.id"
-                    class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4"
-                  >
-                    <div class="flex items-center gap-3">
+                <div class="space-y-3">
+                  <div class="h-3 w-3/4 rounded-full bg-white/10" />
+                  <div class="h-3 w-2/3 rounded-full bg-white/10" />
+                  <div class="h-3 w-full rounded-full bg-white/10" />
+                </div>
+                <div class="mt-auto flex gap-3">
+                  <div class="h-7 w-28 rounded-full bg-white/5" />
+                  <div class="h-7 w-28 rounded-full bg-white/5" />
+                </div>
+              </div>
+            </div>
+
+            <template v-else>
+              <article
+                v-for="post in posts"
+                :key="post.id"
+                class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
+              >
+                <div
+                  class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+                />
+                <div class="relative flex flex-col gap-8 p-8 sm:p-10">
+                  <header class="flex flex-wrap items-center gap-6">
+                    <div class="flex items-center gap-4">
                       <div
-                        class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10"
+                        class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
                       >
                         <img
-                          :src="comment.user.photo ?? defaultAvatar"
-                          :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+                          :src="post.user.photo ?? defaultAvatar"
+                          :alt="`${post.user.firstName} ${post.user.lastName}`"
                           class="h-full w-full object-cover"
                           loading="lazy"
                         />
                       </div>
                       <div>
                         <p class="text-sm font-medium text-slate-200">
-                          {{ comment.user.firstName }} {{ comment.user.lastName }}
+                          {{ post.user.firstName }} {{ post.user.lastName }}
                         </p>
-                        <p class="text-[11px] uppercase tracking-wide text-slate-400">
-                          {{ formatDateTime(comment.publishedAt) }}
+                        <p class="text-xs text-slate-400">
+                          Publié le {{ formatDateTime(post.publishedAt) }}
                         </p>
                       </div>
                     </div>
-                    <p class="text-sm leading-relaxed text-slate-200/80">
-                      {{ comment.content }}
-                    </p>
-                    <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
+                    <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
                       <span
-                        class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
+                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
                       >
                         <span class="text-base">{{ reactionEmojis.like }}</span>
-                        {{ formatNumber(comment.reactions_count) }} réactions
+                        {{ formatNumber(post.reactions_count) }} réactions
                       </span>
                       <span
-                        class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
+                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
                       >
                         <span class="text-base">💬</span>
-                        {{ formatNumber(comment.totalComments) }} réponses
+                        {{ formatNumber(post.totalComments) }} commentaires
                       </span>
                     </div>
-                  </article>
-                </div>
-              </div>
+                  </header>
 
-              <footer
-                v-if="post.reactions_preview.length"
-                class="flex flex-wrap items-center gap-3 text-sm"
-              >
-                <span class="text-xs uppercase tracking-wide text-slate-400"
-                  >Réactions coup de cœur</span
-                >
-                <div class="flex flex-wrap gap-3">
-                  <div
-                    v-for="reaction in post.reactions_preview.slice(0, 4)"
-                    :key="reaction.id"
-                    class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
-                  >
-                    <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
-                    <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
-                    <span class="text-[11px] uppercase tracking-wide text-slate-400">{{
-                      reactionLabels[reaction.type]
-                    }}</span>
+                  <div class="space-y-4">
+                    <h2
+                      class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
+                    >
+                      {{ post.title }}
+                    </h2>
+                    <p class="text-base text-slate-200/80">
+                      {{ post.summary }}
+                    </p>
                   </div>
+
+                  <div
+                    v-if="post.comments_preview.length"
+                    class="rounded-2xl border border-white/10 bg-black/20 p-6"
+                  >
+                    <div class="flex items-center justify-between">
+                      <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
+                        Commentaires récents
+                      </p>
+                      <p class="text-xs text-slate-400">
+                        {{ formatNumber(post.comments_preview.length) }} aperçus
+                      </p>
+                    </div>
+                    <div class="mt-4 space-y-4">
+                      <article
+                        v-for="comment in post.comments_preview.slice(0, 4)"
+                        :key="comment.id"
+                        class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4"
+                      >
+                        <div class="flex items-center gap-3">
+                          <div
+                            class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10"
+                          >
+                            <img
+                              :src="comment.user.photo ?? defaultAvatar"
+                              :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+                              class="h-full w-full object-cover"
+                              loading="lazy"
+                            />
+                          </div>
+                          <div>
+                            <p class="text-sm font-medium text-slate-200">
+                              {{ comment.user.firstName }} {{ comment.user.lastName }}
+                            </p>
+                            <p class="text-[11px] uppercase tracking-wide text-slate-400">
+                              {{ formatDateTime(comment.publishedAt) }}
+                            </p>
+                          </div>
+                        </div>
+                        <p class="text-sm leading-relaxed text-slate-200/80">
+                          {{ comment.content }}
+                        </p>
+                        <div
+                          class="mt-auto flex items-center justify-between text-xs text-slate-400"
+                        >
+                          <span
+                            class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
+                          >
+                            <span class="text-base">{{ reactionEmojis.like }}</span>
+                            {{ formatNumber(comment.reactions_count) }} réactions
+                          </span>
+                          <span
+                            class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
+                          >
+                            <span class="text-base">💬</span>
+                            {{ formatNumber(comment.totalComments) }} réponses
+                          </span>
+                        </div>
+                      </article>
+                    </div>
+                  </div>
+
+                  <footer
+                    v-if="post.reactions_preview.length"
+                    class="flex flex-wrap items-center gap-3 text-sm"
+                  >
+                    <span class="text-xs uppercase tracking-wide text-slate-400"
+                      >Réactions coup de cœur</span
+                    >
+                    <div class="flex flex-wrap gap-3">
+                      <div
+                        v-for="reaction in post.reactions_preview.slice(0, 4)"
+                        :key="reaction.id"
+                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
+                      >
+                        <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
+                        <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
+                        <span class="text-[11px] uppercase tracking-wide text-slate-400">{{
+                          reactionLabels[reaction.type]
+                        }}</span>
+                      </div>
+                    </div>
+                  </footer>
                 </div>
-              </footer>
-            </div>
-          </article>
-        </template>
+              </article>
+            </template>
+          </div>
+
+          <LayoutRightSidebar class="hidden lg:flex" />
+        </div>
       </section>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- create a reusable right sidebar widget stack with weather, quiz leaders, and rating cards
- update the blog index page layout to show the new sidebar next to the posts feed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4116327ac8326961400d4231d16b1