### PR TITLE
Ensure pinia plugin executes before other plugins

### DIFF
--- a/plugins/pinia.ts
+++ b/plugins/pinia.ts
@@ -2,6 +2,7 @@ import { createPinia } from "~/lib/pinia-shim";
 
 export default defineNuxtPlugin({
   name: "pinia-plugin",
+  enforce: "pre",
   setup(nuxtApp) {
     const pinia = createPinia();
 


### PR DESCRIPTION
## Summary
- ensure the Pinia plugin is enforced to run before other Nuxt plugins so stores can be injected before use

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a4ab583c832694ffdbd33d89a12d