### PR TITLE
Fix malformed index layout

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -123,6 +123,8 @@
         "engagement": { "label": "التفاعل", "value": 92 },
         "content": { "label": "المحتوى", "value": 88 },
         "responsiveness": { "label": "سرعة الاستجابة", "value": 84 }
+      }
+    },
     "sidebar": {
       "title": "ابقَ على تواصل",
       "subtitle": "موارد لمتابعة مجتمع برو وورلد.",
@@ -143,6 +145,7 @@
           "action": "إرسال محتوى"
         }
       }
+    }
     }
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -121,7 +121,8 @@
         "engagement": { "label": "Engagement", "value": 92 },
         "content": { "label": "Inhalt", "value": 88 },
         "responsiveness": { "label": "Reaktionsfähigkeit", "value": 84 }
-
+      }
+    },
     "sidebar": {
       "title": "Bleib in Verbindung",
       "subtitle": "Ressourcen, um mit der BroWorld-Community Schritt zu halten.",
@@ -142,6 +143,7 @@
           "action": "Inhalt einreichen"
         }
       }
+    }
     }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -121,6 +121,8 @@
         "engagement": { "label": "Engagement", "value": 92 },
         "content": { "label": "Content", "value": 88 },
         "responsiveness": { "label": "Responsiveness", "value": 84 }
+      }
+    },
     "sidebar": {
       "title": "Stay connected",
       "subtitle": "Resources to keep up with the BroWorld community.",
@@ -141,6 +143,7 @@
           "action": "Submit content"
         }
       }
+    }
     }
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -121,6 +121,8 @@
         "engagement": { "label": "Engagement", "value": 92 },
         "content": { "label": "Contenu", "value": 88 },
         "responsiveness": { "label": "Réactivité", "value": 84 }
+      }
+    },
     "sidebar": {
       "title": "Restez connecté",
       "subtitle": "Des ressources pour suivre la communauté BroWorld.",
@@ -141,6 +143,7 @@
           "action": "Proposer du contenu"
         }
       }
+    }
     }
   }
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -124,6 +124,8 @@
         "engagement": { "label": "参与度", "value": 92 },
         "content": { "label": "内容", "value": 88 },
         "responsiveness": { "label": "响应速度", "value": 84 }
+      }
+    },
     "sidebar": {
       "title": "保持联系",
       "subtitle": "帮助你紧跟 BroWorld 社区的最新动态。",
@@ -144,6 +146,7 @@
           "action": "提交内容"
         }
       }
+    }
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,60 +6,52 @@
           class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_260px] xl:grid-cols-[minmax(0,1fr)_280px]"
         >
           <div class="space-y-10">
-    <section class="mx-auto max-w-7xl px-6 pb-24">
-      <div
-        class="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px] xl:grid-cols-[minmax(0,1fr)_360px]"
-      >
-        <div class="space-y-10">
-          <div
-            v-if="pending"
-            class="grid gap-8 md:grid-cols-2"
-          >
             <div
-              v-for="index in 4"
-              :key="index"
-              class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
+              v-if="pending"
+              class="grid gap-8 md:grid-cols-2"
             >
-              <div class="flex items-center gap-4">
-                <div class="h-14 w-14 rounded-2xl bg-white/10" />
+              <div
+                v-for="index in 4"
+                :key="index"
+                class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 backdrop-blur-xl"
+              >
+                <div class="flex items-center gap-4">
+                  <div class="h-14 w-14 rounded-2xl bg-white/10" />
+                  <div class="space-y-3">
+                    <div class="h-3 w-32 rounded-full bg-white/10" />
+                    <div class="h-3 w-24 rounded-full bg-white/10" />
+                  </div>
+                </div>
                 <div class="space-y-3">
-                  <div class="h-3 w-32 rounded-full bg-white/10" />
-                  <div class="h-3 w-24 rounded-full bg-white/10" />
+                  <div class="h-3 w-3/4 rounded-full bg-white/10" />
+                  <div class="h-3 w-2/3 rounded-full bg-white/10" />
+                  <div class="h-3 w-full rounded-full bg-white/10" />
+                </div>
+                <div class="mt-auto flex gap-3">
+                  <div class="h-7 w-28 rounded-full bg-white/5" />
+                  <div class="h-7 w-28 rounded-full bg-white/5" />
                 </div>
               </div>
-              <div class="space-y-3">
-                <div class="h-3 w-3/4 rounded-full bg-white/10" />
-                <div class="h-3 w-2/3 rounded-full bg-white/10" />
-                <div class="h-3 w-full rounded-full bg-white/10" />
-              </div>
-              <div class="mt-auto flex gap-3">
-                <div class="h-7 w-28 rounded-full bg-white/5" />
-                <div class="h-7 w-28 rounded-full bg-white/5" />
-              </div>
             </div>
-          </div>
 
-          <template v-else>
-            <PostCard
+            <template v-else>
+              <PostCard
                 v-for="post in posts"
                 :key="post.id"
                 :post="post"
                 :default-avatar="defaultAvatar"
                 :reaction-emojis="reactionEmojis"
                 :reaction-labels="reactionLabels"
-            />
-          </template>
-        </div>
+              />
+            </template>
+          </div>
 
-        <RightSidebar
-          class="hidden lg:flex"
-          :title="sidebarContent.title"
-          :subtitle="sidebarContent.subtitle"
-          :widgets="sidebarContent.widgets"
-        />
-      </div>
-    </section>
-  </div>
+          <RightSidebar
+            class="hidden lg:flex"
+            :title="sidebarContent.title"
+            :subtitle="sidebarContent.subtitle"
+            :widgets="sidebarContent.widgets"
+          />
         </div>
       </section>
     </div>
@@ -68,7 +60,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-
+import type { SidebarWidgetData } from "~/components/blog/SidebarWidget.vue";
 import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
 import type { ReactionType } from "~/lib/mock/blog";
@@ -94,7 +86,6 @@ const reactionLabels = computed<Record<ReactionType, string>>(() => ({
   sad: t("blog.reactions.sad"),
   angry: t("blog.reactions.angry"),
 }));
-import type { SidebarWidgetData } from "~/components/blog/SidebarWidget.vue";
 
 const { posts, pending, fetchPosts } = usePostsStore();
 


### PR DESCRIPTION
## Summary
- remove duplicated markup on the index page and ensure the loader/posts layout renders correctly
- tidy the page script imports to keep type imports grouped
- fix the blog sidebar translation blocks in each locale so the JSON is well-formed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d41dee421c8326a6b61f5381fe5aca