### PR TITLE
fix: reference tailwind utilities in sidebar

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -48,6 +48,8 @@ const emit = defineEmits<{ (e: 'select', key: string): void }>()
 </script>
 
 <style scoped>
+@reference "../../assets/css/tailwind.css";
+
 .app-card {
   border-radius: 24px;
   background: rgba(255, 255, 255, 0.95);


### PR DESCRIPTION
## Summary
- add a Tailwind CSS reference directive to the sidebar component's scoped style so utility classes resolve correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c3cb158c8326a11c12a0b47d65e0