### PR TITLE
refactor: use built-in web APIs for nuxt config polyfills

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,23 +1,27 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import os from 'node:os'
 import { webcrypto } from 'node:crypto'
-import { fetch as undiciFetch, Headers, FormData, Request, Response, File, Blob } from 'undici'
+import { Blob as NodeBlob, File as NodeFile } from 'node:buffer'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import compression from 'vite-plugin-compression'
 import { aliases } from 'vuetify/iconsets/mdi'
 
-if (typeof globalThis.fetch !== 'function') {
-  globalThis.fetch = undiciFetch
-  globalThis.Headers = Headers
-  globalThis.FormData = FormData
-  globalThis.Request = Request
-  globalThis.Response = Response
-  globalThis.File = File
-  globalThis.Blob = Blob
+const globalScope = globalThis as typeof globalThis & {
+  crypto: Crypto | undefined
+  Blob: typeof NodeBlob | undefined
+  File: typeof NodeFile | undefined
 }
 
-if (!globalThis.crypto || typeof globalThis.crypto.getRandomValues !== 'function') {
-  globalThis.crypto = webcrypto as Crypto
+if (!globalScope.crypto || typeof globalScope.crypto.getRandomValues !== 'function') {
+  globalScope.crypto = webcrypto as Crypto
+}
+
+if (typeof globalScope.Blob !== 'function') {
+  globalScope.Blob = NodeBlob
+}
+
+if (typeof globalScope.File !== 'function') {
+  globalScope.File = NodeFile
 }
 
 const osWithAvailableParallelism = os as typeof os & {


### PR DESCRIPTION
## Summary
- replace the undici import in `nuxt.config.ts` with Node's built-in Blob and File exports
- guard the global polyfills to rely on Node's native fetch implementation while still ensuring crypto, Blob, and File exist

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d46aa799f08326b75c4d55dd1863a6