### PR TITLE
Fix live region label association

### DIFF
--- a/components/PostCard.vue
+++ b/components/PostCard.vue
@@ -105,10 +105,11 @@
         </form>
       </div>
 
-      <footer class="px-3 w-full max-w-2xl pt-1" aria-live="polite">
+      <footer class="px-3 w-full max-w-2xl pt-1">
         <div
           class="mt-4 flex flex-wrap items-center gap-2 text-sm text-slate-400"
           :aria-label="metaAriaLabel"
+          aria-live="polite"
           data-test="post-meta-bar"
         >
           <span class="inline-flex items-center gap-1">


### PR DESCRIPTION
## Summary
- move the polite live region onto the metadata container so announcements include the aria label text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5815e2720832687dfcd7c51d74ffc