### PR TITLE
Fix i18n detection and simplify reaction chips

### DIFF
--- a/components/blog/CommentCard.vue
+++ b/components/blog/CommentCard.vue
@@ -22,21 +22,27 @@
       {{ comment.content }}
     </p>
     <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
-      <span class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1">
+      <span
+        :aria-label="t('blog.comment.reactions', { count: formatNumber(comment.reactions_count) })"
+        class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
+      >
         <span
           aria-hidden="true"
           class="text-base"
           >👍</span
         >
-        {{ t("blog.comment.reactions", { count: formatNumber(comment.reactions_count) }) }}
+        <span aria-hidden="true">{{ formatNumber(comment.reactions_count) }}</span>
       </span>
-      <span class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1">
+      <span
+        :aria-label="t('blog.comment.replies', { count: formatNumber(comment.totalComments) })"
+        class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
+      >
         <span
           aria-hidden="true"
           class="text-base"
           >💬</span
         >
-        {{ t("blog.comment.replies", { count: formatNumber(comment.totalComments) }) }}
+        <span aria-hidden="true">{{ formatNumber(comment.totalComments) }}</span>
       </span>
     </div>
   </article>

--- a/components/blog/PostCard.vue
+++ b/components/blog/PostCard.vue
@@ -29,6 +29,7 @@
         </div>
         <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
           <span
+            :aria-label="t('blog.post.reactions', { count: formatNumber(post.reactions_count) })"
             class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
           >
             <span
@@ -36,9 +37,10 @@
               class="text-base"
               >{{ reactionEmojis.like }}</span
             >
-            {{ t("blog.post.reactions", { count: formatNumber(post.reactions_count) }) }}
+            <span aria-hidden="true">{{ formatNumber(post.reactions_count) }}</span>
           </span>
           <span
+            :aria-label="t('blog.post.comments', { count: formatNumber(post.totalComments) })"
             class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
           >
             <span
@@ -46,7 +48,7 @@
               class="text-base"
               >💬</span
             >
-            {{ t("blog.post.comments", { count: formatNumber(post.totalComments) }) }}
+            <span aria-hidden="true">{{ formatNumber(post.totalComments) }}</span>
           </span>
         </div>
       </header>
@@ -98,15 +100,12 @@
             :key="reaction.id"
             class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/20 px-3 py-1 text-slate-200 shadow-sm"
           >
+            <span class="sr-only">{{ reactionLabels[reaction.type] }}</span>
             <span
               aria-hidden="true"
               class="text-lg"
               >{{ reactionEmojis[reaction.type] }}</span
             >
-            <span class="text-sm font-medium">{{ reaction.user.firstName }}</span>
-            <span class="text-[11px] uppercase tracking-wide text-slate-400">
-              {{ reactionLabels[reaction.type] }}
-            </span>
           </div>
         </div>
       </footer>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,7 @@ export default defineNuxtConfig({
     "@nuxt/scripts",
     "motion-v/nuxt",
     "lenis/nuxt",
+    "@nuxtjs/i18n",
     "nuxt-llms",
   ],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@nuxt/fonts": "^0.11.4",
     "@nuxt/image": "^1.11.0",
     "@nuxt/scripts": "0.11.13",
+    "@nuxtjs/i18n": "^9.5.6",
     "@splinetool/runtime": "^1.10.56",
     "@types/lodash.template": "^4.5.3",
     "@uiw/color-convert": "^2.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@nuxt/scripts':
         specifier: 0.11.13
         version: 0.11.13(@netlify/blobs@9.1.2)(@unhead/vue@2.0.14(vue@3.5.21(typescript@5.9.2)))(db0@0.3.2)(ioredis@5.7.0)(magicast@0.3.5)(typescript@5.9.2)(vue@3.5.21(typescript@5.9.2))
+      '@nuxtjs/i18n':
+        specifier: ^9.5.6
+        version: 9.5.6(@vue/compiler-dom@3.5.21)(eslint@9.35.0(jiti@2.5.1))(magicast@0.3.5)(rollup@4.50.0)(vue@3.5.21(typescript@5.9.2))
       '@splinetool/runtime':
         specifier: ^1.10.56
         version: 1.10.56


### PR DESCRIPTION
## Summary
- enable browser language detection by registering `@nuxtjs/i18n` as a Nuxt module dependency
- remove visible reaction/user labels from post and comment stats while preserving emoji counts and screen reader text

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d421563e1c8326b908653ae9895eaf