### PR TITLE
Align right sidebar breakpoints with layout

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -314,7 +314,7 @@
         type="button"
         :class="iconTriggerClasses"
         :aria-label="t('layout.actions.openWidgets')"
-        @click="emit('toggle-right')"
+        @click="emit('toggle-right', $event)"
       >
         <v-icon
           icon="mdi-dots-vertical"

--- a/components/layout/RightSidebar.vue
+++ b/components/layout/RightSidebar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="hidden h-full flex-col md:flex">
+  <div class="hidden h-full flex-col xl:flex">
     <UiScrollArea
       orientation="vertical"
       type="hover"
@@ -52,70 +52,18 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { useEventListener, useMediaQuery } from "@vueuse/core";
 
 import RightSidebarContent from "~/components/layout/RightSidebarContent.vue";
-import type {
-  SidebarLeaderboardData,
-  SidebarLeaderboardParticipant,
-  SidebarLeaderboardRaw,
-  SidebarRatingData,
-  SidebarRatingRaw,
-  SidebarWeatherData,
-} from "~/components/layout/right-sidebar.types";
+import { useRightSidebarData } from "~/composables/useRightSidebarData";
 
-const { tm } = useI18n();
 const route = useRoute();
 
-const weather = computed(() => tm("sidebar.weather") as SidebarWeatherData);
-
-const leaderboard = computed<SidebarLeaderboardData>(() => {
-  const raw = tm("sidebar.leaderboard") as SidebarLeaderboardRaw | undefined;
-  const order: Array<keyof NonNullable<SidebarLeaderboardRaw["participants"]>> = [
-    "first",
-    "second",
-    "third",
-  ];
-
-  const participants = order
-    .map((key, index) => {
-      const participant = raw?.participants?.[key];
-
-      if (!participant) {
-        return null;
-      }
-
-      return {
-        position: index + 1,
-        ...participant,
-      } satisfies SidebarLeaderboardParticipant;
-    })
-    .filter((participant): participant is SidebarLeaderboardParticipant => Boolean(participant));
-
-  return {
-    title: raw?.title ?? "",
-    live: raw?.live ?? "",
-    participants,
-  };
-});
-
-const rating = computed<SidebarRatingData>(() => {
-  const raw = tm("sidebar.rating") as SidebarRatingRaw;
-
-  return {
-    title: raw.title ?? "",
-    subtitle: raw.subtitle ?? "",
-    average: raw.average ?? "",
-    total: raw.total ?? 0,
-    icon: raw.icon ?? "",
-    stars: raw.stars ?? 0,
-    categories: Object.values(raw.categories ?? {}),
-  };
-});
+const { weather, leaderboard, rating } = useRightSidebarData();
 
 const isDesktop = import.meta.client
-  ? useMediaQuery("(min-width: 768px)")
+  ? useMediaQuery("(min-width: 1280px)")
   : ref(true);
 
 const isDrawerOpen = ref(false);
@@ -179,7 +127,7 @@ function closeDrawer(options: { returnFocus?: boolean } = {}) {
   previousFocus.value = null;
 }
 
-function toggleDrawer(trigger: HTMLElement | null) {
+function toggleDrawer(trigger?: HTMLElement | null) {
   if (isDrawerOpen.value) {
     closeDrawer({ returnFocus: true });
     return;
@@ -348,5 +296,11 @@ onBeforeUnmount(() => {
   lastTrigger.value = null;
   previousFocus.value = null;
   lastTouchPoint.value = null;
+});
+
+defineExpose({
+  openDrawer,
+  closeDrawer,
+  toggleDrawer,
 });
 </script>

--- a/composables/useRightSidebarData.ts
+++ b/composables/useRightSidebarData.ts
@@ -1,0 +1,61 @@
+import { computed } from 'vue'
+import type {
+  SidebarLeaderboardData,
+  SidebarLeaderboardParticipant,
+  SidebarLeaderboardRaw,
+  SidebarRatingData,
+  SidebarRatingRaw,
+  SidebarWeatherData,
+} from '@/components/layout/right-sidebar.types'
+
+export function useRightSidebarData() {
+  const { tm } = useI18n()
+
+  const weather = computed(() => tm('sidebar.weather') as SidebarWeatherData)
+
+  const leaderboard = computed<SidebarLeaderboardData>(() => {
+    const raw = tm('sidebar.leaderboard') as SidebarLeaderboardRaw | undefined
+    const order: Array<keyof NonNullable<SidebarLeaderboardRaw['participants']>> = [
+      'first',
+      'second',
+      'third',
+    ]
+
+    const participants = order
+      .map((key, index) => {
+        const participant = raw?.participants?.[key]
+
+        if (!participant) {
+          return null
+        }
+
+        return {
+          position: index + 1,
+          ...participant,
+        } satisfies SidebarLeaderboardParticipant
+      })
+      .filter((participant): participant is SidebarLeaderboardParticipant => Boolean(participant))
+
+    return {
+      title: raw?.title ?? '',
+      live: raw?.live ?? '',
+      participants,
+    }
+  })
+
+  const rating = computed<SidebarRatingData>(() => {
+    const raw = tm('sidebar.rating') as SidebarRatingRaw
+
+    return {
+      title: raw.title ?? '',
+      subtitle: raw.subtitle ?? '',
+      average: raw.average ?? '',
+      total: raw.total ?? 0,
+      icon: raw.icon ?? '',
+      stars: raw.stars ?? 0,
+      categories: Object.values(raw.categories ?? {}),
+    }
+  })
+
+  return { weather, leaderboard, rating }
+}


### PR DESCRIPTION
## Summary
- update the right sidebar rail to only display on xl screens so it matches the layout grid visibility
- align the drawer breakpoint with the layout (>=1280px) so the mobile slide-over is available on tablet widths

## Testing
- pnpm lint *(fails: corepack cannot download pnpm in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69604d76c8326ad6c8ab03a42d7b1