### PR TITLE
fix: polyfill crypto for node

### DIFF
--- a/plugins/crypto-polyfill.server.ts
+++ b/plugins/crypto-polyfill.server.ts
@@ -1,0 +1,13 @@
+export default defineNuxtPlugin(async () => {
+  if (import.meta.client) {
+    return;
+  }
+
+  const existingCrypto = globalThis.crypto as Crypto | undefined;
+
+  if (!existingCrypto || typeof existingCrypto.getRandomValues !== 'function') {
+    const { webcrypto } = await import('node:crypto');
+
+    (globalThis as typeof globalThis & { crypto: Crypto }).crypto = webcrypto as unknown as Crypto;
+  }
+});


### PR DESCRIPTION
## Summary
- add a server-only Nuxt plugin that polyfills `crypto.getRandomValues` when it is missing in the Node runtime used for development

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4671e3dc083269deb7e665ab9c09c