### PR TITLE
refactor: remove ObjectValues export

### DIFF
--- a/content/1.getting-started/2.installation.md
+++ b/content/1.getting-started/2.installation.md
@@ -207,8 +207,6 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-export type ObjectValues<T> = T[keyof T];
 ```
 
 ::alert{type="success" icon="lucide:circle-check"}

--- a/content/1.getting-started/3.contribution.md
+++ b/content/1.getting-started/3.contribution.md
@@ -191,7 +191,7 @@ const ComponentNameDirection = { Top: 'top'} as const
 enum COMPONENT_NAME_DIRECTION_WRONG = { Top = 'top'};
 
 // DO ✅
-import type { ObjectValues } from "@/lib/utils";
+type ObjectValues<T> = T[keyof T];
 export const COMPONENT_NAME_DIRECTION = { Top: 'top', Bottom: 'bottom'} as const
 
 //Types and Interfaces should use CamelCase to differentiate them from constants and variables.

--- a/content/zh-cn/1.getting-started/2.installation.md
+++ b/content/zh-cn/1.getting-started/2.installation.md
@@ -207,8 +207,6 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
-
-export type ObjectValues<T> = T[keyof T];
 ```
 
 ::alert{type="success" icon="lucide:circle-check"}

--- a/content/zh-cn/1.getting-started/3.contribution.md
+++ b/content/zh-cn/1.getting-started/3.contribution.md
@@ -195,7 +195,7 @@ const ComponentNameDirection = { Top: 'top'} as const
 enum COMPONENT_NAME_DIRECTION_WRONG = { Top = 'top'};
 
 // DO ✅
-import type { ObjectValues } from "@/lib/utils";
+type ObjectValues<T> = T[keyof T];
 export const COMPONENT_NAME_DIRECTION = { Top: 'top', Bottom: 'bottom'} as const
 
 //Types and Interfaces should use CamelCase to differentiate them from constants and variables.

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,4 +5,3 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export type ObjectValues<T> = T[keyof T];


### PR DESCRIPTION
## Summary
- remove the unused `ObjectValues` type export from `lib/utils`
- update English and Chinese installation docs to only mention the `cn` helper
- adjust contribution guide snippets to define `ObjectValues` locally in the example

## Testing
- `pnpm lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dcc71edc83269c5d71b34713a623