### PR TITLE
feat: add nested sidebar sections

### DIFF
--- a/components/layout/AppSidebarRight.vue
+++ b/components/layout/AppSidebarRight.vue
@@ -31,8 +31,9 @@ const isDark = computed(() => useColorMode().value == "dark");
 interface SidebarItem {
   key: string
   label: string
-  icon: string
-  to: string
+  icon?: string
+  to?: string
+  children?: SidebarItem[]
 }
 
 const props = withDefaults(

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -104,8 +104,17 @@ const appIcons = [
 ]
 
 const sidebarItems = [
-  { key: 'apps', label: 'layout.sidebar.items.apps', icon: 'mdi-apps', to: '/' },
-  { key: 'calendar', label: 'layout.sidebar.items.calendar', icon: 'mdi-calendar-month', to: '/' },
+  {
+    key: 'apps',
+    label: 'layout.sidebar.items.apps',
+    icon: 'mdi-apps',
+    to: '/',
+    children: [
+      { key: 'calendar', label: 'layout.sidebar.items.calendar', icon: 'mdi-calendar-month', to: '/' },
+      { key: 'cv', label: 'layout.sidebar.items.cv', icon: 'mdi-file-account', to: '/' },
+      { key: 'jobs', label: 'layout.sidebar.items.jobs', icon: 'mdi-briefcase-search', to: '/' },
+    ],
+  },
   { key: 'help', label: 'layout.sidebar.items.help', icon: 'mdi-lifebuoy', to: '/help' },
   { key: 'about', label: 'layout.sidebar.items.about', icon: 'mdi-information-outline', to: '/about' },
   { key: 'contact', label: 'layout.sidebar.items.contact', icon: 'mdi-email-outline', to: '/contact' },


### PR DESCRIPTION
## Summary
- restructure the left sidebar component to render grouped parent items with optional children
- add nested calendar, CV, and jobs entries under the Apps parent and style the subnavigation
- relax sidebar item typings so both sidebars accept grouped menu data

## Testing
- pnpm lint *(fails: network restrictions prevented downloading pnpm@10.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d7593aac68832691d63d79c044fbb2