### PR TITLE
Handle optional Nuxt UI Pro layer

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import { randomFillSync, webcrypto } from 'node:crypto'
 import { Blob as NodeBlob, File as NodeFile } from 'node:buffer'
 import { URL } from 'node:url'
+import { createRequire } from 'node:module'
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 import compression from 'vite-plugin-compression'
 import { aliases } from 'vuetify/iconsets/mdi'
@@ -197,6 +198,19 @@ const osWithAvailableParallelism = os as typeof os & {
   availableParallelism?: () => number
 }
 
+const require = createRequire(import.meta.url)
+
+const nuxtLayers: string[] = ['shadcn-docs-nuxt']
+
+try {
+  require.resolve('@nuxt/ui-pro/nuxt.config')
+  nuxtLayers.unshift('@nuxt/ui-pro')
+} catch (error) {
+  console.warn(
+    `@nuxt/ui-pro layer skipped: ${(error as Error | undefined)?.message ?? 'Unknown error'}`,
+  )
+}
+
 if (typeof osWithAvailableParallelism.availableParallelism !== 'function') {
   Object.defineProperty(osWithAvailableParallelism, 'availableParallelism', {
     configurable: true,
@@ -261,7 +275,7 @@ export default defineNuxtConfig({
       ignore: ["**/index.ts", "**/shaders.ts", "**/types.ts"],
     },
   ],
-  extends: ['@nuxt/ui-pro', 'shadcn-docs-nuxt'],
+  extends: nuxtLayers,
   sitemap: {
     siteUrl: 'https://bro-world-space.com',
     trailingSlash: false,


### PR DESCRIPTION
## Summary
- add runtime detection for the optional `@nuxt/ui-pro` layer and warn when it is missing
- fall back to the remaining shadcn documentation layer so Nuxt can start without the pro package

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d46f9c95548326895e53d30cc3ad45