### PR TITLE
Fix icon cache serialization for Nuxt SSR

### DIFF
--- a/components/Icon.vue
+++ b/components/Icon.vue
@@ -55,11 +55,22 @@ async function resolveIcon(name: string) {
   }
 
   try {
-    const svg = await $fetch<string>(`https://api.iconify.design/${name}.svg`)
-    iconCache.value[name] = svg
+    const svg = await $fetch<string>(`https://api.iconify.design/${name}.svg`, {
+      responseType: 'text',
+      parseResponse: (text) => text,
+    })
+
+    iconCache.value = {
+      ...iconCache.value,
+      [name]: typeof svg === 'string' ? svg : String(svg),
+    }
   } catch (error) {
     console.warn(`Unable to load icon "${name}":`, error)
-    iconCache.value[name] = null
+
+    iconCache.value = {
+      ...iconCache.value,
+      [name]: null,
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure the custom Icon component writes to the shared cache using plain objects
to avoid Nuxt payload serialization failures
- normalize icon fetch responses to plain text before caching to keep SSR safe

## Testing
- pnpm lint *(fails: unable to download pnpm binaries in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d36a5d588326820d75e9a18d94a4