### PR TITLE
Remove NuxtLayout wrapper from app root

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -3,9 +3,7 @@
     :color="false"
     class="z-100 bg-primary/80"
   />
-  <NuxtLayout>
-    <NuxtPage />
-  </NuxtLayout>
+  <NuxtPage />
   <AlertPanel />
 </template>
 


### PR DESCRIPTION
## Summary
- render the root app component with <NuxtPage /> so layouts are chosen per page
- rely on the default layout for the application chrome instead of wrapping everything globally

## Testing
- not run (pnpm fails to download in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6cc66112883268f4cdceda66acf6c