### PR TITLE
feat: add localized auth pages

### DIFF
--- a/components/auth/Terms.vue
+++ b/components/auth/Terms.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="space-y-4 text-body-2">
+    <p>
+      {{ t('register.termsIntro') }}
+    </p>
+    <ul class="ms-4 list-disc space-y-2">
+      <li>{{ t('register.termsPoint1') }}</li>
+      <li>{{ t('register.termsPoint2') }}</li>
+      <li>{{ t('register.termsPoint3') }}</li>
+    </ul>
+    <p>
+      {{ t('register.termsOutro') }}
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "vue-i18n";
+
+const { t } = useI18n();
+</script>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -11,14 +11,14 @@
     "GettingStartedDescription": "مقدمة عن Inspira UI وأهم مفاهيمه.",
     "Installation": "التثبيت",
     "InstallationDescription": "اتبع الدليل خطوة بخطوة لتثبيت Inspira UI في مشروعك.",
-  "Components": "المكوّنات",
-  "ComponentsDescription": "استكشف جميع المكوّنات المتاحة وكيفية استخدامها.",
-  "V1DocsDescription": "توثيق استخدام Inspira UI مع Tailwind CSS v3.",
-  "Community": "المجتمع",
-  "GitHub": "غيتهاب",
-  "GitHubDescription": "الكود المصدري لـ Inspira UI.",
-  "Discord": "ديسكورد",
-  "DiscordDescription": "تواصل مع المجتمع عبر ديسكورد",
+    "Components": "المكوّنات",
+    "ComponentsDescription": "استكشف جميع المكوّنات المتاحة وكيفية استخدامها.",
+    "V1DocsDescription": "توثيق استخدام Inspira UI مع Tailwind CSS v3.",
+    "Community": "المجتمع",
+    "GitHub": "غيتهاب",
+    "GitHubDescription": "الكود المصدري لـ Inspira UI.",
+    "Discord": "ديسكورد",
+    "DiscordDescription": "تواصل مع المجتمع عبر ديسكورد",
     "Forum": "المنتدى",
     "ForumDiscord": "انضم إلى المنتدى"
   },
@@ -53,7 +53,17 @@
   "auth": {
     "Account": "الحساب",
     "Login": "تسجيل الدخول",
-    "Register": "إنشاء حساب"
+    "Register": "إنشاء حساب",
+    "usernameOrEmail": "البريد الإلكتروني أو اسم المستخدم",
+    "password": "كلمة المرور",
+    "signIn": "تسجيل الدخول",
+    "signUpPrompt": "لا تملك حسابًا؟",
+    "signUp": "إنشاء حساب",
+    "requiredError": "يرجى إدخال البريد الإلكتروني وكلمة المرور.",
+    "invalidError": "تعذر تسجيل الدخول بهذه البيانات. حاول مرة أخرى.",
+    "successTitle": "مرحبًا بعودتك",
+    "success": "تم تسجيل دخولك بنجاح.",
+    "errorGeneric": "حدث خطأ أثناء تسجيل الدخول."
   },
   "blog": {
     "hero": {
@@ -192,5 +202,30 @@
         }
       }
     }
