### PR TITLE
Enable global injection for Vue i18n templates

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -5,6 +5,7 @@ import fr from "./locales/fr.json";
 
 export default defineI18nConfig(() => ({
   legacy: false,
+  globalInjection: true,
   locale: "en",
   fallbackLocale: "en",
   availableLocales: ["en", "fr", "de", "ar"],


### PR DESCRIPTION
## Summary
- enable global i18n injection so `$t` is available directly in templates

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d44b4c8d508326b5687ba3f7cbd6a8