### PR TITLE
fix: register icon components and layout

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -3,10 +3,14 @@
     :color="false"
     class="z-100 bg-primary/80"
   />
-  <NuxtLayout />
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
 const config = useConfig();
 const route = useRoute();
 const { themeClass, radius } = useThemes();

--- a/components/SmartIcon.vue
+++ b/components/SmartIcon.vue
@@ -1,0 +1,28 @@
+<template>
+  <Icon
+    v-if="iconName"
+    :icon="iconName"
+    :width="iconSize"
+    :height="iconSize"
+    v-bind="attrs"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    name?: string
+    size?: number | string
+  }>(),
+  {
+    size: 16,
+  },
+)
+
+const attrs = useAttrs()
+
+const iconName = computed(() => props.name)
+const iconSize = computed(() => props.size)
+</script>

--- a/components/layout/RightSidebar.vue
+++ b/components/layout/RightSidebar.vue
@@ -6,13 +6,13 @@
       class="h-full w-full overflow-hidden py-6 pr-2"
     >
       <div class="flex h-full flex-col gap-6 pr-4">
-        <LayoutSidebarWeatherCard :weather="weather" />
-        <LayoutSidebarLeaderboardCard
+        <SidebarWeatherCard :weather="weather" />
+        <SidebarLeaderboardCard
           :title="leaderboard.title"
           :live-label="leaderboard.live"
           :participants="leaderboard.participants"
         />
-        <LayoutSidebarRatingCard :rating="rating" />
+        <SidebarRatingCard :rating="rating" />
       </div>
     </UiScrollArea>
   </aside>

--- a/plugins/iconify.ts
+++ b/plugins/iconify.ts
@@ -1,0 +1,6 @@
+import { defineNuxtPlugin } from '#app'
+import { Icon } from '@iconify/vue'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.component('Icon', Icon)
+})


### PR DESCRIPTION
## Summary
- register the Iconify Icon component globally so `<Icon>` renders without warnings
- add a SmartIcon wrapper component that maps the existing props onto `<Icon>`
- fix layout usage by nesting `<NuxtPage />` in `<NuxtLayout>` and referencing the sidebar cards by their actual component names

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d475e74a308326868c09b2a312c405