### PR TITLE
Add Mercure token support

### DIFF
--- a/lib/mercure/client.ts
+++ b/lib/mercure/client.ts
@@ -1,0 +1,103 @@
+const PRIVATE_TOPIC_PATTERNS = [
+  /^user\/[^/]+\/presence$/i,
+  /^chat\/conversation\/[^/]+$/i,
+]
+
+function normalizeTopic(raw: string): string {
+  const trimmed = raw.trim()
+
+  if (!trimmed) {
+    return ''
+  }
+
+  try {
+    const url = new URL(trimmed)
+    return url.pathname.replace(/^\/+/, '')
+  } catch {
+    return trimmed.replace(/^\/+/, '').split('?')[0] ?? ''
+  }
+}
+
+export function topicRequiresMercureToken(topic: string): boolean {
+  const normalized = normalizeTopic(topic)
+
+  return PRIVATE_TOPIC_PATTERNS.some((pattern) => pattern.test(normalized))
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  return Array.from(headers.entries()).reduce<Record<string, string>>((acc, [key, value]) => {
+    acc[key] = value
+    return acc
+  }, {})
+}
+
+export interface MercureRequestOptions {
+  hubUrl: string
+  topics: string[]
+  token?: string | null
+  init?: RequestInit
+  baseUrl?: string
+}
+
+export interface MercureRequestConfig {
+  url: string
+  init: RequestInit
+}
+
+function resolveBaseUrl(options: MercureRequestOptions): string | undefined {
+  if (options.baseUrl) {
+    return options.baseUrl
+  }
+
+  if (import.meta.client && typeof window !== 'undefined') {
+    return window.location.origin
+  }
+
+  return undefined
+}
+
+export function buildMercureRequest(options: MercureRequestOptions): MercureRequestConfig {
+  const { hubUrl, topics, token, init } = options
+
+  if (!hubUrl) {
+    throw new Error('A Mercure hub URL is required.')
+  }
+
+  const baseUrl = resolveBaseUrl(options)
+  const url = baseUrl ? new URL(hubUrl, baseUrl) : new URL(hubUrl)
+  const requiresToken = topics.some(topicRequiresMercureToken)
+
+  topics.forEach((topic) => {
+    if (topic) {
+      url.searchParams.append('topic', topic)
+    }
+  })
+
+  const headers = new Headers(init?.headers ?? {})
+
+  if (requiresToken) {
+    if (!token) {
+      throw new Error('A Mercure subscribe token is required for private topics.')
+    }
+
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  const headerEntries = Array.from(headers.entries())
+  const resolvedInit: RequestInit = {
+    ...init,
+  }
+
+  if (headerEntries.length > 0) {
+    resolvedInit.headers = headersToObject(headers)
+  }
+
+  if (requiresToken && !resolvedInit.credentials) {
+    resolvedInit.credentials = 'include'
+  }
+
+  return {
+    url: url.toString(),
+    init: resolvedInit,
+  }
+}

--- a/server/api/mercure/token.get.ts
+++ b/server/api/mercure/token.get.ts
@@ -1,0 +1,74 @@
+import { createError } from 'h3'
+import type { FetchError } from 'ofetch'
+import { joinURL } from 'ufo'
+import type { MercureTokenEnvelope } from '~/types/mercure'
+import { withAuthHeaders } from '~/server/utils/auth/session'
+
+function sanitizeBaseEndpoint(raw: string): string {
+  return raw.replace(/\/$/, '')
+}
+
+function isFetchError(error: unknown): error is FetchError<unknown> {
+  return Boolean(error && typeof error === 'object' && 'response' in error)
+}
+
+function resolveErrorMessage(payload: unknown): string | undefined {
+  if (payload && typeof payload === 'object') {
+    const maybeMessage = (payload as { message?: unknown }).message
+
+    if (typeof maybeMessage === 'string' && maybeMessage.trim()) {
+      return maybeMessage
+    }
+  }
+
+  return undefined
+}
+
+export default defineEventHandler(async (event) => {
+  const runtimeConfig = useRuntimeConfig(event)
+  const baseEndpoint = sanitizeBaseEndpoint(runtimeConfig.auth?.apiBase ?? 'https://bro-world.org/api')
+  const endpoint = joinURL(baseEndpoint, '/v1/mercure/token')
+
+  try {
+    const response = await $fetch<MercureTokenEnvelope>(endpoint, {
+      method: 'GET',
+      headers: withAuthHeaders(event),
+    })
+
+    if (!response?.token) {
+      throw createError({
+        statusCode: 502,
+        statusMessage: 'Invalid Mercure token response.',
+      })
+    }
+
+    return response
+  } catch (error) {
+    if (isFetchError(error)) {
+      const status = error.response?.status ?? 502
+      const message = resolveErrorMessage(error.data) ?? 'Unable to mint Mercure token.'
+
+      if (status === 401 || status === 403) {
+        throw createError({
+          statusCode: status,
+          statusMessage: 'Unauthorized Mercure token request',
+          data: { message },
+        })
+      }
+
+      throw createError({
+        statusCode: 502,
+        statusMessage: 'Mercure token service unavailable',
+        data: { message },
+      })
+    }
+
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Unexpected Mercure token error',
+      data: {
+        message: error instanceof Error ? error.message : 'Unable to mint Mercure token.',
+      },
+    })
+  }
+})

--- a/types/mercure.ts
+++ b/types/mercure.ts
@@ -1,0 +1,13 @@
+export interface MercureTokenEnvelope {
+  token: string
+  expiresAt?: string | null
+  expiresIn?: number | null
+}
+
+export interface MercureTokenState {
+  token: string
+  /**
+   * Unix timestamp (ms) at which the token expires. `null` when unknown.
+   */
+  expiresAt: number | null
+}


### PR DESCRIPTION
## Summary
- add a Nuxt server endpoint that proxies Mercure token minting through the Symfony API while forwarding the session JWT
- extend the auth session store to cache, refresh, and expose the Mercure subscribe token alongside the current session state
- introduce a Mercure request helper that injects the subscribe token for private presence and chat topics

## Testing
- pnpm eslint server/api/mercure/token.get.ts stores/auth-session.ts lib/mercure/client.ts types/mercure.ts
- pnpm lint *(fails: repository currently contains unrelated lint errors)*
- pnpm test:unit *(fails: TypeError: Unknown file extension ".css" for Vuetify components in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ed6387608326a1ebfe255654d355