### PR TITLE
Fix blog translation keys to match locale structure

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -53,13 +53,13 @@ const props = defineProps<{
 const { t } = useI18n();
 
 const reactionsLabel = computed(() =>
-  t("blog.comments.reactionCount", {
+  t("blog.reactions.comments.reactionCount", {
     count: props.formatNumber(props.comment.reactions_count),
   }),
 );
 
 const repliesLabel = computed(() =>
-  t("blog.comments.replyCount", {
+  t("blog.reactions.comments.replyCount", {
     count: props.formatNumber(props.comment.totalComments),
   }),
 );

--- a/components/blog/CommentCard.vue
+++ b/components/blog/CommentCard.vue
@@ -23,7 +23,9 @@
     </p>
     <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
       <span
-        :aria-label="t('blog.comment.reactions', { count: formatNumber(comment.reactions_count) })"
+        :aria-label="
+          t('blog.reactions.comment.reactions', { count: formatNumber(comment.reactions_count) })
+        "
         class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
       >
         <span
@@ -34,7 +36,9 @@
         <span aria-hidden="true">{{ formatNumber(comment.reactions_count) }}</span>
       </span>
       <span
-        :aria-label="t('blog.comment.replies', { count: formatNumber(comment.totalComments) })"
+        :aria-label="
+          t('blog.reactions.comment.replies', { count: formatNumber(comment.totalComments) })
+        "
         class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
       >
         <span

--- a/components/blog/PostCard.vue
+++ b/components/blog/PostCard.vue
@@ -23,13 +23,15 @@
               {{ post.user.firstName }} {{ post.user.lastName }}
             </p>
             <p class="text-xs text-slate-400">
-              {{ t("blog.post.publishedOn", { date: formatDateTime(post.publishedAt) }) }}
+              {{ t("blog.reactions.post.publishedOn", { date: formatDateTime(post.publishedAt) }) }}
             </p>
           </div>
         </div>
         <div class="ms-auto flex flex-wrap gap-3 text-sm text-slate-200">
           <span
-            :aria-label="t('blog.post.reactions', { count: formatNumber(post.reactions_count) })"
+            :aria-label="
+              t('blog.reactions.post.reactions', { count: formatNumber(post.reactions_count) })
+            "
             class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
           >
             <span
@@ -40,7 +42,9 @@
             <span aria-hidden="true">{{ formatNumber(post.reactions_count) }}</span>
           </span>
           <span
-            :aria-label="t('blog.post.comments', { count: formatNumber(post.totalComments) })"
+            :aria-label="
+              t('blog.reactions.post.comments', { count: formatNumber(post.totalComments) })
+            "
             class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-3 py-1"
           >
             <span
@@ -70,11 +74,13 @@
       >
         <div class="flex items-center justify-between">
           <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
-            {{ t("blog.post.recentComments") }}
+            {{ t("blog.reactions.post.recentComments") }}
           </p>
           <p class="text-xs text-slate-400">
             {{
-              t("blog.post.commentPreviews", { count: formatNumber(post.comments_preview.length) })
+              t("blog.reactions.post.commentPreviews", {
+                count: formatNumber(post.comments_preview.length),
+              })
             }}
           </p>
         </div>
@@ -92,7 +98,7 @@
         class="flex flex-wrap items-center gap-3 text-sm"
       >
         <span class="text-xs uppercase tracking-wide text-slate-400">
-          {{ t("blog.post.reactionSpotlight") }}
+          {{ t("blog.reactions.post.reactionSpotlight") }}
         </span>
         <div class="flex flex-wrap gap-3">
           <div
@@ -134,12 +140,12 @@ const reactionEmojis: Record<ReactionType, string> = {
 const { locale, t } = useI18n();
 
 const reactionLabels = computed<Record<ReactionType, string>>(() => ({
-  like: t("blog.reactionTypes.like"),
-  love: t("blog.reactionTypes.love"),
-  wow: t("blog.reactionTypes.wow"),
-  haha: t("blog.reactionTypes.haha"),
-  sad: t("blog.reactionTypes.sad"),
-  angry: t("blog.reactionTypes.angry"),
+  like: t("blog.reactions.reactionTypes.like"),
+  love: t("blog.reactions.reactionTypes.love"),
+  wow: t("blog.reactions.reactionTypes.wow"),
+  haha: t("blog.reactions.reactionTypes.haha"),
+  sad: t("blog.reactions.reactionTypes.sad"),
+  angry: t("blog.reactions.reactionTypes.angry"),
 }));
 
 function formatDateTime(value: string) {

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -5,6 +5,7 @@ import fr from "./locales/fr.json";
 
 export default defineI18nConfig(() => ({
   legacy: false,
+  globalInjection: true,
   locale: "en",
   fallbackLocale: "en",
   availableLocales: ["en", "fr", "de", "ar"],


### PR DESCRIPTION
## Summary
- align blog post and comment components with the `blog.reactions` translation namespace so localized strings render correctly
- update reaction label lookups to use the proper nested i18n keys

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d44b4c8d508326b5687ba3f7cbd6a8