### PR TITLE
fix: ensure node crypto polyfill is applied early

### DIFF
--- a/lib/setup-node-crypto.ts
+++ b/lib/setup-node-crypto.ts
@@ -1,0 +1,25 @@
+import { randomFillSync, webcrypto } from 'node:crypto'
+
+type GlobalWithOptionalCrypto = typeof globalThis & { crypto?: Crypto }
+
+const globalScope = globalThis as GlobalWithOptionalCrypto
+
+if (typeof globalScope.crypto?.getRandomValues !== 'function') {
+  const fallbackCrypto = {
+    getRandomValues<T extends ArrayBufferView | null>(array: T): T {
+      if (!array) {
+        throw new TypeError('Expected input to be an array')
+      }
+
+      randomFillSync(array as ArrayBufferView)
+      return array
+    },
+  }
+
+  const nodeCrypto = webcrypto as Crypto | undefined
+
+  globalScope.crypto =
+    nodeCrypto && typeof nodeCrypto.getRandomValues === 'function'
+      ? nodeCrypto
+      : (fallbackCrypto as unknown as Crypto)
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,9 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+import './lib/setup-node-crypto'
+
 import http from 'node:http'
 import https from 'node:https'
 import os from 'node:os'
-import { randomFillSync, webcrypto } from 'node:crypto'
 import { Blob as NodeBlob, File as NodeFile } from 'node:buffer'
 import { URL } from 'node:url'
 import { createRequire } from 'node:module'
@@ -140,34 +141,12 @@ function createFetch() {
 }
 
 const globalScope = globalThis as typeof globalThis & {
-  crypto: Crypto | undefined
   Blob: typeof NodeBlob | undefined
   File: typeof NodeFile | undefined
   fetch: ReturnType<typeof createFetch> | undefined
   Headers: typeof SimpleHeaders | undefined
   Request: typeof SimpleRequest | undefined
   Response: typeof SimpleResponse | undefined
-}
-
-if (!globalScope.crypto || typeof globalScope.crypto.getRandomValues !== 'function') {
-  const fallbackCrypto = {
-    getRandomValues<T extends ArrayBufferView | null>(array: T): T {
-      if (!array) {
-        throw new TypeError('Expected input to be an array')
-      }
-
-      randomFillSync(array as ArrayBufferView)
-      return array
-    },
-  }
-
-  const nodeCrypto = webcrypto as Crypto | undefined
-  const cryptoWithRandomValues =
-    nodeCrypto && typeof nodeCrypto.getRandomValues === 'function'
-      ? nodeCrypto
-      : (fallbackCrypto as unknown as Crypto)
-
-  globalScope.crypto = cryptoWithRandomValues
 }
 
 if (typeof globalScope.Blob !== 'function') {


### PR DESCRIPTION
## Summary
- add a small Node-specific crypto setup module that polyfills `crypto.getRandomValues` when needed
- import the new setup before other Nuxt config dependencies so the dev server can start without runtime errors

## Testing
- npx eslint lib/setup-node-crypto.ts nuxt.config.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4713ecb508326936602bc22bf1f8d