### PR TITLE
refactor: extract post and sidebar components

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -1,0 +1,66 @@
+<template>
+  <article class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4">
+    <div class="flex items-center gap-3">
+      <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10">
+        <img
+          :src="comment.user.photo ?? defaultAvatar"
+          :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+          class="h-full w-full object-cover"
+          loading="lazy"
+        />
+      </div>
+      <div>
+        <p class="text-sm font-medium text-slate-200">
+          {{ comment.user.firstName }} {{ comment.user.lastName }}
+        </p>
+        <p class="text-[11px] uppercase tracking-wide text-slate-400">
+          {{ formatDateTime(comment.publishedAt) }}
+        </p>
+      </div>
+    </div>
+    <p class="text-sm leading-relaxed text-slate-200/80">
+      {{ comment.content }}
+    </p>
+    <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
+      <span class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1">
+        <span class="text-base">{{ reactionEmojis.like }}</span>
+        {{ reactionsLabel }}
+      </span>
+      <span class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1">
+        <span class="text-base">💬</span>
+        {{ repliesLabel }}
+      </span>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import type { BlogCommentPreview, ReactionType } from "~/lib/mock/blog";
+
+type FormatDateTime = (value: string) => string;
+type FormatNumber = (value: number | null | undefined) => string;
+
+const props = defineProps<{
+  comment: BlogCommentPreview;
+  defaultAvatar: string;
+  reactionEmojis: Record<ReactionType, string>;
+  formatDateTime: FormatDateTime;
+  formatNumber: FormatNumber;
+}>();
+
+const { t } = useI18n();
+
+const reactionsLabel = computed(() =>
+  t("blog.comments.reactionCount", {
+    count: props.formatNumber(props.comment.reactions_count),
+  }),
+);
+
+const repliesLabel = computed(() =>
+  t("blog.comments.replyCount", {
+    count: props.formatNumber(props.comment.totalComments),
+  }),
+);
+</script>

