### PR TITLE
Ensure API plugin waits for Pinia

### DIFF
--- a/plugins/api.client.ts
+++ b/plugins/api.client.ts
@@ -8,58 +8,62 @@ interface ErrorPayload {
   title?: string;
 }
 
-export default defineNuxtPlugin((nuxtApp) => {
-  const runtimeConfig = useRuntimeConfig();
-  const baseURL = runtimeConfig.public?.apiBase ?? "/api";
-  const auth = useAuthSession();
-  const { $i18n } = nuxtApp as unknown as { $i18n?: { t: (key: string) => string } };
+export default defineNuxtPlugin({
+  name: "api-client",
+  dependsOn: ["pinia-plugin"],
+  setup(nuxtApp) {
+    const runtimeConfig = useRuntimeConfig();
+    const baseURL = runtimeConfig.public?.apiBase ?? "/api";
+    const auth = useAuthSession();
+    const { $i18n } = nuxtApp as unknown as { $i18n?: { t: (key: string) => string } };
 
-  const api = ofetch.create({
-    baseURL,
-    credentials: "include",
-    async onResponseError({
-      response,
-      error,
-      options,
-    }: {
-      response?: FetchResponse<ErrorPayload>
-      error: FetchError<ErrorPayload>
-      options: FetchOptions
-    }) {
-      const status = response?.status;
-      const payload = (response?._data ?? {}) as ErrorPayload;
-      const message = payload.message || payload.error || error.message || "Unexpected network error";
-      const title = payload.title || (status ? `HTTP ${status}` : undefined);
+    const api = ofetch.create({
+      baseURL,
+      credentials: "include",
+      async onResponseError({
+        response,
+        error,
+        options,
+      }: {
+        response?: FetchResponse<ErrorPayload>
+        error: FetchError<ErrorPayload>
+        options: FetchOptions
+      }) {
+        const status = response?.status;
+        const payload = (response?._data ?? {}) as ErrorPayload;
+        const message = payload.message || payload.error || error.message || "Unexpected network error";
+        const title = payload.title || (status ? `HTTP ${status}` : undefined);
 
-      if (status === 401 || status === 403) {
-        const translator = $i18n?.t ?? ((key: string) => key);
-        const sessionMessage = translator("auth.sessionExpired");
+        if (status === 401 || status === 403) {
+          const translator = $i18n?.t ?? ((key: string) => key);
+          const sessionMessage = translator("auth.sessionExpired");
 
-        await auth.handleUnauthorized(sessionMessage);
+          await auth.handleUnauthorized(sessionMessage);
 
-        return;
-      }
+          return;
+        }
 
-      const suppressNotification = Boolean(
-        options?.context && (options.context as Record<string, unknown>).suppressErrorNotification,
-      );
+        const suppressNotification = Boolean(
+          options?.context && (options.context as Record<string, unknown>).suppressErrorNotification,
+        );
 
-      if (suppressNotification) {
-        return;
-      }
+        if (suppressNotification) {
+          return;
+        }
 
-      nuxtApp.$notify({
-        type: "error",
-        title,
-        message,
-        timeout: null,
-      });
-    },
-  });
+        nuxtApp.$notify({
+          type: "error",
+          title,
+          message,
+          timeout: null,
+        });
+      },
+    });
 
-  return {
-    provide: {
-      api,
-    },
-  };
+    return {
+      provide: {
+        api,
+      },
+    };
+  },
 });


### PR DESCRIPTION
## Summary
- convert the API plugin to a named plugin that depends on the Pinia plugin so stores are available before use
- preserve the API factory while keeping its provide contract unchanged

## Testing
- pnpm lint *(fails: existing lint errors in lib/contact/validation.ts, pages/playground/ui.vue, tests/unit/i18nPages.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a2b84cfc8326a064160d0623d685