### PR TITLE
Fix desktop sidebar visibility

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -52,7 +52,7 @@
           class="layout-grid"
           :class="{ 'layout-grid--no-right': !showRightWidgets }"
         >
-          <div class="hidden md:block">
+          <div v-if="!isMobile" class="layout-sidebar">
             <AppSidebar
               :items="sidebarItems"
               :active-key="activeSidebar"
@@ -65,7 +65,7 @@
 
             <div
               v-if="showRightWidgets"
-              class="mt-6 hidden md:block xl:hidden"
+              class="layout-right-widgets"
             >
               <AppRightWidgets />
             </div>
@@ -73,7 +73,7 @@
 
           <div
             v-if="showRightWidgets"
-            class="hidden xl:block"
+            class="layout-right-rail"
           >
             <AppRightWidgets />
           </div>
@@ -238,11 +238,28 @@ const currentYear = new Date().getFullYear()
   grid-template-columns: minmax(0, 1fr);
 }
 
+.layout-sidebar {
+  display: none;
+}
+
+.layout-right-widgets {
+  margin-top: 24px;
+  display: none;
+}
+
+.layout-right-rail {
+  display: none;
+}
+
 .layout-grid--no-right {
   grid-template-columns: minmax(0, 1fr);
 }
 
 @media (min-width: 768px) {
+  .layout-sidebar {
+    display: block;
+  }
+
   .layout-grid {
     grid-template-columns: 320px minmax(0, 1fr);
   }
@@ -250,9 +267,21 @@ const currentYear = new Date().getFullYear()
   .layout-grid--no-right {
     grid-template-columns: 320px minmax(0, 1fr);
   }
+
+  .layout-right-widgets {
+    display: block;
+  }
 }
 
 @media (min-width: 1280px) {
+  .layout-right-widgets {
+    display: none;
+  }
+
+  .layout-right-rail {
+    display: block;
+  }
+
   .layout-grid {
     grid-template-columns: 320px minmax(0, 1fr) 360px;
   }


### PR DESCRIPTION
## Summary
- render the application sidebar whenever the viewport is not considered mobile
- replace Tailwind utility visibility toggles with dedicated layout classes and responsive CSS
- keep the secondary widget rail responsive by mirroring the previous breakpoints in scoped styles

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d9a068b8832691cbeab391869c00