+  },
+  "register": {
+    "email": "البريد الإلكتروني",
+    "password": "كلمة المرور",
+    "repeatPassword": "تأكيد كلمة المرور",
+    "agree": "أوافق على",
+    "terms": "الشروط والأحكام",
+    "requirements": "متطلبات كلمة المرور",
+    "requirement1": "يجب أن تتكون من 8 أحرف على الأقل.",
+    "requirement2": "يفضل أن تحتوي على أرقام أو رموز لزيادة الأمان.",
+    "signUp": "إنشاء حساب",
+    "haveAccount": "لديك حساب بالفعل؟",
+    "signIn": "تسجيل الدخول",
+    "termsTitle": "الشروط والأحكام",
+    "errorTerms": "يجب الموافقة على الشروط والأحكام.",
+    "errorMissing": "يرجى إكمال جميع الحقول المطلوبة.",
+    "errorMismatch": "كلمتا المرور غير متطابقتين.",
+    "errorGeneric": "حدث خطأ أثناء إنشاء الحساب.",
+    "successTitle": "تم إنشاء الحساب",
+    "success": "تم إنشاء حسابك بنجاح.",
+    "termsIntro": "بإنشاء حساب فإنك تؤكد فهمك وقبولك لسياساتنا.",
+    "termsPoint1": "نستخدم معلوماتك فقط لإنشاء حسابك وتأمينه.",
+    "termsPoint2": "يمكنك تغيير إعدادات الإشعارات في أي وقت.",
+    "termsPoint3": "سيتم حذف بياناتك من أنظمتنا النشطة خلال 30 يومًا عند حذف الحساب.",
+    "termsOutro": "يرجى التواصل مع فريق الدعم إذا كانت لديك أسئلة حول كيفية تعاملنا مع بياناتك."
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -11,14 +11,14 @@
     "GettingStartedDescription": "Einführung in Inspira UI und die wichtigsten Konzepte.",
     "Installation": "Installation",
     "InstallationDescription": "Folge der Schritt-für-Schritt-Anleitung, um Inspira UI in deinem Projekt zu installieren.",
-  "Components": "Komponenten",
-  "ComponentsDescription": "Entdecke alle verfügbaren Komponenten und ihre Verwendung.",
-  "V1DocsDescription": "Dokumentation zur Nutzung von Inspira UI mit Tailwind CSS v3.",
-  "Community": "Community",
-  "GitHub": "GitHub",
-  "GitHubDescription": "Quellcode für Inspira UI.",
-  "Discord": "Discord",
-  "DiscordDescription": "Vernetze dich mit der Community auf Discord",
+    "Components": "Komponenten",
+    "ComponentsDescription": "Entdecke alle verfügbaren Komponenten und ihre Verwendung.",
+    "V1DocsDescription": "Dokumentation zur Nutzung von Inspira UI mit Tailwind CSS v3.",
+    "Community": "Community",
+    "GitHub": "GitHub",
+    "GitHubDescription": "Quellcode für Inspira UI.",
+    "Discord": "Discord",
+    "DiscordDescription": "Vernetze dich mit der Community auf Discord",
     "Forum": "Forum",
     "ForumDiscord": "Dem Forum beitreten"
   },
@@ -53,7 +53,17 @@
   "auth": {
     "Account": "Konto",
     "Login": "Anmelden",
-    "Register": "Registrieren"
+    "Register": "Registrieren",
+    "usernameOrEmail": "E-Mail-Adresse oder Benutzername",
+    "password": "Passwort",
+    "signIn": "Anmelden",
+    "signUpPrompt": "Noch kein Konto?",
+    "signUp": "Jetzt registrieren",
+    "requiredError": "Bitte geben Sie Ihre E-Mail-Adresse und Ihr Passwort ein.",
+    "invalidError": "Anmeldung mit diesen Daten nicht möglich. Bitte versuchen Sie es erneut.",
+    "successTitle": "Willkommen zurück",
+    "success": "Sie wurden erfolgreich angemeldet.",
+    "errorGeneric": "Beim Anmelden ist ein Fehler aufgetreten."
   },
   "blog": {
     "hero": {
@@ -190,5 +200,30 @@
         }
       }
     }
