### PR TITLE
Rework layout drawers for dual sidebar experience

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -198,6 +198,30 @@
 
     <div class="flex items-center gap-1">
       <button
+        v-if="!isMobile"
+        type="button"
+        :class="iconTriggerClasses"
+        :aria-label="t('layout.actions.openNavigation')"
+        @click="emit('toggle-left')"
+      >
+        <v-icon
+          icon="mdi-view-sidebar"
+          size="22"
+        />
+      </button>
+      <button
+        v-if="!isMobile && props.showRightToggle"
+        type="button"
+        :class="iconTriggerClasses"
+        :aria-label="t('layout.actions.openWidgets')"
+        @click="emit('toggle-right')"
+      >
+        <v-icon
+          icon="mdi-view-sidebar-right"
+          size="22"
+        />
+      </button>
+      <button
         v-if="!config.header.darkModeToggle"
         type="button"
         :class="iconTriggerClasses"
@@ -310,11 +334,11 @@
         </v-list>
       </v-menu>
       <button
-        v-if="isMobile"
+        v-if="isMobile && props.showRightToggle"
         type="button"
         :class="iconTriggerClasses"
         :aria-label="t('layout.actions.openWidgets')"
-        @click="emit('toggle-right', $event)"
+        @click="emit('toggle-right')"
       >
         <v-icon
           icon="mdi-dots-vertical"
@@ -356,6 +380,7 @@ const props = defineProps<{
   isMobile: boolean
   locale: string
   locales: string[]
+  showRightToggle: boolean
 }>()
 
 const emit = defineEmits([


### PR DESCRIPTION
## Summary
- replace the previous grid-based layout with Vuetify navigation drawers so the navigation rail and community widgets stay visible while offering independent scroll areas
- synchronize drawer state with breakpoint watchers so mobile views close both panels while desktop keeps them pinned unless toggled off
- update the top bar controls to expose left and right sidebar toggles on larger screens and hide the widget trigger when the right rail is unavailable

## Testing
- not run (dependency installation restricted)


------
https://chatgpt.com/codex/tasks/task_e_68d6a491aa5483269f5d0b503364da32