### PR TITLE
fix: allow configuring base URL via env

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -211,6 +211,14 @@ if (typeof osWithAvailableParallelism.availableParallelism !== 'function') {
   })
 }
 
+const rawBaseURL =
+  process.env.NUXT_APP_BASE_URL ??
+  process.env.NUXT_PUBLIC_APP_BASE_URL ??
+  (process.env.NODE_ENV === "development" ? "/" : "/")
+
+const normalizedBaseURL = rawBaseURL.startsWith("/") ? rawBaseURL : `/${rawBaseURL}`
+const baseURL = normalizedBaseURL.endsWith("/") ? normalizedBaseURL : `${normalizedBaseURL}/`
+
 export default defineNuxtConfig({
   devtools: { enabled: true },
   plugins: [
@@ -418,7 +426,7 @@ export default defineNuxtConfig({
         },
       ],
     },
-    baseURL: process.env.NODE_ENV === "development" ? "/" : "/docs/",
+    baseURL,
   },
   llms: {
     domain: "https://broworld.com/",


### PR DESCRIPTION
## Summary
- normalize the Nuxt base URL so deployments default to `/` and can be overridden through environment variables

## Testing
- `pnpm lint` *(fails: Invalid package.json in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d57589ba448326a8fc513f7a7bbd78