+  },
+  "register": {
+    "email": "E-Mail-Adresse",
+    "password": "Passwort",
+    "repeatPassword": "Passwort bestätigen",
+    "agree": "Ich akzeptiere die",
+    "terms": "Allgemeinen Geschäftsbedingungen",
+    "requirements": "Passwort-Anforderungen",
+    "requirement1": "Muss mindestens 8 Zeichen enthalten.",
+    "requirement2": "Sollte Zahlen oder Sonderzeichen für zusätzliche Sicherheit enthalten.",
+    "signUp": "Konto erstellen",
+    "haveAccount": "Sie haben bereits ein Konto?",
+    "signIn": "Anmelden",
+    "termsTitle": "Allgemeine Geschäftsbedingungen",
+    "errorTerms": "Sie müssen den Allgemeinen Geschäftsbedingungen zustimmen.",
+    "errorMissing": "Bitte füllen Sie alle Pflichtfelder aus.",
+    "errorMismatch": "Die Passwörter stimmen nicht überein.",
+    "errorGeneric": "Beim Erstellen des Kontos ist ein Fehler aufgetreten.",
+    "successTitle": "Konto erstellt",
+    "success": "Ihr Konto wurde erfolgreich erstellt.",
+    "termsIntro": "Mit dem Erstellen eines Kontos bestätigen Sie, dass Sie unsere Richtlinien verstehen und akzeptieren.",
+    "termsPoint1": "Wir verwenden Ihre Informationen nur, um Ihr Konto zu erstellen und zu schützen.",
+    "termsPoint2": "Sie können Ihre Benachrichtigungseinstellungen jederzeit anpassen.",
+    "termsPoint3": "Durch das Löschen Ihres Kontos werden Ihre Daten innerhalb von 30 Tagen aus unseren aktiven Systemen entfernt.",
+    "termsOutro": "Kontaktieren Sie unser Support-Team, wenn Sie Fragen zum Umgang mit Ihren Daten haben."
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -12,13 +12,13 @@
     "Installation": "Installation",
     "InstallationDescription": "Follow the step-by-step guide to install Inspira UI in your project.",
     "Components": "Components",
-  "ComponentsDescription": "Explore all available components and their usage.",
-  "V1DocsDescription": "Docs for using Inspira UI with Tailwind CSS v3.",
-  "Community": "Community",
-  "GitHub": "GitHub",
-  "GitHubDescription": "Source code for Inspira UI.",
-  "Discord": "Discord",
-  "DiscordDescription": "Connect with community on Discord",
+    "ComponentsDescription": "Explore all available components and their usage.",
+    "V1DocsDescription": "Docs for using Inspira UI with Tailwind CSS v3.",
+    "Community": "Community",
+    "GitHub": "GitHub",
+    "GitHubDescription": "Source code for Inspira UI.",
+    "Discord": "Discord",
+    "DiscordDescription": "Connect with community on Discord",
     "Forum": "Forum",
     "ForumDiscord": "Join the forum"
   },
@@ -53,7 +53,17 @@
   "auth": {
     "Account": "Account",
     "Login": "Log in",
-    "Register": "Register"
+    "Register": "Register",
+    "usernameOrEmail": "Email address or username",
+    "password": "Password",
+    "signIn": "Sign in",
+    "signUpPrompt": "Don't have an account?",
+    "signUp": "Create one",
+    "requiredError": "Please enter your email and password.",
+    "invalidError": "We couldn't sign you in with those details. Please try again.",
+    "successTitle": "Welcome back",
+    "success": "You have been signed in successfully.",
+    "errorGeneric": "Something went wrong while signing you in."
   },
   "blog": {
     "hero": {
@@ -190,5 +200,30 @@
         }
       }
     }