--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -1,0 +1,163 @@
+<template>
+  <article
+    class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
+  >
+    <div
+      class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+    />
+    <div class="relative flex flex-col gap-8 p-8 sm:p-10">
+      <header class="flex flex-wrap items-center gap-6">
+        <div class="flex items-center gap-4">
+          <div
+            class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
+          >
+            <img
+              :src="post.user.photo ?? defaultAvatar"
+              :alt="`${post.user.firstName} ${post.user.lastName}`"
+              class="h-full w-full object-cover"
+              loading="lazy"
+            />
+          </div>
+          <div>
+            <p class="text-sm font-medium text-slate-200">
+              {{ post.user.firstName }} {{ post.user.lastName }}
+            </p>
+            <p class="text-xs text-slate-400">
+              {{ publishedLabel }}
+            </p>
+          </div>
+        </div>
+        <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
+          <span
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+          >
+            <span class="text-base">{{ reactionEmojis.like }}</span>
+            {{ reactionsLabel }}
+          </span>
+          <span
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
+          >
+            <span class="text-base">💬</span>
+            {{ commentsLabel }}
+          </span>
+        </div>
+      </header>
+
+      <div class="space-y-4">
+        <h2
+          class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
+        >
+          {{ post.title }}
+        </h2>
+        <p class="text-base text-slate-200/80">
+          {{ post.summary }}
+        </p>
+      </div>
+
+      <section
+        v-if="hasCommentPreview"
+        class="rounded-2xl border border-white/10 bg-black/20 p-6"
+      >
+        <div class="flex items-center justify-between">
+          <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
+            {{ recentCommentsLabel }}
+          </p>
+          <p class="text-xs text-slate-400">
+            {{ commentPreviewCountLabel }}
+          </p>
+        </div>
+        <div class="mt-4 space-y-4">
+          <CommentCard
+            v-for="comment in topComments"
+            :key="comment.id"
+            :comment="comment"
+            :default-avatar="defaultAvatar"
+            :reaction-emojis="reactionEmojis"
+            :format-date-time="formatDateTime"
+            :format-number="formatNumber"
+          />
+        </div>
+      </section>
+
+      <footer
+        v-if="hasReactionPreview"
+        class="flex flex-wrap items-center gap-3 text-sm"
+      >
+        <span class="text-xs uppercase tracking-wide text-slate-400">
+          {{ highlightedReactionsLabel }}
+        </span>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="reaction in topReactions"
+            :key="reaction.id"
+            class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
+          >
+            <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
+            <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
+            <span class="text-[11px] uppercase tracking-wide text-slate-400">
+              {{ reactionLabels[reaction.type] }}
+            </span>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+import CommentCard from "~/components/CommentCard.vue";
+import type { BlogPost, ReactionType } from "~/lib/mock/blog";
+
+const props = defineProps<{
+  post: BlogPost;
+  defaultAvatar: string;
+  reactionEmojis: Record<ReactionType, string>;
+  reactionLabels: Record<ReactionType, string>;
+}>();
+
+const { locale, t } = useI18n();
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat(locale.value ?? "fr-FR", {
+    dateStyle: "long",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatNumber(value: number | null | undefined) {
+  return new Intl.NumberFormat(locale.value ?? "fr-FR").format(value ?? 0);
+}
+
+const publishedLabel = computed(() =>
+  t("blog.posts.publishedOn", { date: formatDateTime(props.post.publishedAt) }),
+);
+
+const reactionsLabel = computed(() =>
+  t("blog.posts.reactionCount", {
+    count: formatNumber(props.post.reactions_count),
+  }),
+);
+
+const commentsLabel = computed(() =>
+  t("blog.posts.commentCount", {
+    count: formatNumber(props.post.totalComments),
+  }),
+);
+
+const recentCommentsLabel = computed(() => t("blog.posts.recentComments"));
+
+const commentPreviewCountLabel = computed(() =>
+  t("blog.posts.previewCount", {
+    count: formatNumber(props.post.comments_preview.length),
+  }),
+);
+
+const highlightedReactionsLabel = computed(() => t("blog.posts.highlightedReactions"));
+
+const topComments = computed(() => props.post.comments_preview.slice(0, 4));
+const topReactions = computed(() => props.post.reactions_preview.slice(0, 4));
+const hasCommentPreview = computed(() => topComments.value.length > 0);
+const hasReactionPreview = computed(() => topReactions.value.length > 0);
+</script>

--- a/components/layout/RightSidebar.vue
+++ b/components/layout/RightSidebar.vue
@@ -1,130 +1,94 @@
 <template>
-  <aside class="sticky top-24 flex flex-col gap-6">
-    <section
-      class="rounded-3xl border border-white/5 bg-white/5 p-6 text-slate-200 shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] backdrop-blur-xl"
+  <aside class="sticky top-24 hidden h-[calc(100vh-6rem)] lg:flex">
+    <UiScrollArea
+      orientation="vertical"
+      type="hover"
+      class="h-full w-full overflow-hidden py-6 pr-2"
     >
-      <div class="flex items-start justify-between gap-4">
-        <div>
-          <p class="text-xs uppercase tracking-[0.3em] text-primary/80">{{ weather.badge }}</p>
-          <h3 class="mt-3 text-2xl font-semibold text-white">{{ weather.title }}</h3>
-          <p class="mt-2 text-sm text-slate-300">{{ weather.subtitle }}</p>
-        </div>
-        <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-3xl">
-          {{ weather.icon }}
-        </div>
+      <div class="flex h-full flex-col gap-6 pr-4">
+        <LayoutSidebarWeatherCard :weather="weather" />
+        <LayoutSidebarLeaderboardCard
+          :title="leaderboard.title"
+          :live-label="leaderboard.live"
+          :participants="leaderboard.participants"
+        />
+        <LayoutSidebarRatingCard :rating="rating" />
       </div>
-      <dl class="mt-6 space-y-3 text-sm text-slate-300">
-        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
-          <dt class="uppercase tracking-wide text-xs text-slate-400">Localisation</dt>
-          <dd class="font-medium text-white">{{ weather.location }}</dd>
-        </div>
-        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
-          <dt class="uppercase tracking-wide text-xs text-slate-400">Température</dt>
-          <dd class="font-medium text-white">{{ weather.temperature }}</dd>
-        </div>
-        <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
-          <dt class="uppercase tracking-wide text-xs text-slate-400">Conseil</dt>
-          <dd class="max-w-[10rem] text-right text-sm leading-snug">{{ weather.tip }}</dd>
-        </div>
-      </dl>
-    </section>
-
-    <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
-      <header class="flex items-center justify-between text-slate-200">
-        <h3 class="text-lg font-semibold text-white">Top 3 in Quiz</h3>
-        <span class="text-xs uppercase tracking-[0.3em] text-primary/70">live</span>
-      </header>
-      <ul class="mt-5 space-y-4">
-        <li
-          v-for="(participant, index) in topParticipants"
-          :key="participant.name"
-          class="flex items-center gap-3 rounded-2xl border border-white/5 bg-black/20 px-4 py-3 text-sm text-slate-300"
-        >
-          <span
-            class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/15 text-base font-semibold text-primary"
-          >
-            {{ index + 1 }}
-          </span>
-          <div class="flex-1">
-            <p class="font-medium text-white">{{ participant.name }}</p>
-            <p class="text-xs uppercase tracking-wide text-slate-400">{{ participant.role }}</p>
-          </div>
-          <span class="rounded-full bg-primary/15 px-3 py-1 text-xs font-medium text-primary">{{
-            participant.score
-          }}</span>
-        </li>
-      </ul>
-    </section>
-
-    <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
-      <header class="flex items-start justify-between">
-        <div>
-          <h3 class="text-lg font-semibold text-white">Rating overview</h3>
-          <p class="text-sm text-slate-300">Commentaires des membres pour la semaine</p>
-        </div>
-        <div class="text-right text-white">
-          <p class="text-3xl font-bold">{{ rating.average }}</p>
-          <p class="text-xs uppercase tracking-[0.3em] text-slate-400">/ {{ rating.total }}</p>
-        </div>
-      </header>
-      <div class="mt-6 flex items-center gap-3 text-primary">
-        <span class="text-2xl">{{ rating.icon }}</span>
-        <div class="flex gap-1 text-xl">
-          <span
-            v-for="star in 5"
-            :key="star"
-            >{{ star <= rating.stars ? "★" : "☆" }}</span
-          >
-        </div>
-      </div>
-      <ul class="mt-6 space-y-4 text-sm text-slate-300">
-        <li
-          v-for="category in rating.categories"
-          :key="category.label"
-          class="space-y-2"
-        >
-          <div class="flex items-center justify-between">
-            <span class="font-medium text-white">{{ category.label }}</span>
-            <span class="text-xs text-slate-400">{{ category.value }}%</span>
-          </div>
-          <div class="h-2 w-full overflow-hidden rounded-full bg-black/20">
-            <div
-              class="h-full rounded-full bg-gradient-to-r from-primary/60 to-primary"
-              :style="{ width: `${category.value}%` }"
-            />
-          </div>
-        </li>
-      </ul>
-    </section>
+    </UiScrollArea>
   </aside>
 </template>
 
 <script setup lang="ts">
-const weather = {
-  badge: "News",
-  title: "Rain ahead",
-  subtitle: "Préparez-vous pour une journée humide avec des vents légers.",
-  icon: "🌧️",
-  location: "Berlin, Allemagne",
-  temperature: "18°C",
-  tip: "N'oubliez pas votre parapluie pour rester au sec.",
-};
+import { computed } from "vue";
 
-const topParticipants = [
-  { name: "Bro World", role: "Product Team", score: "982 pts" },
-  { name: "Adam Don", role: "Community", score: "953 pts" },
-  { name: "Nina Ko", role: "Marketing", score: "917 pts" },
-];
+interface SidebarWeatherContent {
+  badge: string;
+  title: string;
+  subtitle: string;
+  icon: string;
+  location: string;
+  temperature: string;
+  tip: string;
+  locationLabel: string;
+  temperatureLabel: string;
+  tipLabel: string;
+}
 
-const rating = {
-  average: "4.7",
-  total: 5,
-  icon: "⭐",
-  stars: 5,
-  categories: [
-    { label: "Engagement", value: 92 },
-    { label: "Contenu", value: 88 },
-    { label: "Réactivité", value: 84 },
-  ],
-};
+interface SidebarParticipant {
+  name: string;
+  role: string;
+  score: string;
+}
+
+interface SidebarLeaderboardContent {
+  title: string;
+  live: string;
+  participants: Record<"first" | "second" | "third", SidebarParticipant>;
+}
+
+interface SidebarRatingCategory {
+  label: string;
+  value: number;
+}
+
+interface SidebarRatingContent {
+  title: string;
+  subtitle: string;
+  average: string;
+  total: number;
+  icon: string;
+  stars: number;
+  categories: Record<string, SidebarRatingCategory>;
+}
+
+const { tm } = useI18n();
+
+const weather = computed(() => tm("sidebar.weather") as SidebarWeatherContent);
+
+const leaderboard = computed(() => {
+  const raw = tm("sidebar.leaderboard") as SidebarLeaderboardContent;
+  const order: Array<keyof SidebarLeaderboardContent["participants"]> = [
+    "first",
+    "second",
+    "third",
+  ];
+
+  return {
+    title: raw.title,
+    live: raw.live,
+    participants: order.map((key, index) => ({
+      position: index + 1,
+      ...raw.participants[key],
+    })),
+  };
+});
+
+const rating = computed(() => {
+  const raw = tm("sidebar.rating") as SidebarRatingContent;
+
+  return {
+    ...raw,
+    categories: Object.values(raw.categories ?? {}),
+  };
+});
 </script>

--- a/components/layout/SidebarLeaderboardCard.vue
+++ b/components/layout/SidebarLeaderboardCard.vue
@@ -1,0 +1,43 @@
+<template>
+  <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
+    <header class="flex items-center justify-between text-slate-200">
+      <h3 class="text-lg font-semibold text-white">{{ title }}</h3>
+      <span class="text-xs uppercase tracking-[0.3em] text-primary/70">{{ liveLabel }}</span>
+    </header>
+    <ul class="mt-5 space-y-4">
+      <li
+        v-for="participant in participants"
+        :key="participant.name"
+        class="flex items-center gap-3 rounded-2xl border border-white/5 bg-black/20 px-4 py-3 text-sm text-slate-300"
+      >
+        <span
+          class="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/15 text-base font-semibold text-primary"
+        >
+          {{ participant.position }}
+        </span>
+        <div class="flex-1">
+          <p class="font-medium text-white">{{ participant.name }}</p>
+          <p class="text-xs uppercase tracking-wide text-slate-400">{{ participant.role }}</p>
+        </div>
+        <span class="rounded-full bg-primary/15 px-3 py-1 text-xs font-medium text-primary">
+          {{ participant.score }}
+        </span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface SidebarLeaderboardCardProps {
+  title: string;
+  liveLabel: string;
+  participants: Array<{
+    position: number;
+    name: string;
+    role: string;
+    score: string;
+  }>;
+}
+
+defineProps<SidebarLeaderboardCardProps>();
+</script>

--- a/components/layout/SidebarRatingCard.vue
+++ b/components/layout/SidebarRatingCard.vue
@@ -1,0 +1,61 @@
+<template>
+  <section class="rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur-xl">
+    <header class="flex items-start justify-between">
+      <div>
+        <h3 class="text-lg font-semibold text-white">{{ rating.title }}</h3>
+        <p class="text-sm text-slate-300">{{ rating.subtitle }}</p>
+      </div>
+      <div class="text-right text-white">
+        <p class="text-3xl font-bold">{{ rating.average }}</p>
+        <p class="text-xs uppercase tracking-[0.3em] text-slate-400">/ {{ rating.total }}</p>
+      </div>
+    </header>
+    <div class="mt-6 flex items-center gap-3 text-primary">
+      <span class="text-2xl">{{ rating.icon }}</span>
+      <div class="flex gap-1 text-xl">
+        <span
+          v-for="star in 5"
+          :key="star"
+          >{{ star <= rating.stars ? "★" : "☆" }}</span
+        >
+      </div>
+    </div>
+    <ul class="mt-6 space-y-4 text-sm text-slate-300">
+      <li
+        v-for="category in rating.categories"
+        :key="category.label"
+        class="space-y-2"
+      >
+        <div class="flex items-center justify-between">
+          <span class="font-medium text-white">{{ category.label }}</span>
+          <span class="text-xs text-slate-400">{{ category.value }}%</span>
+        </div>
+        <div class="h-2 w-full overflow-hidden rounded-full bg-black/20">
+          <div
+            class="h-full rounded-full bg-gradient-to-r from-primary/60 to-primary"
+            :style="{ width: `${category.value}%` }"
+          />
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface SidebarRatingCardProps {
+  rating: {
+    title: string;
+    subtitle: string;
+    average: string;
+    total: number;
+    icon: string;
+    stars: number;
+    categories: Array<{
+      label: string;
+      value: number;
+    }>;
+  };
+}
+
+defineProps<SidebarRatingCardProps>();
+</script>

--- a/components/layout/SidebarWeatherCard.vue
+++ b/components/layout/SidebarWeatherCard.vue
@@ -1,0 +1,51 @@
+<template>
+  <section
+    class="rounded-3xl border border-white/5 bg-white/5 p-6 text-slate-200 shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] backdrop-blur-xl"
+  >
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-xs uppercase tracking-[0.3em] text-primary/80">{{ weather.badge }}</p>
+        <h3 class="mt-3 text-2xl font-semibold text-white">{{ weather.title }}</h3>
+        <p class="mt-2 text-sm text-slate-300">{{ weather.subtitle }}</p>
+      </div>
+      <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/15 text-3xl">
+        {{ weather.icon }}
+      </div>
+    </div>
+    <dl class="mt-6 space-y-3 text-sm text-slate-300">
+      <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+        <dt class="uppercase tracking-wide text-xs text-slate-400">{{ weather.locationLabel }}</dt>
+        <dd class="font-medium text-white">{{ weather.location }}</dd>
+      </div>
+      <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+        <dt class="uppercase tracking-wide text-xs text-slate-400">
+          {{ weather.temperatureLabel }}
+        </dt>
+        <dd class="font-medium text-white">{{ weather.temperature }}</dd>
+      </div>
+      <div class="flex items-center justify-between rounded-2xl bg-white/5 px-4 py-3">
+        <dt class="uppercase tracking-wide text-xs text-slate-400">{{ weather.tipLabel }}</dt>
+        <dd class="max-w-[10rem] text-right text-sm leading-snug">{{ weather.tip }}</dd>
+      </div>
+    </dl>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface SidebarWeatherCardProps {
+  weather: {
+    badge: string;
+    title: string;
+    subtitle: string;
+    icon: string;
+    location: string;
+    temperature: string;
+    tip: string;
+    locationLabel: string;
+    temperatureLabel: string;
+    tipLabel: string;
+  };
+}
+
+defineProps<SidebarWeatherCardProps>();
+</script>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -52,5 +52,63 @@
     "Account": "الحساب",
     "Login": "تسجيل الدخول",
     "Register": "إنشاء حساب"
+  },
+  "blog": {
+    "reactions": {
+      "like": "إعجاب",
+      "love": "محبة",
+      "wow": "واو",
+      "haha": "هاها",
+      "sad": "حزين",
+      "angry": "غاضب"
+    },
+    "posts": {
+      "publishedOn": "نُشر في {date}",
+      "reactionCount": "{count} تفاعل",
+      "commentCount": "{count} تعليقًا",
+      "recentComments": "أحدث التعليقات",
+      "previewCount": "{count} معاينات",
+      "highlightedReactions": "أبرز التفاعلات"
+    },
+    "comments": {
+      "reactionCount": "{count} تفاعل",
+      "replyCount": "{count} ردًا"
+    }
+  },
+  "sidebar": {
+    "weather": {
+      "badge": "أخبار",
+      "title": "أمطار في الطريق",
+      "subtitle": "استعد ليوم ماطر مع رياح خفيفة.",
+      "icon": "🌧️",
+      "location": "برلين، ألمانيا",
+      "locationLabel": "الموقع",
+      "temperature": "18°م",
+      "temperatureLabel": "درجة الحرارة",
+      "tipLabel": "نصيحة",
+      "tip": "لا تنسَ مظلتك لتحافظ على جفافك."
+    },
+    "leaderboard": {
+      "title": "أفضل 3 في الاختبار",
+      "live": "مباشر",
+      "participants": {
+        "first": { "name": "Bro World", "role": "فريق المنتج", "score": "982 نقطة" },
+        "second": { "name": "Adam Don", "role": "المجتمع", "score": "953 نقطة" },
+        "third": { "name": "Nina Ko", "role": "التسويق", "score": "917 نقطة" }
+      }
+    },
+    "rating": {
+      "title": "نظرة عامة على التقييم",
+      "subtitle": "ملاحظات الأعضاء لهذا الأسبوع",
+      "average": "4.7",
+      "total": 5,
+      "icon": "⭐",
+      "stars": 5,
+      "categories": {
+        "engagement": { "label": "التفاعل", "value": 92 },
+        "content": { "label": "المحتوى", "value": 88 },
+        "responsiveness": { "label": "سرعة الاستجابة", "value": 84 }
+      }
+    }
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -52,5 +52,63 @@
     "Account": "Konto",
     "Login": "Anmelden",
     "Register": "Registrieren"
+  },
+  "blog": {
+    "reactions": {
+      "like": "Gefällt mir",
+      "love": "Liebe",
+      "wow": "Wow",
+      "haha": "Haha",
+      "sad": "Traurig",
+      "angry": "Wütend"
+    },
+    "posts": {
+      "publishedOn": "Veröffentlicht am {date}",
+      "reactionCount": "{count} Reaktionen",
+      "commentCount": "{count} Kommentare",
+      "recentComments": "Aktuelle Kommentare",
+      "previewCount": "{count} Vorschauen",
+      "highlightedReactions": "Beliebte Reaktionen"
+    },
+    "comments": {
+      "reactionCount": "{count} Reaktionen",
+      "replyCount": "{count} Antworten"
+    }
+  },
+  "sidebar": {
+    "weather": {
+      "badge": "Neuigkeiten",
+      "title": "Regen in Sicht",
+      "subtitle": "Bereite dich auf einen regnerischen Tag mit leichtem Wind vor.",
+      "icon": "🌧️",
+      "location": "Berlin, Deutschland",
+      "locationLabel": "Ort",
+      "temperature": "18°C",
+      "temperatureLabel": "Temperatur",
+      "tipLabel": "Tipp",
+      "tip": "Vergiss deinen Regenschirm nicht, um trocken zu bleiben."
+    },
+    "leaderboard": {
+      "title": "Top 3 im Quiz",
+      "live": "live",
+      "participants": {
+        "first": { "name": "Bro World", "role": "Produktteam", "score": "982 Pkt" },
+        "second": { "name": "Adam Don", "role": "Community", "score": "953 Pkt" },
+        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 Pkt" }
+      }
+    },
+    "rating": {
+      "title": "Bewertungsübersicht",
+      "subtitle": "Rückmeldungen der Mitglieder dieser Woche",
+      "average": "4.7",
+      "total": 5,
+      "icon": "⭐",
+      "stars": 5,
+      "categories": {
+        "engagement": { "label": "Engagement", "value": 92 },
+        "content": { "label": "Inhalt", "value": 88 },
+        "responsiveness": { "label": "Reaktionsfähigkeit", "value": 84 }
+      }
+    }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -52,5 +52,63 @@
     "Account": "Account",
     "Login": "Log in",
     "Register": "Register"
+  },
+  "blog": {
+    "reactions": {
+      "like": "Like",
+      "love": "Love",
+      "wow": "Wow",
+      "haha": "Haha",
+      "sad": "Sad",
+      "angry": "Angry"
+    },
+    "posts": {
+      "publishedOn": "Published on {date}",
+      "reactionCount": "{count} reactions",
+      "commentCount": "{count} comments",
+      "recentComments": "Recent comments",
+      "previewCount": "{count} previews",
+      "highlightedReactions": "Fan favorite reactions"
+    },
+    "comments": {
+      "reactionCount": "{count} reactions",
+      "replyCount": "{count} replies"
+    }
+  },
+  "sidebar": {
+    "weather": {
+      "badge": "News",
+      "title": "Rain ahead",
+      "subtitle": "Get ready for a rainy day with light winds.",
+      "icon": "🌧️",
+      "location": "Berlin, Germany",
+      "locationLabel": "Location",
+      "temperature": "18°C",
+      "temperatureLabel": "Temperature",
+      "tipLabel": "Tip",
+      "tip": "Don't forget your umbrella to stay dry."
+    },
+    "leaderboard": {
+      "title": "Top 3 in Quiz",
+      "live": "live",
+      "participants": {
+        "first": { "name": "Bro World", "role": "Product Team", "score": "982 pts" },
+        "second": { "name": "Adam Don", "role": "Community", "score": "953 pts" },
+        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 pts" }
+      }
+    },
+    "rating": {
+      "title": "Rating overview",
+      "subtitle": "Member feedback for the week",
+      "average": "4.7",
+      "total": 5,
+      "icon": "⭐",
+      "stars": 5,
+      "categories": {
+        "engagement": { "label": "Engagement", "value": 92 },
+        "content": { "label": "Content", "value": 88 },
+        "responsiveness": { "label": "Responsiveness", "value": 84 }
+      }
+    }
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -52,5 +52,63 @@
     "Account": "Compte",
     "Login": "Connexion",
     "Register": "Inscription"
+  },
+  "blog": {
+    "reactions": {
+      "like": "J'aime",
+      "love": "J'adore",
+      "wow": "Waouh",
+      "haha": "Haha",
+      "sad": "Triste",
+      "angry": "En colère"
+    },
+    "posts": {
+      "publishedOn": "Publié le {date}",
+      "reactionCount": "{count} réactions",
+      "commentCount": "{count} commentaires",
+      "recentComments": "Commentaires récents",
+      "previewCount": "{count} aperçus",
+      "highlightedReactions": "Réactions coup de cœur"
+    },
+    "comments": {
+      "reactionCount": "{count} réactions",
+      "replyCount": "{count} réponses"
+    }
+  },
+  "sidebar": {
+    "weather": {
+      "badge": "Actualités",
+      "title": "Pluie en approche",
+      "subtitle": "Préparez-vous pour une journée humide avec des vents légers.",
+      "icon": "🌧️",
+      "location": "Berlin, Allemagne",
+      "locationLabel": "Localisation",
+      "temperature": "18°C",
+      "temperatureLabel": "Température",
+      "tipLabel": "Conseil",
+      "tip": "N'oubliez pas votre parapluie pour rester au sec."
+    },
+    "leaderboard": {
+      "title": "Top 3 du quiz",
+      "live": "en direct",
+      "participants": {
+        "first": { "name": "Bro World", "role": "Équipe produit", "score": "982 pts" },
+        "second": { "name": "Adam Don", "role": "Communauté", "score": "953 pts" },
+        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 pts" }
+      }
+    },
+    "rating": {
+      "title": "Vue d'ensemble des notes",
+      "subtitle": "Commentaires des membres cette semaine",
+      "average": "4.7",
+      "total": 5,
+      "icon": "⭐",
+      "stars": 5,
+      "categories": {
+        "engagement": { "label": "Engagement", "value": 92 },
+        "content": { "label": "Contenu", "value": 88 },
+        "responsiveness": { "label": "Réactivité", "value": 84 }
+      }
+    }
   }
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -52,5 +52,63 @@
     "Account": "账户",
     "Login": "登录",
     "Register": "注册"
+  },
+  "blog": {
+    "reactions": {
+      "like": "点赞",
+      "love": "喜爱",
+      "wow": "惊讶",
+      "haha": "哈哈",
+      "sad": "难过",
+      "angry": "生气"
+    },
+    "posts": {
+      "publishedOn": "发布于 {date}",
+      "reactionCount": "{count} 个反应",
+      "commentCount": "{count} 条评论",
+      "recentComments": "最新评论",
+      "previewCount": "{count} 条预览",
+      "highlightedReactions": "精选反应"
+    },
+    "comments": {
+      "reactionCount": "{count} 个反应",
+      "replyCount": "{count} 条回复"
+    }
+  },
+  "sidebar": {
+    "weather": {
+      "badge": "资讯",
+      "title": "即将降雨",
+      "subtitle": "准备迎接一个有小风的雨天。",
+      "icon": "🌧️",
+      "location": "德国柏林",
+      "locationLabel": "位置",
+      "temperature": "18°C",
+      "temperatureLabel": "气温",
+      "tipLabel": "提示",
+      "tip": "别忘了带伞保持干爽。"
+    },
+    "leaderboard": {
+      "title": "测验前三名",
+      "live": "实时",
+      "participants": {
+        "first": { "name": "Bro World", "role": "产品团队", "score": "982 分" },
+        "second": { "name": "Adam Don", "role": "社区", "score": "953 分" },
+        "third": { "name": "Nina Ko", "role": "市场", "score": "917 分" }
+      }
+    },
+    "rating": {
+      "title": "评分概览",
+      "subtitle": "本周会员反馈",
+      "average": "4.7",
+      "total": 5,
+      "icon": "⭐",
+      "stars": 5,
+      "categories": {
+        "engagement": { "label": "参与度", "value": 92 },
+        "content": { "label": "内容", "value": 88 },
+        "responsiveness": { "label": "响应速度", "value": 84 }
+      }
+    }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,21 +1,9 @@
 <template>
-  <div
-    class="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-50"
-  >
-    <div class="pointer-events-none absolute inset-0 overflow-hidden">
-      <div class="absolute -left-32 -top-32 h-96 w-96 rounded-full bg-primary/20 blur-3xl" />
-      <div
-        class="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-primary/10 blur-3xl"
-      />
-      <div
-        class="absolute left-1/3 top-1/2 h-40 w-40 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/5 blur-2xl"
-      />
-    </div>
-
+  <div class="relative min-h-screen overflow-hidden bg-transparent text-slate-50">
     <div class="relative z-10">
       <section class="mx-auto max-w-7xl px-6 pb-24">
         <div
-          class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]"
+          class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_260px] xl:grid-cols-[minmax(0,1fr)_280px]"
         >
           <div class="space-y-10">
             <div
