### PR TITLE
fix: polyfill availableParallelism for Node 18

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,27 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import os from 'node:os'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import compression from 'vite-plugin-compression'
 import { aliases } from 'vuetify/iconsets/mdi'
+
+const osWithAvailableParallelism = os as typeof os & {
+  availableParallelism?: () => number
+}
+
+if (typeof osWithAvailableParallelism.availableParallelism !== 'function') {
+  Object.defineProperty(osWithAvailableParallelism, 'availableParallelism', {
+    configurable: true,
+    enumerable: false,
+    value: () => {
+      try {
+        const cpuInfo = os.cpus()
+        return Array.isArray(cpuInfo) && cpuInfo.length > 0 ? cpuInfo.length : 1
+      } catch {
+        return 1
+      }
+    },
+  })
+}
 
 export default defineNuxtConfig({
   devtools: { enabled: true },


### PR DESCRIPTION
## Summary
- polyfill `os.availableParallelism` during Nuxt configuration load so Nuxt can start on Node 18 environments

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4658473e88326ada70a8257260e29