### PR TITLE
feat: make right sidebar permanent on desktop

### DIFF
--- a/components/layout/RightSidebarContent.vue
+++ b/components/layout/RightSidebarContent.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="flex h-full flex-col gap-6">
+    <SidebarWeatherCard :weather="weather" />
+    <SidebarLeaderboardCard
+      :title="leaderboard.title"
+      :live-label="leaderboard.live"
+      :participants="leaderboard.participants"
+    />
+    <SidebarRatingCard :rating="rating" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import SidebarLeaderboardCard from "~/components/layout/SidebarLeaderboardCard.vue";
+import SidebarRatingCard from "~/components/layout/SidebarRatingCard.vue";
+import SidebarWeatherCard from "~/components/layout/SidebarWeatherCard.vue";
+import type {
+  SidebarLeaderboardData,
+  SidebarRatingData,
+  SidebarWeatherData,
+} from "~/components/layout/right-sidebar.types";
+
+defineProps<{
+  weather: SidebarWeatherData;
+  leaderboard: SidebarLeaderboardData;
+  rating: SidebarRatingData;
+}>();
+</script>

--- a/components/layout/right-sidebar.types.ts
+++ b/components/layout/right-sidebar.types.ts
@@ -1,0 +1,59 @@
+export interface SidebarWeatherData {
+  badge: string;
+  title: string;
+  subtitle: string;
+  icon: string;
+  location: string;
+  temperature: string;
+  tip: string;
+  locationLabel: string;
+  temperatureLabel: string;
+  tipLabel: string;
+}
+
+export interface SidebarLeaderboardParticipant {
+  position: number;
+  name: string;
+  role: string;
+  score: string;
+}
+
+export interface SidebarLeaderboardData {
+  title: string;
+  live: string;
+  participants: SidebarLeaderboardParticipant[];
+}
+
+export interface SidebarLeaderboardRaw {
+  title?: string;
+  live?: string;
+  participants?: Record<
+    "first" | "second" | "third",
+    Omit<SidebarLeaderboardParticipant, "position">
+  >;
+}
+
+export interface SidebarRatingCategory {
+  label: string;
+  value: number;
+}
+
+export interface SidebarRatingData {
+  title: string;
+  subtitle: string;
+  average: string;
+  total: number;
+  icon: string;
+  stars: number;
+  categories: SidebarRatingCategory[];
+}
+
+export interface SidebarRatingRaw {
+  title?: string;
+  subtitle?: string;
+  average?: string;
+  total?: number;
+  icon?: string;
+  stars?: number;
+  categories?: Record<string, SidebarRatingCategory>;
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -12,23 +12,26 @@
         <aside
           v-if="showLeftAside"
           class="fixed z-30 -ml-2 hidden w-full shrink-0 overflow-y-auto top-[102px] md:sticky md:block"
-          :class="[
-            config.aside.useLevel && config.aside.levelStyle === 'aside'
-              ? 'h-[calc(100vh-3.5rem)] md:top-[61px]'
-              : 'h-[calc(100vh-6rem)] md:top-[101px]',
-          ]"
+          :class="stickyOffsets"
         >
           <Aside :is-mobile="false" />
         </aside>
         <div class="min-w-0">
           <slot />
         </div>
+        <aside
+          v-if="showRightAside"
+          class="hidden w-full md:sticky md:block"
+          :class="stickyOffsets"
+        >
+          <LayoutRightSidebar />
+        </aside>
       </div>
     </div>
     <div v-else>
       <slot />
+      <LayoutRightSidebar v-if="showRightAside" />
     </div>
-    <LayoutRightSidebar v-if="showRightAside" />
     <Toaster />
     <VFooter />
   </div>
@@ -50,9 +53,26 @@ const useStructuredLayout = computed(() => hasContentPage.value && page.value?.f
 const showLeftAside = computed(() => hasContentPage.value && (page.value?.aside ?? true));
 const showRightAside = computed(() => hasContentPage.value && (page.value?.rightAside ?? true));
 
+const stickyOffsets = computed(() =>
+  config.value.aside.useLevel && config.value.aside.levelStyle === "aside"
+    ? "h-[calc(100vh-3.5rem)] md:top-[61px]"
+    : "h-[calc(100vh-6rem)] md:top-[101px]",
+);
+
 const layoutColumns = computed(() => {
-  if (showLeftAside.value) {
+  const left = showLeftAside.value;
+  const right = showRightAside.value;
+
+  if (left && right) {
+    return "md:grid-cols-[240px_minmax(0,1fr)_280px] lg:grid-cols-[280px_minmax(0,1fr)_320px]";
+  }
+
+  if (left) {
     return "md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,1fr)]";
+  }
+
+  if (right) {
+    return "md:grid-cols-[minmax(0,1fr)_280px] lg:grid-cols-[minmax(0,1fr)_320px]";
   }
 
   return null;


### PR DESCRIPTION
## Summary
- integrate the right sidebar into the structured layout grid so it always reserves space alongside the main content on desktop
- refactor the right sidebar component to render static content on md+ viewports while keeping a swipeable drawer experience for small screens
- extract shared sidebar content markup and strongly typed helpers for weather, leaderboard, and rating data

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated contact, playground, and test files)*

------
https://chatgpt.com/codex/tasks/task_e_68d58a524e9083268abbc5e9531cbae0