### PR TITLE
Animate right sidebar vertically

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -314,7 +314,7 @@
         type="button"
         :class="iconTriggerClasses"
         :aria-label="t('layout.actions.openWidgets')"
-        @click="emit('toggle-right')"
+        @click="emit('toggle-right', $event)"
       >
         <v-icon
           icon="mdi-dots-vertical"

--- a/composables/useRightSidebarData.ts
+++ b/composables/useRightSidebarData.ts
@@ -1,0 +1,61 @@
+import { computed } from 'vue'
+import type {
+  SidebarLeaderboardData,
+  SidebarLeaderboardParticipant,
+  SidebarLeaderboardRaw,
+  SidebarRatingData,
+  SidebarRatingRaw,
+  SidebarWeatherData,
+} from '@/components/layout/right-sidebar.types'
+
+export function useRightSidebarData() {
+  const { tm } = useI18n()
+
+  const weather = computed(() => tm('sidebar.weather') as SidebarWeatherData)
+
+  const leaderboard = computed<SidebarLeaderboardData>(() => {
+    const raw = tm('sidebar.leaderboard') as SidebarLeaderboardRaw | undefined
+    const order: Array<keyof NonNullable<SidebarLeaderboardRaw['participants']>> = [
+      'first',
+      'second',
+      'third',
+    ]
+
+    const participants = order
+      .map((key, index) => {
+        const participant = raw?.participants?.[key]
+
+        if (!participant) {
+          return null
+        }
+
+        return {
+          position: index + 1,
+          ...participant,
+        } satisfies SidebarLeaderboardParticipant
+      })
+      .filter((participant): participant is SidebarLeaderboardParticipant => Boolean(participant))
+
+    return {
+      title: raw?.title ?? '',
+      live: raw?.live ?? '',
+      participants,
+    }
+  })
+
+  const rating = computed<SidebarRatingData>(() => {
+    const raw = tm('sidebar.rating') as SidebarRatingRaw
+
+    return {
+      title: raw.title ?? '',
+      subtitle: raw.subtitle ?? '',
+      average: raw.average ?? '',
+      total: raw.total ?? 0,
+      icon: raw.icon ?? '',
+      stars: raw.stars ?? 0,
+      categories: Object.values(raw.categories ?? {}),
+    }
+  })
+
+  return { weather, leaderboard, rating }
+}


### PR DESCRIPTION
## Summary
- make the mobile right sidebar drawer slide on the Y axis with focus-safe pointer-event handling so it appears separately from the content
- lift the desktop right rail with a subtle translate-y transition to match the requested vertical offset

## Testing
- pnpm lint *(fails: Corepack cannot download pnpm due to proxy 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69604d76c8326ad6c8ab03a42d7b1