### PR TITLE
Integrate sliding right sidebar

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -314,7 +314,7 @@
         type="button"
         :class="iconTriggerClasses"
         :aria-label="t('layout.actions.openWidgets')"
-        @click="emit('toggle-right')"
+        @click="emit('toggle-right', $event)"
       >
         <v-icon
           icon="mdi-dots-vertical"

--- a/components/layout/RightSidebar.vue
+++ b/components/layout/RightSidebar.vue
@@ -179,7 +179,7 @@ function closeDrawer(options: { returnFocus?: boolean } = {}) {
   previousFocus.value = null;
 }
 
-function toggleDrawer(trigger: HTMLElement | null) {
+function toggleDrawer(trigger?: HTMLElement | null) {
   if (isDrawerOpen.value) {
     closeDrawer({ returnFocus: true });
     return;
@@ -348,5 +348,11 @@ onBeforeUnmount(() => {
   lastTrigger.value = null;
   previousFocus.value = null;
   lastTouchPoint.value = null;
+});
+
+defineExpose({
+  openDrawer,
+  closeDrawer,
+  toggleDrawer,
 });
 </script>


### PR DESCRIPTION
## Summary
- replace the Vuetify drawer widgets with the dedicated `RightSidebar` component in the default layout
- expose control methods from `RightSidebar` and wire the top bar button so the drawer can be toggled on mobile
- clean up unused styles and close the sidebar automatically when layouts or routes change

## Testing
- pnpm lint *(fails: ESLint requires generated .nuxt/eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68d69604d76c8326ad6c8ab03a42d7b1