+  },
+  "register": {
+    "email": "Email address",
+    "password": "Password",
+    "repeatPassword": "Confirm password",
+    "agree": "I agree to the",
+    "terms": "terms and conditions",
+    "requirements": "Password requirements",
+    "requirement1": "Must contain at least 8 characters.",
+    "requirement2": "Should include numbers or special characters for extra security.",
+    "signUp": "Create account",
+    "haveAccount": "Already have an account?",
+    "signIn": "Sign in",
+    "termsTitle": "Terms & Conditions",
+    "errorTerms": "You must agree to the terms and conditions.",
+    "errorMissing": "Please complete all required fields.",
+    "errorMismatch": "Passwords do not match.",
+    "errorGeneric": "Something went wrong while creating your account.",
+    "successTitle": "Account created",
+    "success": "Your account has been created successfully.",
+    "termsIntro": "By creating an account you confirm that you understand and accept our policies.",
+    "termsPoint1": "We only use your information to create and secure your account.",
+    "termsPoint2": "You can update your notification preferences at any time.",
+    "termsPoint3": "Deleting your account will remove your data from our active systems within 30 days.",
+    "termsOutro": "Please contact our support team if you have any questions about how we handle your data."
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -12,13 +12,13 @@
     "Installation": "Installation",
     "InstallationDescription": "Suivez le guide étape par étape pour installer Inspira UI dans votre projet.",
     "Components": "Composants",
-  "ComponentsDescription": "Explorez tous les composants disponibles et leur utilisation.",
-  "V1DocsDescription": "Documentation pour utiliser Inspira UI avec Tailwind CSS v3.",
-  "Community": "Communauté",
-  "GitHub": "GitHub",
-  "GitHubDescription": "Code source d'Inspira UI.",
-  "Discord": "Discord",
-  "DiscordDescription": "Rejoignez la communauté sur Discord",
+    "ComponentsDescription": "Explorez tous les composants disponibles et leur utilisation.",
+    "V1DocsDescription": "Documentation pour utiliser Inspira UI avec Tailwind CSS v3.",
+    "Community": "Communauté",
+    "GitHub": "GitHub",
+    "GitHubDescription": "Code source d'Inspira UI.",
+    "Discord": "Discord",
+    "DiscordDescription": "Rejoignez la communauté sur Discord",
     "Forum": "Forum",
     "ForumDiscord": "Rejoindre le forum"
   },
@@ -53,7 +53,17 @@
   "auth": {
     "Account": "Compte",
     "Login": "Connexion",
-    "Register": "Inscription"
+    "Register": "Inscription",
+    "usernameOrEmail": "Adresse e-mail ou nom d'utilisateur",
+    "password": "Mot de passe",
+    "signIn": "Se connecter",
+    "signUpPrompt": "Pas encore de compte ?",
+    "signUp": "Créer un compte",
+    "requiredError": "Veuillez saisir votre e-mail et votre mot de passe.",
+    "invalidError": "Impossible de vous connecter avec ces informations. Veuillez réessayer.",
+    "successTitle": "Content de vous revoir",
+    "success": "Connexion réussie.",
+    "errorGeneric": "Une erreur est survenue lors de la connexion."
   },
   "blog": {
     "hero": {
@@ -190,5 +200,30 @@
         }
       }
     }
