### PR TITLE
Improve spacing and depth on post card components

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="flex flex-col gap-4 rounded-2xl border border-white/5 bg-white/5 p-5 sm:p-6">
+  <article class="flex flex-col gap-4 rounded-2xl border border-white/5 bg-white/5 p-5 shadow-[0_18px_40px_-30px_rgba(15,23,42,0.9)] sm:p-6">
     <div class="flex items-center gap-4">
       <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10 sm:h-12 sm:w-12">
         <img

--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -1,11 +1,11 @@
 <template>
   <article
-    class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)]"
+    class="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/10 p-6 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-2xl transition-all duration-500 hover:-translate-y-1 hover:border-primary/50 hover:bg-white/15 hover:shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] sm:p-8"
   >
     <div
       class="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-primary/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100"
     />
-    <div class="relative flex flex-col gap-10 p-10 sm:p-12">
+    <div class="relative flex flex-col gap-10">
       <PostMeta
         :user="post.user"
         :default-avatar="defaultAvatar"
@@ -29,7 +29,7 @@
         v-if="hasCommentPreview"
         class="rounded-2xl border border-white/10 bg-black/20 p-6 sm:p-7"
       >
-        <div class="flex items-center justify-between">
+        <div class="flex flex-wrap items-center justify-between gap-2">
           <p class="text-sm font-semibold uppercase tracking-wide text-slate-300">
             {{ recentCommentsLabel }}
           </p>
@@ -37,7 +37,7 @@
             {{ commentPreviewCountLabel }}
           </p>
         </div>
-        <div class="mt-5 space-y-5">
+        <div class="mt-6 space-y-5">
           <CommentCard
             v-for="comment in topComments"
             :key="comment.id"


### PR DESCRIPTION
## Summary
- add consistent padding and a subtle resting shadow to the post card container
- loosen the comment preview header spacing so it wraps gracefully on small widths
- give individual comment cards a light drop shadow for additional separation

## Testing
- pnpm exec eslint components/PostCard.vue components/CommentCard.vue

------
https://chatgpt.com/codex/tasks/task_e_68d4803786bc83269a7b351c943913b9