### PR TITLE
Fix blog sidebar locale keys

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -57,75 +57,95 @@
     "reactions": {
       "like": "إعجاب",
       "love": "محبة",
-    "post": {
-      "publishedOn": "نُشر في {date}",
-      "reactions": "{count} تفاعلات",
-      "comments": "{count} تعليقات",
-      "recentComments": "أحدث التعليقات",
-      "commentPreviews": "{count} معاينات",
-      "reactionSpotlight": "أبرز التفاعلات"
-    },
-    "comment": {
-      "reactions": "{count} تفاعلات",
-      "replies": "{count} ردود"
-    },
-    "reactionTypes": {
-      "like": "إعجاب",
-      "love": "حب",
-      "wow": "واو",
-      "haha": "هاها",
-      "sad": "حزين",
-      "angry": "غاضب"
-    },
-    "posts": {
-      "publishedOn": "نُشر في {date}",
-      "reactionCount": "{count} تفاعل",
-      "commentCount": "{count} تعليقًا",
-      "recentComments": "أحدث التعليقات",
-      "previewCount": "{count} معاينات",
-      "highlightedReactions": "أبرز التفاعلات"
-    },
-    "comments": {
-      "reactionCount": "{count} تفاعل",
-      "replyCount": "{count} ردًا"
-    }
-  },
-  "sidebar": {
-    "weather": {
-      "badge": "أخبار",
-      "title": "أمطار في الطريق",
-      "subtitle": "استعد ليوم ماطر مع رياح خفيفة.",
-      "icon": "🌧️",
-      "location": "برلين، ألمانيا",
-      "locationLabel": "الموقع",
-      "temperature": "18°م",
-      "temperatureLabel": "درجة الحرارة",
-      "tipLabel": "نصيحة",
-      "tip": "لا تنسَ مظلتك لتحافظ على جفافك."
-    },
-    "leaderboard": {
-      "title": "أفضل 3 في الاختبار",
-      "live": "مباشر",
-      "participants": {
-        "first": { "name": "Bro World", "role": "فريق المنتج", "score": "982 نقطة" },
-        "second": { "name": "Adam Don", "role": "المجتمع", "score": "953 نقطة" },
-        "third": { "name": "Nina Ko", "role": "التسويق", "score": "917 نقطة" }
-      }
-    },
-    "rating": {
-      "title": "نظرة عامة على التقييم",
-      "subtitle": "ملاحظات الأعضاء لهذا الأسبوع",
-      "average": "4.7",
-      "total": 5,
-      "icon": "⭐",
-      "stars": 5,
-      "categories": {
-        "engagement": { "label": "التفاعل", "value": 92 },
-        "content": { "label": "المحتوى", "value": 88 },
-        "responsiveness": { "label": "سرعة الاستجابة", "value": 84 }
+      "post": {
+        "publishedOn": "نُشر في {date}",
+        "reactions": "{count} تفاعلات",
+        "comments": "{count} تعليقات",
+        "recentComments": "أحدث التعليقات",
+        "commentPreviews": "{count} معاينات",
+        "reactionSpotlight": "أبرز التفاعلات"
+      },
+      "comment": {
+        "reactions": "{count} تفاعلات",
+        "replies": "{count} ردود"
+      },
+      "reactionTypes": {
+        "like": "إعجاب",
+        "love": "حب",
+        "wow": "واو",
+        "haha": "هاها",
+        "sad": "حزين",
+        "angry": "غاضب"
+      },
+      "posts": {
+        "publishedOn": "نُشر في {date}",
+        "reactionCount": "{count} تفاعل",
+        "commentCount": "{count} تعليقًا",
+        "recentComments": "أحدث التعليقات",
+        "previewCount": "{count} معاينات",
+        "highlightedReactions": "أبرز التفاعلات"
+      },
+      "comments": {
+        "reactionCount": "{count} تفاعل",
+        "replyCount": "{count} ردًا"
       }
     },
     "sidebar": {
+      "weather": {
+        "badge": "أخبار",
+        "title": "أمطار في الطريق",
+        "subtitle": "استعد ليوم ماطر مع رياح خفيفة.",
+        "icon": "🌧️",
+        "location": "برلين، ألمانيا",
+        "locationLabel": "الموقع",
+        "temperature": "18°م",
+        "temperatureLabel": "درجة الحرارة",
+        "tipLabel": "نصيحة",
+        "tip": "لا تنسَ مظلتك لتحافظ على جفافك."
+      },
+      "leaderboard": {
+        "title": "أفضل 3 في الاختبار",
+        "live": "مباشر",
+        "participants": {
+          "first": {
+            "name": "Bro World",
+            "role": "فريق المنتج",
+            "score": "982 نقطة"
+          },
+          "second": {
+            "name": "Adam Don",
+            "role": "المجتمع",
+            "score": "953 نقطة"
+          },
+          "third": {
+            "name": "Nina Ko",
+            "role": "التسويق",
+            "score": "917 نقطة"
+          }
+        }
+      },
+      "rating": {
+        "title": "نظرة عامة على التقييم",
+        "subtitle": "ملاحظات الأعضاء لهذا الأسبوع",
+        "average": "4.7",
+        "total": 5,
+        "icon": "⭐",
+        "stars": 5,
+        "categories": {
+          "engagement": {
+            "label": "التفاعل",
+            "value": 92
+          },
+          "content": {
+            "label": "المحتوى",
+            "value": 88
+          },
+          "responsiveness": {
+            "label": "سرعة الاستجابة",
+            "value": 84
+          }
+        }
+      },
       "title": "ابقَ على تواصل",
       "subtitle": "موارد لمتابعة مجتمع برو وورلد.",
       "widgets": {
@@ -145,7 +165,6 @@
           "action": "إرسال محتوى"
         }
       }
-    }
     }
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -55,75 +55,95 @@
   },
   "blog": {
     "reactions": {
-    "post": {
-      "publishedOn": "Veröffentlicht am {date}",
-      "reactions": "{count} Reaktionen",
-      "comments": "{count} Kommentare",
-      "recentComments": "Neueste Kommentare",
-      "commentPreviews": "{count} Vorschauen",
-      "reactionSpotlight": "Reaktions-Highlights"
-    },
-    "comment": {
-      "reactions": "{count} Reaktionen",
-      "replies": "{count} Antworten"
-    },
-    "reactionTypes": {
-      "like": "Gefällt mir",
-      "love": "Liebe",
-      "wow": "Wow",
-      "haha": "Haha",
-      "sad": "Traurig",
-      "angry": "Wütend"
-    },
-    "posts": {
-      "publishedOn": "Veröffentlicht am {date}",
-      "reactionCount": "{count} Reaktionen",
-      "commentCount": "{count} Kommentare",
-      "recentComments": "Aktuelle Kommentare",
-      "previewCount": "{count} Vorschauen",
-      "highlightedReactions": "Beliebte Reaktionen"
-    },
-    "comments": {
-      "reactionCount": "{count} Reaktionen",
-      "replyCount": "{count} Antworten"
-    }
-  },
-  "sidebar": {
-    "weather": {
-      "badge": "Neuigkeiten",
-      "title": "Regen in Sicht",
-      "subtitle": "Bereite dich auf einen regnerischen Tag mit leichtem Wind vor.",
-      "icon": "🌧️",
-      "location": "Berlin, Deutschland",
-      "locationLabel": "Ort",
-      "temperature": "18°C",
-      "temperatureLabel": "Temperatur",
-      "tipLabel": "Tipp",
-      "tip": "Vergiss deinen Regenschirm nicht, um trocken zu bleiben."
-    },
-    "leaderboard": {
-      "title": "Top 3 im Quiz",
-      "live": "live",
-      "participants": {
-        "first": { "name": "Bro World", "role": "Produktteam", "score": "982 Pkt" },
-        "second": { "name": "Adam Don", "role": "Community", "score": "953 Pkt" },
-        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 Pkt" }
-      }
-    },
-    "rating": {
-      "title": "Bewertungsübersicht",
-      "subtitle": "Rückmeldungen der Mitglieder dieser Woche",
-      "average": "4.7",
-      "total": 5,
-      "icon": "⭐",
-      "stars": 5,
-      "categories": {
-        "engagement": { "label": "Engagement", "value": 92 },
-        "content": { "label": "Inhalt", "value": 88 },
-        "responsiveness": { "label": "Reaktionsfähigkeit", "value": 84 }
+      "post": {
+        "publishedOn": "Veröffentlicht am {date}",
+        "reactions": "{count} Reaktionen",
+        "comments": "{count} Kommentare",
+        "recentComments": "Neueste Kommentare",
+        "commentPreviews": "{count} Vorschauen",
+        "reactionSpotlight": "Reaktions-Highlights"
+      },
+      "comment": {
+        "reactions": "{count} Reaktionen",
+        "replies": "{count} Antworten"
+      },
+      "reactionTypes": {
+        "like": "Gefällt mir",
+        "love": "Liebe",
+        "wow": "Wow",
+        "haha": "Haha",
+        "sad": "Traurig",
+        "angry": "Wütend"
+      },
+      "posts": {
+        "publishedOn": "Veröffentlicht am {date}",
+        "reactionCount": "{count} Reaktionen",
+        "commentCount": "{count} Kommentare",
+        "recentComments": "Aktuelle Kommentare",
+        "previewCount": "{count} Vorschauen",
+        "highlightedReactions": "Beliebte Reaktionen"
+      },
+      "comments": {
+        "reactionCount": "{count} Reaktionen",
+        "replyCount": "{count} Antworten"
       }
     },
     "sidebar": {
+      "weather": {
+        "badge": "Neuigkeiten",
+        "title": "Regen in Sicht",
+        "subtitle": "Bereite dich auf einen regnerischen Tag mit leichtem Wind vor.",
+        "icon": "🌧️",
+        "location": "Berlin, Deutschland",
+        "locationLabel": "Ort",
+        "temperature": "18°C",
+        "temperatureLabel": "Temperatur",
+        "tipLabel": "Tipp",
+        "tip": "Vergiss deinen Regenschirm nicht, um trocken zu bleiben."
+      },
+      "leaderboard": {
+        "title": "Top 3 im Quiz",
+        "live": "live",
+        "participants": {
+          "first": {
+            "name": "Bro World",
+            "role": "Produktteam",
+            "score": "982 Pkt"
+          },
+          "second": {
+            "name": "Adam Don",
+            "role": "Community",
+            "score": "953 Pkt"
+          },
+          "third": {
+            "name": "Nina Ko",
+            "role": "Marketing",
+            "score": "917 Pkt"
+          }
+        }
+      },
+      "rating": {
+        "title": "Bewertungsübersicht",
+        "subtitle": "Rückmeldungen der Mitglieder dieser Woche",
+        "average": "4.7",
+        "total": 5,
+        "icon": "⭐",
+        "stars": 5,
+        "categories": {
+          "engagement": {
+            "label": "Engagement",
+            "value": 92
+          },
+          "content": {
+            "label": "Inhalt",
+            "value": 88
+          },
+          "responsiveness": {
+            "label": "Reaktionsfähigkeit",
+            "value": 84
+          }
+        }
+      },
       "title": "Bleib in Verbindung",
       "subtitle": "Ressourcen, um mit der BroWorld-Community Schritt zu halten.",
       "widgets": {
@@ -143,7 +163,6 @@
           "action": "Inhalt einreichen"
         }
       }
-    }
     }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -55,75 +55,95 @@
   },
   "blog": {
     "reactions": {
-    "post": {
-      "publishedOn": "Published on {date}",
-      "reactions": "{count} reactions",
-      "comments": "{count} comments",
-      "recentComments": "Recent comments",
-      "commentPreviews": "{count} previews",
-      "reactionSpotlight": "Reaction spotlight"
-    },
-    "comment": {
-      "reactions": "{count} reactions",
-      "replies": "{count} replies"
-    },
-    "reactionTypes": {
-      "like": "Like",
-      "love": "Love",
-      "wow": "Wow",
-      "haha": "Haha",
-      "sad": "Sad",
-      "angry": "Angry"
-    },
-    "posts": {
-      "publishedOn": "Published on {date}",
-      "reactionCount": "{count} reactions",
-      "commentCount": "{count} comments",
-      "recentComments": "Recent comments",
-      "previewCount": "{count} previews",
-      "highlightedReactions": "Fan favorite reactions"
-    },
-    "comments": {
-      "reactionCount": "{count} reactions",
-      "replyCount": "{count} replies"
-    }
-  },
-  "sidebar": {
-    "weather": {
-      "badge": "News",
-      "title": "Rain ahead",
-      "subtitle": "Get ready for a rainy day with light winds.",
-      "icon": "🌧️",
-      "location": "Berlin, Germany",
-      "locationLabel": "Location",
-      "temperature": "18°C",
-      "temperatureLabel": "Temperature",
-      "tipLabel": "Tip",
-      "tip": "Don't forget your umbrella to stay dry."
-    },
-    "leaderboard": {
-      "title": "Top 3 in Quiz",
-      "live": "live",
-      "participants": {
-        "first": { "name": "Bro World", "role": "Product Team", "score": "982 pts" },
-        "second": { "name": "Adam Don", "role": "Community", "score": "953 pts" },
-        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 pts" }
-      }
-    },
-    "rating": {
-      "title": "Rating overview",
-      "subtitle": "Member feedback for the week",
-      "average": "4.7",
-      "total": 5,
-      "icon": "⭐",
-      "stars": 5,
-      "categories": {
-        "engagement": { "label": "Engagement", "value": 92 },
-        "content": { "label": "Content", "value": 88 },
-        "responsiveness": { "label": "Responsiveness", "value": 84 }
+      "post": {
+        "publishedOn": "Published on {date}",
+        "reactions": "{count} reactions",
+        "comments": "{count} comments",
+        "recentComments": "Recent comments",
+        "commentPreviews": "{count} previews",
+        "reactionSpotlight": "Reaction spotlight"
+      },
+      "comment": {
+        "reactions": "{count} reactions",
+        "replies": "{count} replies"
+      },
+      "reactionTypes": {
+        "like": "Like",
+        "love": "Love",
+        "wow": "Wow",
+        "haha": "Haha",
+        "sad": "Sad",
+        "angry": "Angry"
+      },
+      "posts": {
+        "publishedOn": "Published on {date}",
+        "reactionCount": "{count} reactions",
+        "commentCount": "{count} comments",
+        "recentComments": "Recent comments",
+        "previewCount": "{count} previews",
+        "highlightedReactions": "Fan favorite reactions"
+      },
+      "comments": {
+        "reactionCount": "{count} reactions",
+        "replyCount": "{count} replies"
       }
     },
     "sidebar": {
+      "weather": {
+        "badge": "News",
+        "title": "Rain ahead",
+        "subtitle": "Get ready for a rainy day with light winds.",
+        "icon": "🌧️",
+        "location": "Berlin, Germany",
+        "locationLabel": "Location",
+        "temperature": "18°C",
+        "temperatureLabel": "Temperature",
+        "tipLabel": "Tip",
+        "tip": "Don't forget your umbrella to stay dry."
+      },
+      "leaderboard": {
+        "title": "Top 3 in Quiz",
+        "live": "live",
+        "participants": {
+          "first": {
+            "name": "Bro World",
+            "role": "Product Team",
+            "score": "982 pts"
+          },
+          "second": {
+            "name": "Adam Don",
+            "role": "Community",
+            "score": "953 pts"
+          },
+          "third": {
+            "name": "Nina Ko",
+            "role": "Marketing",
+            "score": "917 pts"
+          }
+        }
+      },
+      "rating": {
+        "title": "Rating overview",
+        "subtitle": "Member feedback for the week",
+        "average": "4.7",
+        "total": 5,
+        "icon": "⭐",
+        "stars": 5,
+        "categories": {
+          "engagement": {
+            "label": "Engagement",
+            "value": 92
+          },
+          "content": {
+            "label": "Content",
+            "value": 88
+          },
+          "responsiveness": {
+            "label": "Responsiveness",
+            "value": 84
+          }
+        }
+      },
       "title": "Stay connected",
       "subtitle": "Resources to keep up with the BroWorld community.",
       "widgets": {
@@ -143,7 +163,6 @@
           "action": "Submit content"
         }
       }
-    }
     }
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -55,75 +55,95 @@
   },
   "blog": {
     "reactions": {
-    "post": {
-      "publishedOn": "Publié le {date}",
-      "reactions": "{count} réactions",
-      "comments": "{count} commentaires",
-      "recentComments": "Commentaires récents",
-      "commentPreviews": "{count} aperçus",
-      "reactionSpotlight": "Réactions coup de cœur"
-    },
-    "comment": {
-      "reactions": "{count} réactions",
-      "replies": "{count} réponses"
-    },
-    "reactionTypes": {
-      "like": "J'aime",
-      "love": "J'adore",
-      "wow": "Waouh",
-      "haha": "Haha",
-      "sad": "Triste",
-      "angry": "En colère"
-    },
-    "posts": {
-      "publishedOn": "Publié le {date}",
-      "reactionCount": "{count} réactions",
-      "commentCount": "{count} commentaires",
-      "recentComments": "Commentaires récents",
-      "previewCount": "{count} aperçus",
-      "highlightedReactions": "Réactions coup de cœur"
-    },
-    "comments": {
-      "reactionCount": "{count} réactions",
-      "replyCount": "{count} réponses"
-    }
-  },
-  "sidebar": {
-    "weather": {
-      "badge": "Actualités",
-      "title": "Pluie en approche",
-      "subtitle": "Préparez-vous pour une journée humide avec des vents légers.",
-      "icon": "🌧️",
-      "location": "Berlin, Allemagne",
-      "locationLabel": "Localisation",
-      "temperature": "18°C",
-      "temperatureLabel": "Température",
-      "tipLabel": "Conseil",
-      "tip": "N'oubliez pas votre parapluie pour rester au sec."
-    },
-    "leaderboard": {
-      "title": "Top 3 du quiz",
-      "live": "en direct",
-      "participants": {
-        "first": { "name": "Bro World", "role": "Équipe produit", "score": "982 pts" },
-        "second": { "name": "Adam Don", "role": "Communauté", "score": "953 pts" },
-        "third": { "name": "Nina Ko", "role": "Marketing", "score": "917 pts" }
-      }
-    },
-    "rating": {
-      "title": "Vue d'ensemble des notes",
-      "subtitle": "Commentaires des membres cette semaine",
-      "average": "4.7",
-      "total": 5,
-      "icon": "⭐",
-      "stars": 5,
-      "categories": {
-        "engagement": { "label": "Engagement", "value": 92 },
-        "content": { "label": "Contenu", "value": 88 },
-        "responsiveness": { "label": "Réactivité", "value": 84 }
+      "post": {
+        "publishedOn": "Publié le {date}",
+        "reactions": "{count} réactions",
+        "comments": "{count} commentaires",
+        "recentComments": "Commentaires récents",
+        "commentPreviews": "{count} aperçus",
+        "reactionSpotlight": "Réactions coup de cœur"
+      },
+      "comment": {
+        "reactions": "{count} réactions",
+        "replies": "{count} réponses"
+      },
+      "reactionTypes": {
+        "like": "J'aime",
+        "love": "J'adore",
+        "wow": "Waouh",
+        "haha": "Haha",
+        "sad": "Triste",
+        "angry": "En colère"
+      },
+      "posts": {
+        "publishedOn": "Publié le {date}",
+        "reactionCount": "{count} réactions",
+        "commentCount": "{count} commentaires",
+        "recentComments": "Commentaires récents",
+        "previewCount": "{count} aperçus",
+        "highlightedReactions": "Réactions coup de cœur"
+      },
+      "comments": {
+        "reactionCount": "{count} réactions",
+        "replyCount": "{count} réponses"
       }
     },
     "sidebar": {
+      "weather": {
+        "badge": "Actualités",
+        "title": "Pluie en approche",
+        "subtitle": "Préparez-vous pour une journée humide avec des vents légers.",
+        "icon": "🌧️",
+        "location": "Berlin, Allemagne",
+        "locationLabel": "Localisation",
+        "temperature": "18°C",
+        "temperatureLabel": "Température",
+        "tipLabel": "Conseil",
+        "tip": "N'oubliez pas votre parapluie pour rester au sec."
+      },
+      "leaderboard": {
+        "title": "Top 3 du quiz",
+        "live": "en direct",
+        "participants": {
+          "first": {
+            "name": "Bro World",
+            "role": "Équipe produit",
+            "score": "982 pts"
+          },
+          "second": {
+            "name": "Adam Don",
+            "role": "Communauté",
+            "score": "953 pts"
+          },
+          "third": {
+            "name": "Nina Ko",
+            "role": "Marketing",
+            "score": "917 pts"
+          }
+        }
+      },
+      "rating": {
+        "title": "Vue d'ensemble des notes",
+        "subtitle": "Commentaires des membres cette semaine",
+        "average": "4.7",
+        "total": 5,
+        "icon": "⭐",
+        "stars": 5,
+        "categories": {
+          "engagement": {
+            "label": "Engagement",
+            "value": 92
+          },
+          "content": {
+            "label": "Contenu",
+            "value": 88
+          },
+          "responsiveness": {
+            "label": "Réactivité",
+            "value": 84
+          }
+        }
+      },
       "title": "Restez connecté",
       "subtitle": "Des ressources pour suivre la communauté BroWorld.",
       "widgets": {
@@ -143,7 +163,6 @@
           "action": "Proposer du contenu"
         }
       }
-    }
     }
   }
 }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -58,75 +58,95 @@
       "like": "点赞",
       "love": "喜爱",
       "wow": "惊讶",
