### PR TITLE
Fix blog translation key usage

### DIFF
--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -131,30 +131,30 @@ function formatNumber(value: number | null | undefined) {
 }
 
 const publishedLabel = computed(() =>
-  t("blog.posts.publishedOn", { date: formatDateTime(props.post.publishedAt) }),
+  t("blog.reactions.posts.publishedOn", { date: formatDateTime(props.post.publishedAt) }),
 );
 
 const reactionsLabel = computed(() =>
-  t("blog.posts.reactionCount", {
+  t("blog.reactions.posts.reactionCount", {
     count: formatNumber(props.post.reactions_count),
   }),
 );
 
 const commentsLabel = computed(() =>
-  t("blog.posts.commentCount", {
+  t("blog.reactions.posts.commentCount", {
     count: formatNumber(props.post.totalComments),
   }),
 );
 
-const recentCommentsLabel = computed(() => t("blog.posts.recentComments"));
+const recentCommentsLabel = computed(() => t("blog.reactions.posts.recentComments"));
 
 const commentPreviewCountLabel = computed(() =>
-  t("blog.posts.previewCount", {
+  t("blog.reactions.posts.previewCount", {
     count: formatNumber(props.post.comments_preview.length),
   }),
 );
 
-const highlightedReactionsLabel = computed(() => t("blog.posts.highlightedReactions"));
+const highlightedReactionsLabel = computed(() => t("blog.reactions.posts.highlightedReactions"));
 
 const topComments = computed(() => props.post.comments_preview.slice(0, 4));
 const topReactions = computed(() => props.post.reactions_preview.slice(0, 4));

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -79,12 +79,12 @@ const reactionEmojis: Record<ReactionType, string> = {
 const { t } = useI18n();
 
 const reactionLabels = computed<Record<ReactionType, string>>(() => ({
-  like: t("blog.reactions.like"),
-  love: t("blog.reactions.love"),
-  wow: t("blog.reactions.wow"),
-  haha: t("blog.reactions.haha"),
-  sad: t("blog.reactions.sad"),
-  angry: t("blog.reactions.angry"),
+  like: t("blog.reactions.reactionTypes.like"),
+  love: t("blog.reactions.reactionTypes.love"),
+  wow: t("blog.reactions.reactionTypes.wow"),
+  haha: t("blog.reactions.reactionTypes.haha"),
+  sad: t("blog.reactions.reactionTypes.sad"),
+  angry: t("blog.reactions.reactionTypes.angry"),
 }));
 
 const { posts, pending, fetchPosts } = usePostsStore();


### PR DESCRIPTION
## Summary
- align blog reaction label lookups with locale structure
- update post metadata labels to use the correct translation namespace

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d42d9b86c08326b4df4cd7dbd7d98e