### PR TITLE
fix: rename auth session helper to avoid h3 conflict

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -2,7 +2,7 @@ import { createError, readBody } from 'h3'
 import type { FetchError } from 'ofetch'
 import { joinURL } from 'ufo'
 import type { AuthLoginResponse, AuthUser } from '~/types/auth'
-import { clearSession, setSession } from '~/server/utils/auth/session'
+import { clearAuthSession, setSession } from '~/server/utils/auth/session'
 
 interface LoginRequestBody {
   identifier?: string
@@ -77,7 +77,7 @@ export default defineEventHandler(async (event) => {
         })
       }
 
-      clearSession(event)
+      clearAuthSession(event)
 
       throw createError({
         statusCode: 502,
@@ -88,7 +88,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    clearSession(event)
+    clearAuthSession(event)
 
     throw createError({
       statusCode: 500,

--- a/server/api/auth/logout.post.ts
+++ b/server/api/auth/logout.post.ts
@@ -1,7 +1,7 @@
-import { clearSession } from '~/server/utils/auth/session'
+import { clearAuthSession } from '~/server/utils/auth/session'
 
 export default defineEventHandler(async (event) => {
-  clearSession(event)
+  clearAuthSession(event)
 
   return {
     success: true,

--- a/server/api/auth/session.get.ts
+++ b/server/api/auth/session.get.ts
@@ -1,4 +1,4 @@
-import { clearSession, getSessionToken, getSessionUser } from '~/server/utils/auth/session'
+import { clearAuthSession, getSessionToken, getSessionUser } from '~/server/utils/auth/session'
 import type { AuthSessionEnvelope } from '~/types/auth'
 
 export default defineEventHandler(async (event) => {
@@ -7,7 +7,7 @@ export default defineEventHandler(async (event) => {
 
   if (!token) {
     if (user) {
-      clearSession(event)
+      clearAuthSession(event)
     }
 
     const response: AuthSessionEnvelope = {

--- a/server/utils/auth/session.ts
+++ b/server/utils/auth/session.ts
@@ -79,7 +79,7 @@ export function setSession(event: H3Event, token: string, user: AuthUser) {
   })
 }
 
-export function clearSession(event: H3Event) {
+export function clearAuthSession(event: H3Event) {
   const { tokenCookieName, userCookieName, tokenPresenceCookieName } = resolveCookiesConfig(event)
 
   deleteCookie(event, tokenCookieName, { path: '/' })


### PR DESCRIPTION
## Summary
- rename the server-side session clearing helper to avoid conflicting with h3 auto-imports
- update auth API handlers to call the renamed helper

## Testing
- pnpm lint *(fails: network proxy blocked the pnpm download)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cb37381c83269641cea29b078926