### PR TITLE
feat: integrate vuetify

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,19 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   devtools: { enabled: true },
-  plugins: [{ src: "~/plugins/clarity.js", mode: "client" }],
+  plugins: [{ src: "~/plugins/clarity.js", mode: "client" }, "~/plugins/vuetify"],
+
+  css: ["vuetify/styles", "@mdi/font/css/materialdesignicons.css"],
+
+  build: {
+    transpile: ["vuetify"],
+  },
+
+  vite: {
+    ssr: {
+      noExternal: ["vuetify"],
+    },
+  },
 
   modules: [
     "@nuxt/fonts",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "theme-colors": "^0.1.0",
     "three": "^0.180.0",
     "three-globe": "^2.44.0",
+    "@mdi/font": "^7.4.47",
+    "vuetify": "^3.7.7",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1",
     "vue-use-spring": "^0.3.3",

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,0 +1,15 @@
+import "vuetify/styles";
+import "@mdi/font/css/materialdesignicons.css";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const vuetify = createVuetify({
+    components,
+    directives,
+    ssr: true,
+  });
+
+  nuxtApp.vueApp.use(vuetify);
+});


### PR DESCRIPTION
## Summary
- add Vuetify and Material Design Icons dependencies to the Nuxt project
- configure Nuxt to include Vuetify styling, transpilation, and SSR handling
- register a Vuetify plugin that initializes the framework and exposes its components/directives

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d453f332bc8326b4a5f3ddf74c7290