-    "post": {
-      "publishedOn": "发布于 {date}",
-      "reactions": "{count} 条互动",
-      "comments": "{count} 条评论",
-      "recentComments": "最新评论",
-      "commentPreviews": "{count} 条预览",
-      "reactionSpotlight": "精选互动"
-    },
-    "comment": {
-      "reactions": "{count} 条互动",
-      "replies": "{count} 条回复"
-    },
-    "reactionTypes": {
-      "like": "点赞",
-      "love": "喜爱",
-      "wow": "惊叹",
-      "haha": "哈哈",
-      "sad": "难过",
-      "angry": "生气"
-    },
-    "posts": {
-      "publishedOn": "发布于 {date}",
-      "reactionCount": "{count} 个反应",
-      "commentCount": "{count} 条评论",
-      "recentComments": "最新评论",
-      "previewCount": "{count} 条预览",
-      "highlightedReactions": "精选反应"
-    },
-    "comments": {
-      "reactionCount": "{count} 个反应",
-      "replyCount": "{count} 条回复"
-    }
-  },
-  "sidebar": {
-    "weather": {
-      "badge": "资讯",
-      "title": "即将降雨",
-      "subtitle": "准备迎接一个有小风的雨天。",
-      "icon": "🌧️",
-      "location": "德国柏林",
-      "locationLabel": "位置",
-      "temperature": "18°C",
-      "temperatureLabel": "气温",
-      "tipLabel": "提示",
-      "tip": "别忘了带伞保持干爽。"
-    },
-    "leaderboard": {
-      "title": "测验前三名",
-      "live": "实时",
-      "participants": {
-        "first": { "name": "Bro World", "role": "产品团队", "score": "982 分" },
-        "second": { "name": "Adam Don", "role": "社区", "score": "953 分" },
-        "third": { "name": "Nina Ko", "role": "市场", "score": "917 分" }
-      }
-    },
-    "rating": {
-      "title": "评分概览",
-      "subtitle": "本周会员反馈",
-      "average": "4.7",
-      "total": 5,
-      "icon": "⭐",
-      "stars": 5,
-      "categories": {
-        "engagement": { "label": "参与度", "value": 92 },
-        "content": { "label": "内容", "value": 88 },
-        "responsiveness": { "label": "响应速度", "value": 84 }
+      "post": {
+        "publishedOn": "发布于 {date}",
+        "reactions": "{count} 条互动",
+        "comments": "{count} 条评论",
+        "recentComments": "最新评论",
+        "commentPreviews": "{count} 条预览",
+        "reactionSpotlight": "精选互动"
+      },
+      "comment": {
+        "reactions": "{count} 条互动",
+        "replies": "{count} 条回复"
+      },
+      "reactionTypes": {
+        "like": "点赞",
+        "love": "喜爱",
+        "wow": "惊叹",
+        "haha": "哈哈",
+        "sad": "难过",
+        "angry": "生气"
+      },
+      "posts": {
+        "publishedOn": "发布于 {date}",
+        "reactionCount": "{count} 个反应",
+        "commentCount": "{count} 条评论",
+        "recentComments": "最新评论",
+        "previewCount": "{count} 条预览",
+        "highlightedReactions": "精选反应"
+      },
+      "comments": {
+        "reactionCount": "{count} 个反应",
+        "replyCount": "{count} 条回复"
       }
     },
     "sidebar": {
+      "weather": {
+        "badge": "资讯",
+        "title": "即将降雨",
+        "subtitle": "准备迎接一个有小风的雨天。",
+        "icon": "🌧️",
+        "location": "德国柏林",
+        "locationLabel": "位置",
+        "temperature": "18°C",
+        "temperatureLabel": "气温",
+        "tipLabel": "提示",
+        "tip": "别忘了带伞保持干爽。"
+      },
+      "leaderboard": {
+        "title": "测验前三名",
+        "live": "实时",
+        "participants": {
+          "first": {
+            "name": "Bro World",
+            "role": "产品团队",
+            "score": "982 分"
+          },
+          "second": {
+            "name": "Adam Don",
+            "role": "社区",
+            "score": "953 分"
+          },
+          "third": {
+            "name": "Nina Ko",
+            "role": "市场",
+            "score": "917 分"
+          }
+        }
+      },
+      "rating": {
+        "title": "评分概览",
+        "subtitle": "本周会员反馈",
+        "average": "4.7",
+        "total": 5,
+        "icon": "⭐",
+        "stars": 5,
+        "categories": {
+          "engagement": {
+            "label": "参与度",
+            "value": 92
+          },
+          "content": {
+            "label": "内容",
+            "value": 88
+          },
+          "responsiveness": {
+            "label": "响应速度",
+            "value": 84
+          }
+        }
+      },
       "title": "保持联系",
       "subtitle": "帮助你紧跟 BroWorld 社区的最新动态。",
       "widgets": {
@@ -146,7 +166,6 @@
           "action": "提交内容"
         }
       }
-    }
     }
   }
 }


### PR DESCRIPTION
## Summary
- flatten the blog sidebar translation keys so `blog.sidebar.title`, `subtitle`, and `widgets` resolve correctly
- apply the fix across English, French, German, Arabic, and Simplified Chinese locale files

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d423e697d08326a57d634e5a7ff8b1