### PR TITLE
Adjust layout to show community sidebar on the left

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -36,9 +36,9 @@
       <div class="app-container">
         <div
           class="layout-grid"
-          :class="{ 'layout-grid--no-right': !showRightWidgets }"
+          :class="layoutGridClasses"
         >
-          <div v-if="!isMobile" class="layout-sidebar">
+          <div v-if="showPrimarySidebar" class="layout-sidebar">
             <AppSidebar
               :items="sidebarItems"
               :active-key="activeSidebar"
@@ -120,6 +120,13 @@ const isMobile = computed(() => !display.mdAndUp.value)
 
 const isDark = computed(() => theme.global.current.value.dark)
 const showRightWidgets = computed(() => route.meta?.showRightWidgets !== false)
+const showPrimarySidebar = computed(
+  () => !isMobile.value && !showRightWidgets.value,
+)
+const layoutGridClasses = computed(() => ({
+  'layout-grid--with-sidebar': showPrimarySidebar.value,
+  'layout-grid--with-widgets': showRightWidgets.value,
+}))
 const showInlineRightWidgets = computed(
   () => showRightWidgets.value && !isDesktop.value && !isMobile.value,
 )
@@ -241,47 +248,18 @@ const currentYear = new Date().getFullYear()
   display: grid;
   gap: 24px;
   grid-template-columns: minmax(0, 1fr);
+  grid-template-areas:
+    "content";
 }
 
 .layout-sidebar {
   display: none;
+  grid-area: sidebar;
 }
 
 .layout-right-rail {
   display: none;
-}
-
-.layout-grid--no-right {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-@media (min-width: 768px) {
-  .layout-sidebar {
-    display: block;
-  }
-
-  .layout-grid {
-    grid-template-columns: 320px minmax(0, 1fr);
-  }
-
-  .layout-grid--no-right {
-    grid-template-columns: 320px minmax(0, 1fr);
-  }
-
-}
-
-@media (min-width: 1280px) {
-  .layout-right-rail {
-    display: block;
-  }
-
-  .layout-grid {
-    grid-template-columns: 320px minmax(0, 1fr) 320px;
-  }
-
-  .layout-grid--no-right {
-    grid-template-columns: 320px minmax(0, 1fr);
-  }
+  grid-area: widgets;
 }
 
 .content-area {
@@ -289,22 +267,33 @@ const currentYear = new Date().getFullYear()
   border-radius: 32px;
   background: transparent;
   padding-top: 8px;
-  grid-column: 1 / -1;
+  grid-area: content;
 }
 
 @media (min-width: 768px) {
-  .content-area {
-    grid-column: 2 / 3;
+  .layout-grid--with-sidebar {
+    grid-template-columns: 320px minmax(0, 1fr);
+    grid-template-areas: "sidebar content";
   }
 
-  .layout-grid--no-right .content-area {
-    grid-column: 2 / 3;
+  .layout-grid--with-sidebar .layout-sidebar {
+    display: block;
   }
 }
 
 @media (min-width: 1280px) {
-  .layout-grid--no-right .content-area {
-    grid-column: 2 / 3;
+  .layout-grid--with-widgets {
+    grid-template-columns: 320px minmax(0, 1fr);
+    grid-template-areas: "widgets content";
+  }
+
+  .layout-grid--with-widgets .layout-right-rail {
+    display: block;
+  }
+
+  .layout-grid--with-widgets.layout-grid--with-sidebar {
+    grid-template-columns: 320px minmax(0, 1fr) 320px;
+    grid-template-areas: "widgets content sidebar";
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- update the default layout grid so the community widgets sidebar renders on the left for large screens
- compute layout classes to avoid duplicating the main navigation when the widgets sidebar is visible
- refresh scoped styles to use grid areas for cleaner responsive positioning

## Testing
- pnpm install *(fails: unable to download pnpm-10.8.0.tgz due to proxy restrictions)*
- npm install *(fails: registry returned 403 for zod)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a491aa5483269f5d0b503364da32