+  },
+  "register": {
+    "email": "Adresse e-mail",
+    "password": "Mot de passe",
+    "repeatPassword": "Confirmez le mot de passe",
+    "agree": "J'accepte les",
+    "terms": "conditions générales",
+    "requirements": "Exigences du mot de passe",
+    "requirement1": "Doit contenir au moins 8 caractères.",
+    "requirement2": "Inclure des chiffres ou des caractères spéciaux pour plus de sécurité.",
+    "signUp": "Créer un compte",
+    "haveAccount": "Vous avez déjà un compte ?",
+    "signIn": "Se connecter",
+    "termsTitle": "Conditions générales",
+    "errorTerms": "Vous devez accepter les conditions générales.",
+    "errorMissing": "Veuillez remplir tous les champs obligatoires.",
+    "errorMismatch": "Les mots de passe ne correspondent pas.",
+    "errorGeneric": "Une erreur est survenue lors de la création du compte.",
+    "successTitle": "Compte créé",
+    "success": "Votre compte a été créé avec succès.",
+    "termsIntro": "En créant un compte, vous confirmez comprendre et accepter nos politiques.",
+    "termsPoint1": "Nous utilisons vos informations uniquement pour créer et sécuriser votre compte.",
+    "termsPoint2": "Vous pouvez modifier vos préférences de notification à tout moment.",
+    "termsPoint3": "La suppression de votre compte entraîne l'effacement de vos données de nos systèmes actifs sous 30 jours.",
+    "termsOutro": "Contactez notre équipe d'assistance si vous avez des questions sur la gestion de vos données."
   }
 }

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,0 +1,129 @@
+<template>
+  <v-container class="py-12" style="margin-top: -70px;">
+    <v-card-text class="text-medium-emphasis pa-1">
+      <form class="mx-auto max-w-xl" @submit.prevent="handleSubmit">
+        <div class="card-padding">
+          <v-text-field
+            v-model="username"
+            density="compact"
+            rounded="xl"
+            :label="t('auth.usernameOrEmail')"
+            required
+            class="font-size-input input-style"
+            append-inner-icon="mdi-account"
+            :disabled="loading"
+            :error="Boolean(error)"
+            :class="fieldAlignment"
+          />
+          <v-text-field
+            v-model="password"
+            density="compact"
+            rounded="xl"
+            :type="showPassword ? 'text' : 'password'"
+            :label="t('auth.password')"
+            required
+            class="font-size-input input-style"
+            :class="fieldAlignment"
+            :disabled="loading"
+            :error="Boolean(error)"
+            :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+            @click:append-inner="togglePassword"
+          />
+
+          <p v-if="error" class="mt-1 text-red text-caption d-flex justify-center">
+            {{ error }}
+          </p>
+
+          <button
+            :disabled="loading"
+            type="submit"
+            class="btn btn-outline-primary bg-primary rounded-xl text-decoration-none font-weight-bold text-uppercase py-2 px-6 me-2 mb-2 w-100"
+          >
+            <v-progress-circular v-if="loading" indeterminate size="20" />
+            <span v-else :class="fieldAlignment">{{ t('auth.signIn') }}</span>
+          </button>
+
+          <p class="text-sm text-body mt-3 mb-0 d-flex justify-center" :class="fieldAlignment">
+            {{ t('auth.signUpPrompt') }}
+            <NuxtLink
+              :to="localePath('/register')"
+              class="text-primary text-decoration-none font-weight-bolder px-1"
+              :class="fieldAlignment"
+            >
+              {{ t('auth.signUp') }}
+            </NuxtLink>
+          </p>
+        </div>
+      </form>
+    </v-card-text>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { useLocalePath } from "#i18n";
+
+import { toast } from "~/components/content/common/toast";
+
+const { t, locale } = useI18n();
+const router = useRouter();
+const localePath = useLocalePath();
+
+const isRtl = computed(() => ["ar", "he", "fa", "ur"].includes(locale.value));
+const fieldAlignment = computed(() => (isRtl.value ? "text-end" : "text-start"));
+
+const username = ref("");
+const password = ref("");
+const loading = ref(false);
+const error = ref("");
+const showPassword = ref(false);
+
+function togglePassword() {
+  showPassword.value = !showPassword.value;
+}
+
+async function handleSubmit() {
+  if (loading.value) return;
+
+  loading.value = true;
+  error.value = "";
+
+  if (!username.value || !password.value) {
+    error.value = t("auth.requiredError");
+    loading.value = false;
+    return;
+  }
+
+  try {
+    const { data, error: fetchError } = await useFetch("/api/auth/login", {
+      method: "POST",
+      body: {
+        username: username.value,
+        password: password.value,
+      },
+    });
+
+    if (fetchError.value) {
+      error.value = fetchError.value.data?.message ?? t("auth.invalidError");
+      return;
+    }
+
+    if (data.value) {
+      toast({
+        title: t("auth.successTitle"),
+        description: t("auth.success"),
+      });
+      const homePath = localePath("/");
+      await router.push(homePath);
+    }
+  } catch (exception) {
+    console.error("Login failed", exception);
+    error.value = t("auth.errorGeneric");
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -1,0 +1,231 @@
+<template>
+  <v-container class="py-12" style="margin-top: -70px;">
+    <v-card-text class="text-medium-emphasis pa-0">
+      <form class="mx-auto max-w-xl" @submit.prevent="handleSubmit">
+        <div class="card-padding">
+          <v-text-field
+            v-model="email"
+            density="compact"
+            rounded="xl"
+            :label="t('register.email')"
+            :class="fieldAlignment"
+            required
+            class="font-size-input input-style"
+            append-inner-icon="mdi-email"
+            :disabled="loading"
+          />
+          <v-text-field
+            v-model="password"
+            density="compact"
+            rounded="xl"
+            :type="showPassword ? 'text' : 'password'"
+            :label="t('register.password')"
+            required
+            class="font-size-input input-style"
+            :class="fieldAlignment"
+            :disabled="loading"
+            :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
+            @click:append-inner="togglePassword"
+          />
+          <v-text-field
+            v-model="repeatPassword"
+            density="compact"
+            rounded="xl"
+            :type="showRepeatPassword ? 'text' : 'password'"
+            :label="t('register.repeatPassword')"
+            required
+            class="font-size-input input-style"
+            :class="fieldAlignment"
+            :disabled="loading"
+            :append-inner-icon="showRepeatPassword ? 'mdi-eye-off' : 'mdi-eye'"
+            @click:append-inner="toggleRepeatPassword"
+          />
+
+          <v-row class="align-center" :class="{ 'flex-row-reverse': isRtl }">
+            <v-col cols="auto">
+              <v-checkbox
+                v-model="checkbox"
+                hide-details
+                class="ma-0 pa-0"
+                density="compact"
+                :disabled="loading"
+              />
+            </v-col>
+            <v-col>
+              <span class="text-body text-sm ls-0" :class="fieldAlignment">
+                {{ t('register.agree') }}
+                <a
+                  href="javascript:void(0)"
+                  class="font-weight-bolder text-decoration-none text-primary"
+                  @click.prevent="showTerms = true"
+                >
+                  {{ t('register.terms') }}
+                </a>
+              </span>
+            </v-col>
+          </v-row>
+
+          <p v-if="error" class="mt-1 text-red d-flex justify-center">
+            {{ error }}
+          </p>
+
+          <p class="mt-1 mb-2 font-weight-bold text-typo" :class="fieldAlignment">
+            {{ t('register.requirements') }}
+          </p>
+
+          <div class="d-sm-flex" :class="isRtl ? 'rtl-block' : 'ltr-block'">
+            <ul class="text-muted ps-6 mb-0" :class="isRtl ? 'rtl-block' : 'ltr-block'">
+              <li>
+                <h6 class="text-h7" :class="isRtl ? 'rtl-block' : 'ltr-block'">
+                  {{ t('register.requirement1') }}
+                </h6>
+              </li>
+              <li>
+                <h6 class="text-h7" :class="isRtl ? 'rtl-block' : 'ltr-block'">
+                  {{ t('register.requirement2') }}
+                </h6>
+              </li>
+            </ul>
+          </div>
+
+          <button
+            :disabled="loading"
+            type="submit"
+            class="btn btn-outline-primary bg-primary rounded-xl text-decoration-none font-weight-bold text-uppercase py-2 px-6 me-2 mt-6 mb-2 w-100"
+          >
+            <v-progress-circular v-if="loading" indeterminate size="20" />
+            <span v-else :class="fieldAlignment">{{ t('register.signUp') }}</span>
+          </button>
+
+          <p class="text-sm text-body mt-1 mb-0 d-flex justify-center" :class="fieldAlignment">
+            {{ t('register.haveAccount') }}
+            <NuxtLink
+              :to="localePath('/login')"
+              class="text-primary text-decoration-none font-weight-bolder px-1"
+              :class="fieldAlignment"
+            >
+              {{ t('register.signIn') }}
+            </NuxtLink>
+          </p>
+        </div>
+      </form>
+    </v-card-text>
+
+    <v-dialog v-model="showTerms" max-width="600">
+      <v-card class="mx-auto">
+        <v-card-title class="text-h6 font-weight-bold" :class="fieldAlignment">
+          {{ t('register.termsTitle') }}
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="text-body-2">
+          <Terms />
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { useLocalePath } from "#i18n";
+
+import { toast } from "~/components/content/common/toast";
+import Terms from "~/components/auth/Terms.vue";
+
+const { t, locale } = useI18n();
+const router = useRouter();
+const localePath = useLocalePath();
+
+const isRtl = computed(() => ["ar", "he", "fa", "ur"].includes(locale.value));
+const fieldAlignment = computed(() => (isRtl.value ? "text-end" : "text-start"));
+
+const email = ref("");
+const password = ref("");
+const repeatPassword = ref("");
+const checkbox = ref(false);
+const loading = ref(false);
+const error = ref("");
+const showPassword = ref(false);
+const showRepeatPassword = ref(false);
+const showTerms = ref(false);
+
+function togglePassword() {
+  showPassword.value = !showPassword.value;
+}
+
+function toggleRepeatPassword() {
+  showRepeatPassword.value = !showRepeatPassword.value;
+}
+
+async function handleSubmit() {
+  if (loading.value) return;
+
+  loading.value = true;
+  error.value = "";
+
+  if (!checkbox.value) {
+    error.value = t("register.errorTerms");
+    loading.value = false;
+    return;
+  }
+
+  if (!email.value || !password.value || !repeatPassword.value) {
+    error.value = t("register.errorMissing");
+    loading.value = false;
+    return;
+  }
+
+  if (password.value !== repeatPassword.value) {
+    error.value = t("register.errorMismatch");
+    loading.value = false;
+    return;
+  }
+
+  try {
+    const { data, error: fetchError } = await useFetch("/api/auth/register", {
+      method: "POST",
+      body: {
+        email: email.value,
+        password: password.value,
+        repeatPassword: repeatPassword.value,
+      },
+    });
+
+    if (fetchError.value) {
+      error.value = fetchError.value.data?.message ?? t("register.errorGeneric");
+      return;
+    }
+
+    if (data.value) {
+      toast({
+        title: t("register.successTitle"),
+        description: t("register.success"),
+      });
+      email.value = "";
+      password.value = "";
+      repeatPassword.value = "";
+      checkbox.value = false;
+      const loginPath = localePath("/login");
+      await router.push(loginPath);
+    }
+  } catch (exception) {
+    console.error("Registration failed", exception);
+    error.value = t("register.errorGeneric");
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.rtl-block {
+  direction: rtl;
+  text-align: right;
+}
+.ltr-block {
+  direction: ltr;
+  text-align: left;
+}
+</style>

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -7,10 +7,10 @@ import { aliases } from 'vuetify/iconsets/mdi'
 
 import { useNuxtApp } from '#app'
 import DateFnsAdapter from '@date-io/date-fns'
-import enUS from 'date-fns/locale/en-US'
-import frFR from 'date-fns/locale/fr'
-import deDE from 'date-fns/locale/de'
-import arSA from 'date-fns/locale/ar-SA'
+import enUSLocale from 'date-fns/locale/en-US'
+import frLocale from 'date-fns/locale/fr'
+import deLocale from 'date-fns/locale/de'
+import arLocale from 'date-fns/locale/ar-SA'
 import { en, fr, de, ar } from 'vuetify/locale'
 
 import '@/assets/styles/material-dashboard.scss'
@@ -27,10 +27,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     vuetifyOptions.date = {
       adapter: DateFnsAdapter,
       locale: {
-        en: enUS,
-        fr: frFR,
-        de: deDE,
-        ar: arSA,
+        en: enUSLocale,
+        fr: frLocale,
+        de: deLocale,
+        ar: arLocale,
       },
     }
 


### PR DESCRIPTION
## Summary
- add dedicated login and registration views with RTL-aware form handling and toast feedback
- extract reusable terms content component for the registration modal
- localize new auth copy across English, French, German, and Arabic and align Vuetify date locales with lint rules

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d54e1d2f008326834539e5be0f6c5d