### PR TITLE
Improve blog card spacing

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -1,7 +1,7 @@
 <template>
-  <article class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-4">
-    <div class="flex items-center gap-3">
-      <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10">
+  <article class="flex flex-col gap-4 rounded-2xl border border-white/5 bg-white/5 p-5 sm:p-6">
+    <div class="flex items-center gap-4">
+      <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10 sm:h-12 sm:w-12">
         <img
           :src="comment.user.photo ?? defaultAvatar"
           :alt="`${comment.user.firstName} ${comment.user.lastName}`"
@@ -24,14 +24,14 @@
     <div class="mt-auto flex items-center justify-between text-xs text-slate-400">
       <span
         :aria-label="reactionsAriaLabel"
-        class="inline-flex items-center gap-1 rounded-full bg-black/20 px-2 py-1"
+        class="inline-flex items-center gap-2 rounded-full bg-black/20 px-3 py-1.5"
       >
         <span aria-hidden="true" class="text-base">👍</span>
         <span aria-hidden="true">{{ reactionsDisplay }}</span>
       </span>
       <span
         :aria-label="repliesAriaLabel"
-        class="inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-1"
+        class="inline-flex items-center gap-2 rounded-full bg-black/10 px-3 py-1.5"
       >
         <span aria-hidden="true" class="text-base">💬</span>
         <span aria-hidden="true">{{ repliesDisplay }}</span>

--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -5,7 +5,7 @@
     <div
       class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
     />
-    <div class="relative flex flex-col gap-8 p-8 sm:p-10">
+    <div class="relative flex flex-col gap-10 p-10 sm:p-12">
       <PostMeta
         :user="post.user"
         :default-avatar="defaultAvatar"
@@ -14,7 +14,7 @@
         :comment-badge="commentBadge"
       />
 
-      <div class="space-y-4">
+      <div class="space-y-5">
         <h2
           class="text-3xl font-semibold leading-tight text-white transition-colors duration-300 group-hover:text-primary"
         >
@@ -27,7 +27,7 @@
 
       <section
         v-if="hasCommentPreview"
-        class="rounded-2xl border border-white/10 bg-black/20 p-6"
+        class="rounded-2xl border border-white/10 bg-black/20 p-6 sm:p-7"
       >
         <div class="flex items-center justify-between">
           <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
@@ -37,7 +37,7 @@
             {{ commentPreviewCountLabel }}
           </p>
         </div>
-        <div class="mt-4 space-y-4">
+        <div class="mt-5 space-y-5">
           <CommentCard
             v-for="comment in topComments"
             :key="comment.id"
@@ -48,12 +48,12 @@
 
       <footer
         v-if="hasReactionPreview"
-        class="flex flex-wrap items-center gap-3 text-sm"
+        class="flex flex-wrap items-center gap-4 text-sm"
       >
         <span class="text-xs uppercase tracking-wide text-slate-400">
           {{ highlightedReactionsLabel }}
         </span>
-        <div class="flex flex-wrap gap-3">
+        <div class="flex flex-wrap gap-4">
           <div
             v-for="reaction in topReactions"
             :key="reaction.id"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="relative min-h-screen overflow-hidden bg-slate-950 text-slate-50">
-    <div class="py-6 space-y-6">
+    <div class="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-10 sm:px-6 lg:px-8">
       <div
           v-if="pending"
-          class="grid gap-6 sm:grid-cols-2"
+          class="grid gap-8 sm:grid-cols-2"
       >
         <div
             v-for="index in 4"
@@ -30,14 +30,16 @@
       </div>
 
       <template v-else>
-        <PostCard
-            v-for="post in posts"
-            :key="post.id"
-            :post="post"
-            :default-avatar="defaultAvatar"
-            :reaction-emojis="reactionEmojis"
-            :reaction-labels="reactionLabels"
-        />
+        <div class="flex flex-col gap-8">
+          <PostCard
+              v-for="post in posts"
+              :key="post.id"
+              :post="post"
+              :default-avatar="defaultAvatar"
+              :reaction-emojis="reactionEmojis"
+              :reaction-labels="reactionLabels"
+          />
+        </div>
       </template>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add layout container spacing to the home page feed so cards breathe
- increase inner padding and gaps in post and comment cards for better readability

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d47ec69ac483269a48d5a4b34e388d