### PR TITLE
Fix layout fallback when localized docs are missing

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -6,19 +6,20 @@
   <LayoutBanner v-if="config.banner.enable" />
   <LayoutHeader />
   <div
-    v-if="page && !page.fullpage"
+    v-if="page?.fullpage !== true"
     class="min-h-screen border-b"
   >
     <div
       class="flex-1 items-start px-4 md:grid md:gap-6 md:px-8 lg:gap-10"
       :class="[
         config.main.padded && 'container',
-        (page.aside ?? true) &&
-          'md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,1fr)]',
+        (page?.aside ?? true)
+          ? 'md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,1fr)]'
+          : null,
       ]"
     >
       <aside
-        v-if="page.aside ?? true"
+        v-if="page?.aside ?? true"
         class="fixed z-30 -ml-2 hidden w-full shrink-0 overflow-y-auto top-[102px] md:sticky md:block"
         :class="[
           config.aside.useLevel && config.aside.levelStyle === 'aside'


### PR DESCRIPTION
## Summary
- ensure the docs layout still renders when `useContent` has no page data
- guard aside rendering logic so it handles missing localized metadata safely

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d42b1b892483268f44dd8d4f70fec6