### PR TITLE
Rename blog post and comment cards to unique components

### DIFF
--- a/components/blog/BlogCommentCard.vue
+++ b/components/blog/BlogCommentCard.vue
@@ -61,6 +61,10 @@ import type { BlogCommentPreview } from "~/lib/mock/blog";
 
 import { computed } from "vue";
 
+defineOptions({
+  name: "BlogCommentCard",
+});
+
 const props = defineProps<{ comment: BlogCommentPreview }>();
 
 const defaultAvatar = "https://bro-world-space.com/img/person.png";

--- a/components/blog/BlogPostCard.vue
+++ b/components/blog/BlogPostCard.vue
@@ -72,7 +72,7 @@
           </p>
         </div>
         <div class="mx-auto mt-4 w-full max-w-2xl space-y-3">
-          <CommentCard
+          <BlogCommentCard
             v-for="comment in post.comments_preview.slice(0, 4)"
             :key="comment.id"
             :comment="comment"
@@ -108,11 +108,15 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import CommentCard from "./CommentCard.vue";
+import BlogCommentCard from "./BlogCommentCard.vue";
 import PostMeta from "./PostMeta.vue";
 import type { BlogPost, ReactionType } from "~/lib/mock/blog";
 
 const props = defineProps<{ post: BlogPost }>();
+
+defineOptions({
+  name: "BlogPostCard",
+});
 
 const defaultAvatar = "https://bro-world-space.com/img/person.png";
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -106,7 +106,7 @@
       </form>
 
       <div class="flex flex-col gap-4">
-        <PostCard
+        <BlogPostCard
             v-for="post in posts"
             :key="post.id"
             :post="post"


### PR DESCRIPTION
## Summary
- rename the blog comment card component and give it an explicit name to avoid duplication
- rename the blog post card component and update its usage to the new name

## Testing
- pnpm dev *(fails: network error downloading pnpm via corepack)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cc64ecd48326b8eba8c64598929e