### PR TITLE
Improve desktop blog layout

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,100 +1,165 @@
 <template>
   <div class="relative min-h-screen overflow-hidden bg-transparent text-slate-50">
-    <div class="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-6 sm:px-6 lg:px-8">
-      <div
-          v-if="pending"
-          class="grid gap-8 sm:grid-cols-2"
+    <div class="mx-auto flex w-full flex-col gap-10 px-4 py-8 sm:px-6 lg:px-8 xl:px-10">
+      <section
+        class="relative overflow-hidden rounded-3xl border border-white/5 bg-gradient-to-br from-white/10 via-white/5 to-white/10 p-8 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-2xl"
+        aria-labelledby="community-hero-heading"
       >
-        <div
-            v-for="index in 4"
-            :key="index"
-            class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl"
-        >
-          <div class="flex items-center gap-4">
-            <div class="h-14 w-14 rounded-2xl bg-white/10" />
-            <div class="space-y-3">
-              <div class="h-3 w-32 rounded-full bg-white/10" />
-              <div class="h-3 w-24 rounded-full bg-white/10" />
-            </div>
-          </div>
-          <div class="space-y-3">
-            <div class="h-3 w-3/4 rounded-full bg-white/10" />
-            <div class="h-3 w-2/3 rounded-full bg-white/10" />
-            <div class="h-3 w-full rounded-full bg-white/10" />
-          </div>
-          <div class="mt-auto flex gap-3">
-            <div class="h-7 w-28 rounded-full bg-white/5" />
-            <div class="h-7 w-28 rounded-full bg-white/5" />
-          </div>
-        </div>
-      </div>
-
-      <template v-else>
-        <div class="flex flex-col gap-6">
-          <form
-              class="flex flex-col gap-4 rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl"
-              @submit.prevent="handleCreatePost"
-          >
-            <div class="flex flex-col gap-3">
-              <h2 class="text-lg font-semibold text-white">
-                {{ t("blog.composer.title") }}
-              </h2>
-              <p class="text-sm text-slate-300">
-                {{ t("blog.composer.subtitle") }}
+        <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_260px]">
+          <div class="space-y-6">
+            <p class="text-xs font-semibold uppercase tracking-[0.2em] text-primary/80">
+              {{ heroContent.eyebrow }}
+            </p>
+            <div class="space-y-4">
+              <h1 id="community-hero-heading" class="text-3xl font-semibold text-white sm:text-4xl">
+                {{ heroContent.title }}
+              </h1>
+              <p class="text-base text-slate-200 sm:text-lg">
+                {{ heroContent.description }}
               </p>
             </div>
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+              <NuxtLink
+                :href="heroContent.primary.href"
+                class="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-6 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+              >
+                <span>{{ heroContent.primary.label }}</span>
+                <span aria-hidden="true">→</span>
+              </NuxtLink>
+              <NuxtLink
+                :href="heroContent.secondary.href"
+                class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 bg-white/5 px-6 py-2 text-sm font-semibold text-white transition hover:border-primary/60 hover:bg-primary/10"
+                :target="heroContent.secondary.href.startsWith('http') ? '_blank' : undefined"
+                :rel="heroContent.secondary.href.startsWith('http') ? 'noopener noreferrer' : undefined"
+              >
+                <span>{{ heroContent.secondary.label }}</span>
+              </NuxtLink>
+            </div>
+          </div>
 
