### PR TITLE
Add Mercure SSE polyfill plugin

### DIFF
--- a/composables/useMercure.ts
+++ b/composables/useMercure.ts
@@ -1,0 +1,11 @@
+import type { MercureConnectionOptions, MercureEventSourceFactory } from "~/types/mercure";
+
+export function useMercure(): MercureEventSourceFactory {
+  const { $mercure } = useNuxtApp();
+
+  function connect(url: string, options?: MercureConnectionOptions) {
+    return $mercure(url, options);
+  }
+
+  return connect;
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@uiw/color-convert": "^2.8.0",
     "@vueuse/core": "^13.9.0",
     "canvas-confetti": "^1.9.3",
+    "event-source-polyfill": "^1.0.35",
     "chartjs-adapter-date-fns": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "cobe": "^0.6.4",

--- a/plugins/event-source.client.ts
+++ b/plugins/event-source.client.ts
@@ -1,0 +1,54 @@
+import { EventSourcePolyfill } from "event-source-polyfill";
+import type { MercureConnectionOptions, MercureQueryValue } from "~/types/mercure";
+
+function appendQueryValue(params: URLSearchParams, key: string, value: MercureQueryValue) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => {
+      if (item === null || item === undefined) {
+        return;
+      }
+
+      params.append(key, String(item));
+    });
+
+    return;
+  }
+
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  params.append(key, String(value));
+}
+
+function createMercureEventSource(input: string, options: MercureConnectionOptions = {}): EventSource {
+  const { token, params, init } = options;
+  const url = new URL(input, window.location.href);
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      appendQueryValue(url.searchParams, key, value);
+    });
+  }
+
+  const headers = new Headers(init?.headers ?? {});
+
+  if (token) {
+    headers.set("Authorization", token.startsWith("Bearer ") ? token : `Bearer ${token}`);
+  }
+
+  return new EventSourcePolyfill(url.toString(), {
+    ...(init ?? {}),
+    headers,
+  });
+}
+
+export default defineNuxtPlugin(() => {
+  window.EventSource = EventSourcePolyfill as unknown as typeof window.EventSource;
+
+  return {
+    provide: {
+      mercure: createMercureEventSource,
+    },
+  };
+});

--- a/types/mercure.ts
+++ b/types/mercure.ts
@@ -1,0 +1,22 @@
+import type { EventSourcePolyfillInit } from "event-source-polyfill";
+
+type Primitive = string | number | boolean | null | undefined;
+
+export type MercureQueryValue = Primitive | Primitive[];
+
+export interface MercureConnectionOptions {
+  /**
+   * Bearer token used to authenticate against the Mercure hub.
+   */
+  token?: string;
+  /**
+   * Extra query string parameters appended to the connection URL.
+   */
+  params?: Record<string, MercureQueryValue>;
+  /**
+   * Additional EventSource configuration forwarded to the polyfill.
+   */
+  init?: EventSourcePolyfillInit;
+}
+
+export type MercureEventSourceFactory = (url: string, options?: MercureConnectionOptions) => EventSource;

--- a/types/nuxt.d.ts
+++ b/types/nuxt.d.ts
@@ -1,9 +1,11 @@
 import type { AlertMessage } from "~/types/alert-panel";
+import type { MercureEventSourceFactory } from "~/types/mercure";
 
 declare module "#app" {
   interface NuxtApp {
     $notify: (alert: AlertMessage) => string;
     $clearAlerts: () => void;
+    $mercure: MercureEventSourceFactory;
   }
 }
 
@@ -11,6 +13,7 @@ declare module "vue" {
   interface ComponentCustomProperties {
     $notify: (alert: AlertMessage) => string;
     $clearAlerts: () => void;
+    $mercure: MercureEventSourceFactory;
   }
 }
 


### PR DESCRIPTION
## Summary
- add the `event-source-polyfill` dependency so Mercure connections can set custom headers
- register a client-only plugin that assigns the polyfill to `window.EventSource` and exposes a factory on the Nuxt app
- provide a `useMercure` composable and shared types so future chat or presence features can create authenticated SSE subscriptions

## Testing
- `pnpm lint` *(fails: repository currently has pre-existing lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ed506f408326b2ba8315e464102a