### PR TITLE
feat: reposition post meta bar actions

### DIFF
--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -105,7 +105,7 @@
         </form>
       </div>
 
-      <div class="px-3 w-full max-w-2xl">
+      <footer class="px-3 w-full max-w-2xl pt-1" aria-live="polite">
         <div
           class="mt-4 flex flex-wrap items-center gap-2 text-sm text-slate-400"
           :aria-label="metaAriaLabel"
@@ -121,7 +121,7 @@
             <span>{{ commentCountDisplay }}</span>
           </span>
         </div>
-      </div>
+      </footer>
 
       <footer
         v-if="hasReactionPreview"

--- a/components/blog/PostMeta.vue
+++ b/components/blog/PostMeta.vue
@@ -54,6 +54,7 @@
               role="menuitem"
               class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-slate-100 transition-colors hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
               data-test="post-action-edit"
+              :aria-label="editLabel"
               @click="handleEdit"
             >
               {{ editLabel }}
@@ -64,6 +65,7 @@
               role="menuitem"
               class="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-rose-200 transition-colors hover:bg-rose-500/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400"
               data-test="post-action-delete"
+              :aria-label="deleteLabel"
               @click="handleDelete"
             >
               {{ deleteLabel }}

--- a/tests/e2e/PostCard.spec.ts
+++ b/tests/e2e/PostCard.spec.ts
@@ -176,6 +176,33 @@ describe("PostCard interactions", () => {
     expect(toastSpy).toHaveBeenCalled();
   });
 
+  it("does not render author actions when the viewer is logged out", () => {
+    setViewerAs(null);
+
+    const wrapper = mountComponent();
+
+    expect(wrapper.find("[data-test='author-actions']").exists()).toBe(false);
+  });
+
+  it("shows a following indicator when the viewer already follows the author", () => {
+    setViewerAs("viewer-1");
+    followingState[basePost.user.id] = true;
+
+    const wrapper = mountComponent();
+
+    const chip = wrapper.find("[data-test='following-chip']");
+    expect(chip.exists()).toBe(true);
+    expect(chip.text()).toBe(en.blog.posts.actions.following);
+  });
+
+  it("renders the post meta bar below the content", () => {
+    const wrapper = mountComponent();
+
+    const metaBar = wrapper.find("[data-test='post-meta-bar']");
+    expect(metaBar.exists()).toBe(true);
+    expect(metaBar.element.closest("footer")).not.toBeNull();
+  });
+
   it("opens the edit modal and saves changes", async () => {
     const wrapper = mountComponent();
 


### PR DESCRIPTION
## Summary
- move the post meta bar into a dedicated footer beneath the main content area
- add aria labels for the author actions menu items and extend PostCard tests to cover follow/following states and meta placement

## Testing
- pnpm test:unit *(fails: vitest prompts for missing `happy-dom` dependency in the container)*
- pnpm add -D happy-dom@16.5.2 *(fails: registry access returns HTTP 403 so the dependency cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d57f7099348326a7db05a7423fd4c9