-            <label class="flex flex-col gap-3 text-sm text-slate-200">
-              <span class="font-medium text-slate-100">
-                {{ t("blog.composer.label") }}
-              </span>
-              <textarea
+          <div class="grid gap-4 sm:grid-cols-3 lg:grid-cols-1">
+            <div
+              v-for="stat in heroStats"
+              :key="stat.id"
+              class="flex flex-col gap-1 rounded-2xl border border-white/10 bg-black/20 p-5 text-white shadow-[0_20px_45px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl"
+            >
+              <span class="text-3xl font-semibold text-white">{{ stat.value }}</span>
+              <span class="text-sm font-medium text-slate-300">{{ stat.label }}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="grid gap-8 xl:grid-cols-[minmax(0,1fr)_320px]">
+        <div class="flex flex-col gap-6">
+          <div
+            v-if="pending"
+            class="grid gap-6 sm:grid-cols-2"
+          >
+            <div
+              v-for="index in 4"
+              :key="index"
+              class="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/5 p-8 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl"
+            >
+              <div class="flex items-center gap-4">
+                <div class="h-14 w-14 rounded-2xl bg-white/10" />
+                <div class="space-y-3">
+                  <div class="h-3 w-32 rounded-full bg-white/10" />
+                  <div class="h-3 w-24 rounded-full bg-white/10" />
+                </div>
+              </div>
+              <div class="space-y-3">
+                <div class="h-3 w-3/4 rounded-full bg-white/10" />
+                <div class="h-3 w-2/3 rounded-full bg-white/10" />
+                <div class="h-3 w-full rounded-full bg-white/10" />
+              </div>
+              <div class="mt-auto flex gap-3">
+                <div class="h-7 w-28 rounded-full bg-white/5" />
+                <div class="h-7 w-28 rounded-full bg-white/5" />
+              </div>
+            </div>
+          </div>
+
+          <template v-else>
+            <form
+              class="flex flex-col gap-4 rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl"
+              @submit.prevent="handleCreatePost"
+            >
+              <div class="flex flex-col gap-3">
+                <h2 class="text-lg font-semibold text-white">
+                  {{ t("blog.composer.title") }}
+                </h2>
+                <p class="text-sm text-slate-300">
+                  {{ t("blog.composer.subtitle") }}
+                </p>
+              </div>
+
+              <label class="flex flex-col gap-3 text-sm text-slate-200">
+                <span class="font-medium text-slate-100">
+                  {{ t("blog.composer.label") }}
+                </span>
+                <textarea
                   v-model="newPostContent"
                   class="min-h-[140px] w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-base text-white placeholder:text-slate-400 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
                   :placeholder="t('blog.composer.placeholder')"
-              />
-            </label>
+                />
+              </label>
 
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <p
                   v-if="composerFeedback"
                   :class="composerFeedback.type === 'success' ? 'text-emerald-300' : 'text-rose-300'"
                   class="text-sm"
-              >
-                {{ composerFeedback.message }}
-              </p>
-              <div class="flex items-center gap-3 sm:justify-end">
-                <span class="text-xs text-slate-400">
-                  {{ characterCountLabel }}
-                </span>
-                <button
-                    type="submit"
-                    class="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors duration-300 hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="creating"
                 >
-                  <span v-if="creating">
-                    {{ t("blog.composer.submitting") }}
+                  {{ composerFeedback.message }}
+                </p>
+                <div class="flex items-center gap-3 sm:justify-end">
+                  <span class="text-xs text-slate-400">
+                    {{ characterCountLabel }}
                   </span>
-                  <span v-else>
-                    {{ t("blog.composer.submit") }}
-                  </span>
-                </button>
+                  <button
+                    type="submit"
+                    class="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors duration-300 hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                    :disabled="creating"
+                  >
+                    <span v-if="creating">
+                      {{ t("blog.composer.submitting") }}
+                    </span>
+                    <span v-else>
+                      {{ t("blog.composer.submit") }}
+                    </span>
+                  </button>
+                </div>
               </div>
-            </div>
-          </form>
+            </form>
 
-          <div class="flex flex-col gap-4">
-            <PostCard
+            <div class="flex flex-col gap-4">
+              <PostCard
                 v-for="post in posts"
                 :key="post.id"
                 :post="post"
                 :default-avatar="defaultAvatar"
                 :reaction-emojis="reactionEmojis"
                 :reaction-labels="reactionLabels"
-            />
-          </div>
+              />
+            </div>
+          </template>
         </div>
-      </template>
+
+        <aside class="flex flex-col gap-5">
+          <div class="rounded-3xl border border-white/5 bg-white/5 p-6 shadow-[0_25px_55px_-25px_rgba(15,23,42,0.65)] backdrop-blur-xl">
+            <h2 class="text-lg font-semibold text-white">{{ sidebarContent.title }}</h2>
+            <p class="mt-2 text-sm text-slate-300">{{ sidebarContent.subtitle }}</p>
+            <div class="mt-5 grid gap-4">
+              <SidebarWidget
+                v-for="widget in sidebarContent.widgets"
+                :key="widget.id"
+                :widget="widget"
+              />
+            </div>
+          </div>
+        </aside>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- rework the blog landing page layout to include a hero section with stats and clear calls-to-action
- expand the desktop grid to show the composer/posts alongside a dedicated sidebar widget column
- reuse existing sidebar widget copy and improve button/link presentation for large screens

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cd7285908326a175bf594da754d4