### PR TITLE
Add tailwind rounded-2xl radius

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,6 +103,7 @@ export default {
         },
       },
       borderRadius: {
+        "2xl": "calc(var(--radius) + 8px)",
         xl: "calc(var(--radius) + 4px)",
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- extend Tailwind's border radius scale to include a 2xl size derived from the design token so rounded-2xl classes resolve correctly

## Testing
- `pnpm lint` *(fails: existing lint errors in lib/contact/validation.ts, pages/playground/ui.vue, tests/unit/i18nPages.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bf1be19c8326b2f7caee052282cf