### PR TITLE
Fix Nuxt startup polyfills for node environment

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,24 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import os from 'node:os'
+import { webcrypto } from 'node:crypto'
+import { fetch as undiciFetch, Headers, FormData, Request, Response, File, Blob } from 'undici'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import compression from 'vite-plugin-compression'
 import { aliases } from 'vuetify/iconsets/mdi'
+
+if (typeof globalThis.fetch !== 'function') {
+  globalThis.fetch = undiciFetch
+  globalThis.Headers = Headers
+  globalThis.FormData = FormData
+  globalThis.Request = Request
+  globalThis.Response = Response
+  globalThis.File = File
+  globalThis.Blob = Blob
+}
+
+if (!globalThis.crypto || typeof globalThis.crypto.getRandomValues !== 'function') {
+  globalThis.crypto = webcrypto as Crypto
+}
 
 const osWithAvailableParallelism = os as typeof os & {
   availableParallelism?: () => number


### PR DESCRIPTION
## Summary
- add a node-side polyfill for fetch and related web APIs used during Nuxt builds
- ensure the crypto.getRandomValues API is available when Nuxt initializes on the server

## Testing
- npx eslint nuxt.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4689a19488326b3c3f2b5a2e2951e