### PR TITLE
Fix AppSidebar rounded utility

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -65,7 +65,8 @@ const emit = defineEmits<{ (e: 'select', key: string): void }>()
 }
 
 .sidebar-item {
-  @apply flex items-center justify-between rounded-2xl px-4 py-3 text-left transition;
+  @apply flex items-center justify-between px-4 py-3 text-left transition;
+  border-radius: calc(var(--radius) + 8px);
   @apply bg-white/70 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2;
 }
 


### PR DESCRIPTION
## Summary
- remove the `rounded-2xl` Tailwind utility from the AppSidebar `@apply` block
- use a direct `border-radius` declaration to preserve the intended appearance without triggering Tailwind errors

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c06f27d88326a7482615d5d58c9b