### PR TITLE
refactor: restore Vuetify shell layout

### DIFF
--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
+html,
+body {
+  min-height: 100%;
+}
+
+#__nuxt {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.v-application {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 html {
   overflow-y: auto;
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -228,7 +228,13 @@ export default defineNuxtConfig({
     "~/plugins/vuetify-i18n.ts",
   ],
 
-  css: ["vuetify/styles", "@mdi/font/css/materialdesignicons.css", "~/assets/styles/index.css"],
+  css: [
+    "vuetify/styles",
+    "@mdi/font/css/materialdesignicons.css",
+    "flag-icons/css/flag-icons.min.css",
+    "~/assets/styles/material-dashboard.scss",
+    "~/assets/styles/index.css",
+  ],
 
   build: {
     transpile: ["vuetify"],

--- a/pages/playground.vue
+++ b/pages/playground.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-3xl font-semibold tracking-tight">Playground</h1>
+      <p class="mt-2 text-base text-muted-foreground">
+        Quick spot-check for the shared Vuetify and Tailwind design surface.
+      </p>
+    </div>
+    <v-card class="p-6">
+      <div class="flex flex-wrap items-center gap-4">
+        <v-btn
+          color="primary"
+          variant="flat"
+        >
+          Vuetify Button
+        </v-btn>
+        <button
+          type="button"
+          class="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+        >
+          Tailwind Button
+        </button>
+      </div>
+    </v-card>
+    <v-card class="p-6">
+      <div class="grid gap-4 md:grid-cols-2">
+        <v-alert
+          type="info"
+          variant="flat"
+        >
+          Vuetify components render with their expected theme tokens.
+        </v-alert>
+        <div class="rounded-lg border border-dashed border-border bg-background/60 p-4">
+          <p class="text-sm text-muted-foreground">
+            Tailwind utility styles layer on top without overriding the Vuetify base styles. Use this page to verify new layout
+            changes quickly.
+          </p>
+        </div>
+      </div>
+    </v-card>
+  </div>
+</template>

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -16,9 +16,6 @@ import esLocale from 'date-fns/locale/es'
 import ruLocale from 'date-fns/locale/ru'
 import arLocale from 'date-fns/locale/ar-SA'
 
-import '@/assets/styles/material-dashboard.scss'
-import "flag-icons"
-
 export type DataTableHeaders = VDataTable['$props']['headers']
 
 function getStoredValue<T>(key: string, fallback: T): T {


### PR DESCRIPTION
## Summary
- restructure the default layout into a Vuetify app shell with responsive drawers, fixed app bar, and quick action utilities
- load Vuetify, icon, and dashboard styles ahead of Tailwind utilities while enforcing full-height wrappers for the app shell
- add a Playground page showcasing Vuetify and Tailwind components and stop importing shared styles inside the Vuetify plugin

## Testing
- pnpm lint *(fails: repository has pre-existing lint violations outside the touched files)*
- pnpm exec eslint layouts/default.vue pages/playground.vue assets/styles/index.css nuxt.config.ts plugins/vuetify.ts *(warns: CSS file is ignored by the eslint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b2eda98083268fba43be9c731b50