### PR TITLE
Fix sidebar padding without tailwind px utility

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -65,7 +65,8 @@ const emit = defineEmits<{ (e: 'select', key: string): void }>()
 }
 
 .sidebar-item {
-  @apply flex items-center justify-between px-4 py-3 text-left transition;
+  @apply flex items-center justify-between text-left transition;
+  padding: 0.75rem 1rem;
   border-radius: calc(var(--radius) + 8px);
   @apply bg-white/70 hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2;
 }


### PR DESCRIPTION
## Summary
- remove the Tailwind `px-4`/`py-3` utilities from the AppSidebar scoped styles to avoid the plugin error
- keep the same visual spacing by applying equivalent padding values directly in CSS

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files such as lib/contact/validation.ts and pages/playground/ui.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c1a39b7c8326b1441e5fd05fff6e