@@ -47,147 +35,14 @@
             </div>
 
             <template v-else>
-              <article
+              <PostCard
                 v-for="post in posts"
                 :key="post.id"
-                class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
-              >
-                <div
-                  class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
-                />
-                <div class="relative flex flex-col gap-8 p-8 sm:p-10">
-                  <header class="flex flex-wrap items-center gap-6">
-                    <div class="flex items-center gap-4">
-                      <div
-                        class="relative h-14 w-14 overflow-hidden rounded-2xl border border-white/20 bg-white/10"
-                      >
-                        <img
-                          :src="post.user.photo ?? defaultAvatar"
-                          :alt="`${post.user.firstName} ${post.user.lastName}`"
-                          class="h-full w-full object-cover"
-                          loading="lazy"
-                        />
-                      </div>
-                      <div>
-                        <p class="text-sm font-medium text-slate-200">
-                          {{ post.user.firstName }} {{ post.user.lastName }}
-                        </p>
-                        <p class="text-xs text-slate-400">
-                          Publié le {{ formatDateTime(post.publishedAt) }}
-                        </p>
-                      </div>
-                    </div>
-                    <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
-                      <span
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                      >
-                        <span class="text-base">{{ reactionEmojis.like }}</span>
-                        {{ formatNumber(post.reactions_count) }} réactions
-                      </span>
-                      <span
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
-                      >
-                        <span class="text-base">💬</span>
-                        {{ formatNumber(post.totalComments) }} commentaires
-                      </span>
-                    </div>
-                  </header>
-
-                  <div class="space-y-4">
-                    <h2
-                      class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
-                    >
-                      {{ post.title }}
-                    </h2>
-                    <p class="text-base text-slate-200/80">
-                      {{ post.summary }}
-                    </p>
-                  </div>
-
-                  <div
-                    v-if="post.comments_preview.length"
-                    class="rounded-2xl border border-white/10 bg-black/20 p-6"
-                  >
-                    <div class="flex items-center justify-between">
-                      <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
-                        Commentaires récents
-                      </p>
-                      <p class="text-xs text-slate-400">
-                        {{ formatNumber(post.comments_preview.length) }} aperçus
-                      </p>
-                    </div>
-                    <div class="mt-4 space-y-4">
-                      <article
-                        v-for="comment in post.comments_preview.slice(0, 4)"
-                        :key="comment.id"
-                        class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4"
-                      >
-                        <div class="flex items-center gap-3">
-                          <div
-                            class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10"
-                          >
-                            <img
-                              :src="comment.user.photo ?? defaultAvatar"
-                              :alt="`${comment.user.firstName} ${comment.user.lastName}`"
-                              class="h-full w-full object-cover"
-                              loading="lazy"
-                            />
-                          </div>
-                          <div>
-                            <p class="text-sm font-medium text-slate-200">
-                              {{ comment.user.firstName }} {{ comment.user.lastName }}
-                            </p>
-                            <p class="text-[11px] uppercase tracking-wide text-slate-400">
-                              {{ formatDateTime(comment.publishedAt) }}
-                            </p>
-                          </div>
-                        </div>
-                        <p class="text-sm leading-relaxed text-slate-200/80">
-                          {{ comment.content }}
-                        </p>
-                        <div
-                          class="mt-auto flex items-center justify-between text-xs text-slate-400"
-                        >
-                          <span
-                            class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
-                          >
-                            <span class="text-base">{{ reactionEmojis.like }}</span>
-                            {{ formatNumber(comment.reactions_count) }} réactions
-                          </span>
-                          <span
-                            class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
-                          >
-                            <span class="text-base">💬</span>
-                            {{ formatNumber(comment.totalComments) }} réponses
-                          </span>
-                        </div>
-                      </article>
-                    </div>
-                  </div>
-
-                  <footer
-                    v-if="post.reactions_preview.length"
-                    class="flex flex-wrap items-center gap-3 text-sm"
-                  >
-                    <span class="text-xs uppercase tracking-wide text-slate-400"
-                      >Réactions coup de cœur</span
-                    >
-                    <div class="flex flex-wrap gap-3">
-                      <div
-                        v-for="reaction in post.reactions_preview.slice(0, 4)"
-                        :key="reaction.id"
-                        class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
-                      >
-                        <span class="text-lg">{{ reactionEmojis[reaction.type] }}</span>
-                        <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
-                        <span class="text-[11px] uppercase tracking-wide text-slate-400">{{
-                          reactionLabels[reaction.type]
-                        }}</span>
-                      </div>
-                    </div>
-                  </footer>
-                </div>
-              </article>
+                :post="post"
+                :default-avatar="defaultAvatar"
+                :reaction-emojis="reactionEmojis"
+                :reaction-labels="reactionLabels"
+              />
             </template>
           </div>
 
