### PR TITLE
Ensure alert panel plugin waits for Pinia

### DIFF
--- a/plugins/alert-panel.client.ts
+++ b/plugins/alert-panel.client.ts
@@ -1,21 +1,25 @@
 import type { AlertMessage } from "~/types/alert-panel";
 import { useAlertPanel } from "~/stores/useAlertPanel";
 
-export default defineNuxtPlugin(() => {
-  const alertStore = useAlertPanel();
+export default defineNuxtPlugin({
+  name: "alert-panel",
+  dependsOn: ["pinia-plugin"],
+  setup() {
+    const alertStore = useAlertPanel();
 
-  function notify(alert: AlertMessage) {
-    return alertStore.push(alert);
-  }
+    function notify(alert: AlertMessage) {
+      return alertStore.push(alert);
+    }
 
-  function clearAlerts() {
-    alertStore.clear();
-  }
+    function clearAlerts() {
+      alertStore.clear();
+    }
 
-  return {
-    provide: {
-      notify,
-      clearAlerts,
-    },
-  };
+    return {
+      provide: {
+        notify,
+        clearAlerts,
+      },
+    };
+  },
 });

--- a/plugins/pinia.ts
+++ b/plugins/pinia.ts
@@ -1,8 +1,11 @@
 import { createPinia } from "~/lib/pinia-shim";
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const pinia = createPinia();
+export default defineNuxtPlugin({
+  name: "pinia-plugin",
+  setup(nuxtApp) {
+    const pinia = createPinia();
 
-  nuxtApp.vueApp.use(pinia);
-  nuxtApp.provide("pinia", pinia);
+    nuxtApp.vueApp.use(pinia);
+    nuxtApp.provide("pinia", pinia);
+  },
 });


### PR DESCRIPTION
## Summary
- give the Pinia plugin an explicit name so other plugins can order themselves after it
- update the alert panel plugin to depend on the Pinia plugin before accessing the store

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5993eae28832692b4f0f153990b5e