### PR TITLE
Fix Vuetify icon plugin to use registered Nuxt Icon component

### DIFF
--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,5 +1,5 @@
 import type { IconProps } from 'vuetify'
-import { Icon } from '#components'
+import { h } from 'vue'
 import type { VDataTable } from 'vuetify/components'
 import { VDateInput } from 'vuetify/labs/VDateInput'
 import { useStorage } from '@vueuse/core'
@@ -47,14 +47,23 @@ export default defineNuxtPlugin((nuxtApp) => {
       },
     }
 
+    const nuxtIconComponent = nuxtApp.vueApp.component('Icon')
     vuetifyOptions.icons = {
       defaultSet: 'nuxtIcon',
       sets: {
         nuxtIcon: {
-          component: ({ icon, tag, ...rest }: IconProps) =>
-              h(tag, rest, [
-                h(Icon, { name: (aliases[icon as string] as string) ?? icon }),
-              ]),
+          component: ({ icon, tag, ...rest }: IconProps) => {
+            const resolvedIconName =
+              typeof icon === 'string'
+                ? (aliases[icon] as string | undefined) ?? icon
+                : icon
+
+            if (!nuxtIconComponent || typeof resolvedIconName !== 'string') {
+              return h(tag, rest)
+            }
+
+            return h(tag, rest, [h(nuxtIconComponent, { name: resolvedIconName })])
+          },
         },
       },
       aliases,


### PR DESCRIPTION
## Summary
- resolve the nuxt-icon component dynamically from the Nuxt app instead of relying on `#components` auto imports
- guard against missing or non-string icon values when creating Vuetify icon VNodes

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4737b9c2c832684f5741eb2972449