### PR TITLE
feat: show locale flag dynamically

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -146,7 +146,7 @@
               size="30"
               class="bg-transparent text-lg"
             >
-              <span>🇬🇧</span>
+              <span>{{ localeToFlag(props.locale) }}</span>
             </v-avatar>
           </button>
         </template>
@@ -211,6 +211,17 @@ const { t } = useI18n()
 
 const localeLabel = computed(() => formatLocaleLabel(props.locale))
 
+const localeFlags: Record<string, string> = {
+  en: '🇬🇧',
+  de: '🇩🇪',
+  fr: '🇫🇷',
+  es: '🇪🇸',
+  it: '🇮🇹',
+  ru: '🇷🇺',
+  ar: '🇸🇦',
+  'zh-cn': '🇨🇳',
+}
+
 function changeLocale(value: string) {
   emit('update:locale', value)
 }
@@ -236,6 +247,27 @@ function formatLocaleLabel(value: string) {
     default:
       return value
   }
+}
+
+function localeToFlag(value: string) {
+  const normalized = value.toLowerCase()
+
+  if (normalized in localeFlags) {
+    return localeFlags[normalized]
+  }
+
+  const parts = normalized.split(/[-_]/).filter(Boolean)
+  const initials = parts.map((part) => part.charAt(0).toUpperCase()).join('')
+
+  if (initials.length === 1 && parts[0]) {
+    return parts[0].slice(0, 2).toUpperCase()
+  }
+
+  if (initials) {
+    return initials
+  }
+
+  return value.toUpperCase()
 }
 </script>
 


### PR DESCRIPTION
## Summary
- replace the top bar language avatar with a locale-aware flag helper
- provide readable uppercase initials when a locale has no mapped flag

## Testing
- pnpm exec eslint components/layout/AppTopBar.vue

------
https://chatgpt.com/codex/tasks/task_e_68d5ca651770832681949314db8495b5