### PR TITLE
Refactor blog feed into reusable cards

### DIFF
--- a/components/blog/CommentCard.vue
+++ b/components/blog/CommentCard.vue
@@ -1,0 +1,68 @@
+<template>
+  <article class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4">
+    <div class="flex items-center gap-3">
+      <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10">
+        <img
+          :src="comment.user.photo ?? defaultAvatar"
+          :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      <div>
+        <p class="text-sm font-medium text-slate-200">
+          {{ comment.user.firstName }} {{ comment.user.lastName }}
+        </p>
+        <p class="text-[11px] uppercase tracking-wide text-slate-400">
+          {{ formatDateTime(comment.publishedAt) }}
+        </p>
+      </div>
+    </div>
+    <p class="text-sm leading-relaxed text-slate-200/80">
+      {{ comment.content }}
+    </p>
+    <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
+      <span class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1">
+        <span
+          aria-hidden="true"
+          class="text-base"
+          >👍</span
+        >
+        {{ t("blog.comment.reactions", { count: formatNumber(comment.reactions_count) }) }}
+      </span>
+      <span class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1">
+        <span
+          aria-hidden="true"
+          class="text-base"
+          >💬</span
+        >
+        {{ t("blog.comment.replies", { count: formatNumber(comment.totalComments) }) }}
+      </span>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import type { BlogCommentPreview } from "~/lib/mock/blog";
+
+import { computed } from "vue";
+
+const props = defineProps<{ comment: BlogCommentPreview }>();
+
+const defaultAvatar = "https://bro-world-space.com/img/person.png";
+
+const { locale, t } = useI18n();
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat(locale.value, {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatNumber(value: number | null | undefined) {
+  return new Intl.NumberFormat(locale.value).format(value ?? 0);
+}
+
+const comment = computed(() => props.comment);
+</script>

--- a/components/blog/PostCard.vue
+++ b/components/blog/PostCard.vue
@@ -1,0 +1,158 @@
+<template>
+  <article
+    class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
+  >
+    <div
+      class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+    />
+    <div class="relative flex flex-col gap-8 p-8 sm:p-10">
+      <header class="flex flex-wrap items-center gap-6">
+        <div class="flex items-center gap-4">
+          <div
+            class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
+          >
+            <img
+              :src="post.user.photo ?? defaultAvatar"
+              :alt="`${post.user.firstName} ${post.user.lastName}`"
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-200">
+              {{ post.user.firstName }} {{ post.user.lastName }}
+            </p>
+            <p class="text-xs text-slate-400">
+              {{ t("blog.post.publishedOn", { date: formatDateTime(post.publishedAt) }) }}
+            </p>
+          </div>
+        </div>
+        <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
+          <span
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+          >
+            <span
+              aria-hidden="true"
+              class="text-base"
+              >{{ reactionEmojis.like }}</span
+            >
+            {{ t("blog.post.reactions", { count: formatNumber(post.reactions_count) }) }}
+          </span>
+          <span
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+          >
+            <span
+              aria-hidden="true"
+              class="text-base"
+              >💬</span
+            >
+            {{ t("blog.post.comments", { count: formatNumber(post.totalComments) }) }}
+          </span>
+        </div>
+      </header>
+
+      <div class="space-y-4">
+        <h2
+          class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
+        >
+          {{ post.title }}
+        </h2>
+        <p class="text-base text-slate-200/80">
+          {{ post.summary }}
+        </p>
+      </div>
+
+      <div
+        v-if="post.comments_preview.length"
+        class="rounded-2xl border border-white/10 bg-black/20 p-6"
+      >
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
+            {{ t("blog.post.recentComments") }}
+          </p>
+          <p class="text-xs text-slate-400">
+            {{
+              t("blog.post.commentPreviews", { count: formatNumber(post.comments_preview.length) })
+            }}
+          </p>
+        </div>
+        <div class="mt-4 space-y-4">
+          <CommentCard
+            v-for="comment in post.comments_preview.slice(0, 4)"
+            :key="comment.id"
+            :comment="comment"
+          />
+        </div>
+      </div>
+
+      <footer
+        v-if="post.reactions_preview.length"
+        class="flex flex-wrap items-center gap-3 text-sm"
+      >
+        <span class="text-xs uppercase tracking-wide text-slate-400">
+          {{ t("blog.post.reactionSpotlight") }}
+        </span>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="reaction in post.reactions_preview.slice(0, 4)"
+            :key="reaction.id"
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
+          >
+            <span
+              aria-hidden="true"
+              class="text-lg"
+              >{{ reactionEmojis[reaction.type] }}</span
+            >
+            <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
+            <span class="text-[11px] uppercase tracking-wide text-slate-400">
+              {{ reactionLabels[reaction.type] }}
+            </span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import CommentCard from "./CommentCard.vue";
+import type { BlogPost, ReactionType } from "~/lib/mock/blog";
+
+const props = defineProps<{ post: BlogPost }>();
+
+const defaultAvatar = "https://bro-world-space.com/img/person.png";
+
+const reactionEmojis: Record<ReactionType, string> = {
+  like: "👍",
+  love: "❤️",
+  wow: "😮",
+  haha: "😂",
+  sad: "😢",
+  angry: "😡",
+};
+
+const { locale, t } = useI18n();
+
+const reactionLabels = computed<Record<ReactionType, string>>(() => ({
+  like: t("blog.reactionTypes.like"),
+  love: t("blog.reactionTypes.love"),
+  wow: t("blog.reactionTypes.wow"),
+  haha: t("blog.reactionTypes.haha"),
+  sad: t("blog.reactionTypes.sad"),
+  angry: t("blog.reactionTypes.angry"),
+}));
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat(locale.value, {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatNumber(value: number | null | undefined) {
+  return new Intl.NumberFormat(locale.value).format(value ?? 0);
+}
+
+const post = computed(() => props.post);
+</script>

--- a/components/blog/RightSidebar.vue
+++ b/components/blog/RightSidebar.vue
@@ -1,0 +1,33 @@
+<template>
+  <aside class="w-full max-w-sm">
+    <div
+      class="sticky top-24 flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl"
+    >
+      <header class="space-y-2">
+        <p class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+          {{ title }}
+        </p>
+        <h2 class="text-2xl font-semibold text-white">
+          {{ subtitle }}
+        </h2>
+      </header>
+      <div class="space-y-4">
+        <SidebarWidget
+          v-for="widget in widgets"
+          :key="widget.id"
+          :widget="widget"
+        />
+      </div>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import SidebarWidget, { type SidebarWidgetData } from "./SidebarWidget.vue";
+
+defineProps<{
+  title: string;
+  subtitle: string;
+  widgets: SidebarWidgetData[];
+}>();
+</script>

--- a/components/blog/SidebarWidget.vue
+++ b/components/blog/SidebarWidget.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    class="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-5 transition-colors duration-300 hover:border-primary/50 hover:bg-primary/10"
+  >
+    <div class="flex items-start gap-4">
+      <div
+        class="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/20 text-2xl"
+      >
+        <span aria-hidden="true">{{ widget.icon }}</span>
+      </div>
+      <div class="flex flex-1 flex-col gap-3">
+        <div>
+          <p class="text-sm font-semibold text-slate-100">
+            {{ widget.title }}
+          </p>
+          <p class="text-sm text-slate-400">
+            {{ widget.description }}
+          </p>
+        </div>
+        <NuxtLink
+          v-if="widget.action"
+          :href="widget.action.href"
+          class="inline-flex items-center gap-2 text-sm font-medium text-primary transition hover:text-primary/80"
+          :target="widget.action.external ? '_blank' : undefined"
+          :rel="widget.action.external ? 'noopener noreferrer' : undefined"
+        >
+          <span>{{ widget.action.label }}</span>
+          <span aria-hidden="true">→</span>
+        </NuxtLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface SidebarWidgetAction {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+export interface SidebarWidgetData {
+  id: string;
+  icon: string;
+  title: string;
+  description: string;
+  action?: SidebarWidgetAction;
+}
+
+defineProps<{ widget: SidebarWidgetData }>();
+</script>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -52,5 +52,48 @@
     "Account": "الحساب",
     "Login": "تسجيل الدخول",
     "Register": "إنشاء حساب"
+  },
+  "blog": {
+    "post": {
+      "publishedOn": "نُشر في {date}",
+      "reactions": "{count} تفاعلات",
+      "comments": "{count} تعليقات",
+      "recentComments": "أحدث التعليقات",
+      "commentPreviews": "{count} معاينات",
+      "reactionSpotlight": "أبرز التفاعلات"
+    },
+    "comment": {
+      "reactions": "{count} تفاعلات",
+      "replies": "{count} ردود"
+    },
+    "reactionTypes": {
+      "like": "إعجاب",
+      "love": "حب",
+      "wow": "واو",
+      "haha": "هاها",
+      "sad": "حزين",
+      "angry": "غاضب"
+    },
+    "sidebar": {
+      "title": "ابقَ على تواصل",
+      "subtitle": "موارد لمتابعة مجتمع برو وورلد.",
+      "widgets": {
+        "community": {
+          "title": "انضم إلى المجتمع",
+          "description": "تحدّث مع صناع آخرين، شارك أفكارك، واحصل على المساعدة فورًا.",
+          "action": "فتح ديسكورد"
+        },
+        "docs": {
+          "title": "استكشف التوثيق",
+          "description": "تعرّف على كيفية الاستفادة القصوى من مكوّنات برو وورلد في مشاريعك.",
+          "action": "قراءة التوثيق"
+        },
+        "contribute": {
+          "title": "ساهم بمقال",
+          "description": "شارك خبراتك مع المجتمع وساعد الآخرين على التطور.",
+          "action": "إرسال محتوى"
+        }
+      }
+    }
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -52,5 +52,48 @@
     "Account": "Konto",
     "Login": "Anmelden",
     "Register": "Registrieren"
+  },
+  "blog": {
+    "post": {
+      "publishedOn": "Veröffentlicht am {date}",
+      "reactions": "{count} Reaktionen",
+      "comments": "{count} Kommentare",
+      "recentComments": "Neueste Kommentare",
+      "commentPreviews": "{count} Vorschauen",
+      "reactionSpotlight": "Reaktions-Highlights"
+    },
+    "comment": {
+      "reactions": "{count} Reaktionen",
+      "replies": "{count} Antworten"
+    },
+    "reactionTypes": {
+      "like": "Gefällt mir",
+      "love": "Liebe",
+      "wow": "Wow",
+      "haha": "Haha",
+      "sad": "Traurig",
+      "angry": "Wütend"
+    },
+    "sidebar": {
+      "title": "Bleib in Verbindung",
+      "subtitle": "Ressourcen, um mit der BroWorld-Community Schritt zu halten.",
+      "widgets": {
+        "community": {
+          "title": "Trete der Community bei",
+          "description": "Tausche dich mit anderen Buildern aus, teile Ideen und erhalte schnelle Hilfe.",
+          "action": "Discord öffnen"
+        },
+        "docs": {
+          "title": "Dokumentation entdecken",
+          "description": "Lerne, wie du das Beste aus den BroWorld-Komponenten in deinen Projekten herausholst.",
+          "action": "Dokumentation lesen"
+        },
+        "contribute": {
+          "title": "Einen Artikel beitragen",
+          "description": "Teile dein Wissen mit der Community und unterstütze andere beim Lernen.",
+          "action": "Inhalt einreichen"
+        }
+      }
+    }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -52,5 +52,48 @@
     "Account": "Account",
     "Login": "Log in",
     "Register": "Register"
+  },
+  "blog": {
+    "post": {
+      "publishedOn": "Published on {date}",
+      "reactions": "{count} reactions",
+      "comments": "{count} comments",
+      "recentComments": "Recent comments",
+      "commentPreviews": "{count} previews",
+      "reactionSpotlight": "Reaction spotlight"
+    },
+    "comment": {
+      "reactions": "{count} reactions",
+      "replies": "{count} replies"
+    },
+    "reactionTypes": {
+      "like": "Like",
+      "love": "Love",
+      "wow": "Wow",
+      "haha": "Haha",
+      "sad": "Sad",
+      "angry": "Angry"
+    },
+    "sidebar": {
+      "title": "Stay connected",
+      "subtitle": "Resources to keep up with the BroWorld community.",
+      "widgets": {
+        "community": {
+          "title": "Join the community",
+          "description": "Chat with other builders, share ideas, and get instant help.",
+          "action": "Open Discord"
+        },
+        "docs": {
+          "title": "Browse the docs",
+          "description": "Learn how to make the most of BroWorld components in your projects.",
+          "action": "Read documentation"
+        },
+        "contribute": {
+          "title": "Contribute an article",
+          "description": "Share your insights with the community and help others grow.",
+          "action": "Submit content"
+        }
+      }
+    }
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -52,5 +52,48 @@
     "Account": "Compte",
     "Login": "Connexion",
     "Register": "Inscription"
+  },
+  "blog": {
+    "post": {
+      "publishedOn": "Publié le {date}",
+      "reactions": "{count} réactions",
+      "comments": "{count} commentaires",
+      "recentComments": "Commentaires récents",
+      "commentPreviews": "{count} aperçus",
+      "reactionSpotlight": "Réactions coup de cœur"
+    },
+    "comment": {
+      "reactions": "{count} réactions",
+      "replies": "{count} réponses"
+    },
+    "reactionTypes": {
+      "like": "J'aime",
+      "love": "J'adore",
+      "wow": "Waouh",
+      "haha": "Haha",
+      "sad": "Triste",
+      "angry": "En colère"
+    },
+    "sidebar": {
+      "title": "Restez connecté",
+      "subtitle": "Des ressources pour suivre la communauté BroWorld.",
+      "widgets": {
+        "community": {
+          "title": "Rejoignez la communauté",
+          "description": "Échangez avec d'autres créateurs, partagez vos idées et obtenez de l'aide rapidement.",
+          "action": "Ouvrir Discord"
+        },
+        "docs": {
+          "title": "Explorer la documentation",
+          "description": "Apprenez à tirer le meilleur parti des composants BroWorld dans vos projets.",
+          "action": "Lire la documentation"
+        },
+        "contribute": {
+          "title": "Contribuer un article",
+          "description": "Partagez vos connaissances avec la communauté et aidez les autres à progresser.",
+          "action": "Proposer du contenu"
+        }
+      }
+    }
   }
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -52,5 +52,48 @@
     "Account": "账户",
     "Login": "登录",
     "Register": "注册"
+  },
+  "blog": {
+    "post": {
+      "publishedOn": "发布于 {date}",
+      "reactions": "{count} 条互动",
+      "comments": "{count} 条评论",
+      "recentComments": "最新评论",
+      "commentPreviews": "{count} 条预览",
+      "reactionSpotlight": "精选互动"
+    },
+    "comment": {
+      "reactions": "{count} 条互动",
+      "replies": "{count} 条回复"
+    },
+    "reactionTypes": {
+      "like": "点赞",
+      "love": "喜爱",
+      "wow": "惊叹",
+      "haha": "哈哈",
+      "sad": "难过",
+      "angry": "生气"
+    },
+    "sidebar": {
+      "title": "保持联系",
+      "subtitle": "帮助你紧跟 BroWorld 社区的最新动态。",
+      "widgets": {
+        "community": {
+          "title": "加入社区",
+          "description": "与其他开发者交流，分享想法并获取即时帮助。",
+          "action": "打开 Discord"
+        },
+        "docs": {
+          "title": "浏览文档",
+          "description": "了解如何在项目中充分利用 BroWorld 组件。",
+          "action": "阅读文档"
+        },
+        "contribute": {
+          "title": "投稿文章",
+          "description": "与社区分享你的经验，帮助更多人进步。",
+          "action": "提交内容"
+        }
+      }
+    }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,240 +1,106 @@
 <template>
-  <div
-    class="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-50"
-  >
-    <div class="pointer-events-none absolute inset-0 overflow-hidden">
-      <div class="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-primary/20 blur-3xl" />
+  <div class="relative min-h-screen overflow-hidden bg-transparent text-slate-50">
+    <section class="mx-auto max-w-7xl px-6 pb-24">
       <div
-        class="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-primary/10 blur-3xl"
-      />
-      <div
-        class="absolute left-1/3 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/5 blur-2xl"
-      />
-    </div>
-
-    <div class="relative z-10">
-      <section class="mx-auto max-w-7xl px-6 pb-24">
-        <div
-          class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]"
-        >
-          <div class="space-y-10">
+        class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]"
+      >
+        <div class="space-y-10">
+          <div
+            v-if="pending"
+            class="grid gap-8 md:grid-cols-2"
+          >
             <div
-              v-if="pending"
-              class="grid gap-8 md:grid-cols-2"
+              v-for="index in 4"
+              :key="index"
+              class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
             >
-              <div
-                v-for="index in 4"
-                :key="index"
-                class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
-              >
-                <div class="flex items-center gap-4">
-                  <div class="h-14 w-14 rounded-2xl bg-white/10" />
-                  <div class="space-y-3">
-                    <div class="h-3 w-32 rounded-full bg-white/10" />
-                    <div class="h-3 w-24 rounded-full bg-white/10" />
-                  </div>
-                </div>
+              <div class="flex items-center gap-4">
+                <div class="h-14 w-14 rounded-2xl bg-white/10" />
                 <div class="space-y-3">
-                  <div class="h-3 w-3/4 rounded-full bg-white/10" />
-                  <div class="h-3 w-2/3 rounded-full bg-white/10" />
-                  <div class="h-3 w-full rounded-full bg-white/10" />
-                </div>
-                <div class="mt-auto flex gap-3">
-                  <div class="h-7 w-28 rounded-full bg-white/5" />
-                  <div class="h-7 w-28 rounded-full bg-white/5" />
+                  <div class="h-3 w-32 rounded-full bg-white/10" />
+                  <div class="h-3 w-24 rounded-full bg-white/10" />
                 </div>
               </div>
+              <div class="space-y-3">
+                <div class="h-3 w-3/4 rounded-full bg-white/10" />
+                <div class="h-3 w-2/3 rounded-full bg-white/10" />
+                <div class="h-3 w-full rounded-full bg-white/10" />
+              </div>
+              <div class="mt-auto flex gap-3">
+                <div class="h-7 w-28 rounded-full bg-white/5" />
+                <div class="h-7 w-28 rounded-full bg-white/5" />
+              </div>
             </div>
-
-            <template v-else>
-              <article
-                v-for="post in posts"
-                :key="post.id"
-                class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
-              >
-                <div
-                  class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
-                />
-                <div class="relative flex flex-col gap-8 p-8 sm:p-10">
-                  <header class="flex flex-wrap items-center gap-6">
-                    <div class="flex items-center gap-4">
-                      <div
-                        class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
-                      >
-                        <img
-                          :src="post.user.photo ?? defaultAvatar"
-                          :alt="`${post.user.firstName} ${post.user.lastName}`"
-                          class="h-full w-full object-cover"
-                          loading="lazy"
-                        />
-                      </div>
-                      <div>
-                        <p class="text-sm font-medium text-slate-200">
-                          {{ post.user.firstName }} {{ post.user.lastName }}
-                        </p>
-                        <p class="text-xs text-slate-400">
-                          Publié le {{ formatDateTime(post.publishedAt) }}
-                        </p>
-                      </div>
-                    </div>
-                    <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
-                      <span
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                      >
-                        <span class="text-base">{{ reactionEmojis.like }}</span>
-                        {{ formatNumber(post.reactions_count) }} réactions
-                      </span>
-                      <span
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                      >
-                        <span class="text-base">💬</span>
-                        {{ formatNumber(post.totalComments) }} commentaires
-                      </span>
-                    </div>
-                  </header>
-
-                  <div class="space-y-4">
-                    <h2
-                      class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
-                    >
-                      {{ post.title }}
-                    </h2>
-                    <p class="text-base text-slate-200/80">
-                      {{ post.summary }}
-                    </p>
-                  </div>
-
-                  <div
-                    v-if="post.comments_preview.length"
-                    class="rounded-2xl border border-white/10 bg-black/20 p-6"
-                  >
-                    <div class="flex items-center justify-between">
-                      <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
-                        Commentaires récents
-                      </p>
-                      <p class="text-xs text-slate-400">
-                        {{ formatNumber(post.comments_preview.length) }} aperçus
-                      </p>
-                    </div>
-                    <div class="mt-4 space-y-4">
-                      <article
-                        v-for="comment in post.comments_preview.slice(0, 4)"
-                        :key="comment.id"
-                        class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4"
-                      >
-                        <div class="flex items-center gap-3">
-                          <div
-                            class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10"
-                          >
-                            <img
-                              :src="comment.user.photo ?? defaultAvatar"
-                              :alt="`${comment.user.firstName} ${comment.user.lastName}`"
-                              class="h-full w-full object-cover"
-                              loading="lazy"
-                            />
-                          </div>
-                          <div>
-                            <p class="text-sm font-medium text-slate-200">
-                              {{ comment.user.firstName }} {{ comment.user.lastName }}
-                            </p>
-                            <p class="text-[11px] uppercase tracking-wide text-slate-400">
-                              {{ formatDateTime(comment.publishedAt) }}
-                            </p>
-                          </div>
-                        </div>
-                        <p class="text-sm leading-relaxed text-slate-200/80">
-                          {{ comment.content }}
-                        </p>
-                        <div
-                          class="mt-auto flex items-center justify-between text-xs text-slate-400"
-                        >
-                          <span
-                            class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
-                          >
-                            <span class="text-base">{{ reactionEmojis.like }}</span>
-                            {{ formatNumber(comment.reactions_count) }} réactions
-                          </span>
-                          <span
-                            class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
-                          >
-                            <span class="text-base">💬</span>
-                            {{ formatNumber(comment.totalComments) }} réponses
-                          </span>
-                        </div>
-                      </article>
-                    </div>
-                  </div>
-
-                  <footer
-                    v-if="post.reactions_preview.length"
-                    class="flex flex-wrap items-center gap-3 text-sm"
-                  >
-                    <span class="text-xs uppercase tracking-wide text-slate-400"
-                      >Réactions coup de cœur</span
-                    >
-                    <div class="flex flex-wrap gap-3">
-                      <div
-                        v-for="reaction in post.reactions_preview.slice(0, 4)"
-                        :key="reaction.id"
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
-                      >
-                        <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
-                        <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
-                        <span class="text-[11px] uppercase tracking-wide text-slate-400">{{
-                          reactionLabels[reaction.type]
-                        }}</span>
-                      </div>
-                    </div>
-                  </footer>
-                </div>
-              </article>
-            </template>
           </div>
 
-          <RightSidebar class="hidden lg:flex" />
+          <template v-else>
+            <PostCard
+              v-for="post in posts"
+              :key="post.id"
+              :post="post"
+            />
+          </template>
         </div>
-      </section>
-    </div>
+
+        <RightSidebar
+          class="hidden lg:flex"
+          :title="sidebarContent.title"
+          :subtitle="sidebarContent.subtitle"
+          :widgets="sidebarContent.widgets"
+        />
+      </div>
+    </section>
   </div>
 </template>
 
 <script setup lang="ts">
 import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
-import type { ReactionType } from "~/lib/mock/blog";
+import { computed } from "vue";
+import type { SidebarWidgetData } from "~/components/blog/SidebarWidget.vue";
 
-const defaultAvatar = "https://bro-world-space.com/img/person.png";
-
-const reactionEmojis: Record<ReactionType, string> = {
-  like: "👍",
-  love: "❤️",
-  wow: "😮",
-  haha: "😂",
-  sad: "😢",
-  angry: "😡",
-};
-
-const reactionLabels: Record<ReactionType, string> = {
-  like: "Like",
-  love: "Love",
-  wow: "Wow",
-  haha: "Haha",
-  sad: "Sad",
-  angry: "Angry",
-};
-
-function formatDateTime(value: string) {
-  return new Intl.DateTimeFormat("fr-FR", {
-    dateStyle: "long",
-    timeStyle: "short",
-  }).format(new Date(value));
-}
-
-function formatNumber(value: number | null | undefined) {
-  return new Intl.NumberFormat("fr-FR").format(value ?? 0);
-}
-
+const { t } = useI18n();
 const { posts, pending, fetchPosts } = usePostsStore();
+
+const sidebarContent = computed(() => ({
+  title: t("blog.sidebar.title"),
+  subtitle: t("blog.sidebar.subtitle"),
+  widgets: [
+    {
+      id: "community",
+      icon: "🤝",
+      title: t("blog.sidebar.widgets.community.title"),
+      description: t("blog.sidebar.widgets.community.description"),
+      action: {
+        label: t("blog.sidebar.widgets.community.action"),
+        href: "https://discord.gg/broworld",
+        external: true,
+      },
+    },
+    {
+      id: "docs",
+      icon: "📘",
+      title: t("blog.sidebar.widgets.docs.title"),
+      description: t("blog.sidebar.widgets.docs.description"),
+      action: {
+        label: t("blog.sidebar.widgets.docs.action"),
+        href: "https://bro-world.com/docs",
+        external: true,
+      },
+    },
+    {
+      id: "contribute",
+      icon: "📝",
+      title: t("blog.sidebar.widgets.contribute.title"),
+      description: t("blog.sidebar.widgets.contribute.description"),
+      action: {
+        label: t("blog.sidebar.widgets.contribute.action"),
+        href: "https://bro-world.com/contact",
+        external: true,
+      },
+    },
+  ] satisfies SidebarWidgetData[],
+}));
 
 await callOnce(() => fetchPosts());
 </script>


### PR DESCRIPTION
## Summary
- make the landing page background transparent and replace the inline feed markup with a reusable `PostCard` component
- extract comment previews, right sidebar, and sidebar widgets into dedicated components for better reuse and styling
- add localized blog strings across all supported locales for the new UI labels

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4180dc5a08326800733451afa7193