@@ -199,6 +54,8 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
 import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
 import type { ReactionType } from "~/lib/mock/blog";
@@ -214,25 +71,16 @@ const reactionEmojis: Record<ReactionType, string> = {
   angry: "😡",
 };
 
-const reactionLabels: Record<ReactionType, string> = {
-  like: "Like",
-  love: "Love",
-  wow: "Wow",
-  haha: "Haha",
-  sad: "Sad",
-  angry: "Angry",
-};
+const { t } = useI18n();
 
-function formatDateTime(value: string) {
-  return new Intl.DateTimeFormat("fr-FR", {
-    dateStyle: "long",
-    timeStyle: "short",
-  }).format(new Date(value));
-}
-
-function formatNumber(value: number | null | undefined) {
-  return new Intl.NumberFormat("fr-FR").format(value ?? 0);
-}
+const reactionLabels = computed<Record<ReactionType, string>>(() => ({
+  like: t("blog.reactions.like"),
+  love: t("blog.reactions.love"),
+  wow: t("blog.reactions.wow"),
+  haha: t("blog.reactions.haha"),
+  sad: t("blog.reactions.sad"),
+  angry: t("blog.reactions.angry"),
+}));
 
 const { posts, pending, fetchPosts } = usePostsStore();
 


### PR DESCRIPTION
## Summary
- widen the main post column on the home page, drop the gradient backdrop, and swap the inline markup for a reusable `PostCard`
- extract comment and sidebar widgets into dedicated components and render sidebar content from translated data
- extend all locales with blog- and sidebar-related strings to keep the new UI fully localized

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d417f4aec48326b55fdcf55b4935f2