### PR TITLE
Fix profile translations path in localized files

### DIFF
--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -114,7 +114,9 @@
       "WhatAreYouWaitingFor": "¿Qué estás esperando?",
       "GetStartedAndStartBuildingAwesomeUI": "Comienza y crea interfaces increíbles",
       "GetStarted": "Comenzar"
-    },
+    }
+  },
+  "pages": {
     "profile": {
       "title": "Perfil",
       "subtitle": "Revisa y administra tu información personal.",
@@ -149,9 +151,7 @@
       "stats": {
         "title": "Estadísticas rápidas"
       }
-    }
-  },
-  "pages": {
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -114,7 +114,9 @@
       "WhatAreYouWaitingFor": "Cosa stai aspettando?",
       "GetStartedAndStartBuildingAwesomeUI": "Inizia subito e crea interfacce straordinarie",
       "GetStarted": "Inizia"
-    },
+    }
+  },
+  "pages": {
     "profile": {
       "title": "Profilo",
       "subtitle": "Rivedi e gestisci le tue informazioni personali.",
@@ -149,9 +151,7 @@
       "stats": {
         "title": "Statistiche rapide"
       }
-    }
-  },
-  "pages": {
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -114,7 +114,9 @@
       "WhatAreYouWaitingFor": "Чего вы ждёте?",
       "GetStartedAndStartBuildingAwesomeUI": "Начните и создавайте потрясающий интерфейс",
       "GetStarted": "Начать"
-    },
+    }
+  },
+  "pages": {
     "profile": {
       "title": "Профиль",
       "subtitle": "Просматривайте и управляйте своей личной информацией.",
@@ -149,9 +151,7 @@
       "stats": {
         "title": "Краткая статистика"
       }
-    }
-  },
-  "pages": {
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",


### PR DESCRIPTION
## Summary
- move the profile translations in Spanish, Italian, and Russian locales under the `pages.profile` key
- remove the now-unused `page.profile` entries so the key path matches other locales

## Testing
- node <<'NODE'
const fs = require('fs');
['es','it','ru','en'].forEach(l=>{
  JSON.parse(fs.readFileSync(`i18n/locales/${l}.json`,'utf8'));
});
console.log('ok');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d5dcb487d88326866434b0f9a92e67