### PR TITLE
feat: support nested sidebar groups

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -5,40 +5,30 @@
     aria-label="Main navigation"
   >
     <nav>
-      <ul class="flex flex-col gap-2">
-        <li v-for="item in items" :key="item.key">
-          <NuxtLink
-            :to="item.to"
-            class="sidebar-item"
-            :class="{ 'sidebar-item--active': item.key === activeKey }"
-            :aria-label="t(item.label)"
-            :aria-current="item.key === activeKey ? 'page' : undefined"
-            @click="emit('select', item.key)"
-          >
-            <div class="flex items-center gap-3">
-              <Icon
-                  :name="resolveIconName(item.icon)"
-                  :size="20"
-              />
-              <span class="text-sm font-medium text-foreground">{{ t(item.label) }}</span>
-            </div>
-            <span class="sr-only">{{ t('layout.sidebar.navigate') }}</span>
-          </NuxtLink>
-        </li>
+      <ul class="flex flex-col gap-3">
+        <AppSidebarNode
+          v-for="item in items"
+          :key="item.key"
+          :item="item"
+          :level="0"
+          :active-key="activeKey"
+          :toggle-group="toggleGroup"
+          :expand-group="expandGroup"
+          :is-group-expanded="isGroupExpanded"
+          :is-item-active="isItemActive"
+          :on-select="handleItemSelect"
+          :resolve-icon-name="resolveIconName"
+        />
       </ul>
     </nav>
   </aside>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 
-interface SidebarItem {
-  key: string
-  label: string
-  icon: string
-  to: string
-}
+import AppSidebarNode from '@/components/layout/AppSidebarNode.vue'
+import type { SidebarItem } from '@/types/sidebar'
 
 const props = withDefaults(
   defineProps<{
@@ -53,7 +43,154 @@ const props = withDefaults(
 
 const sticky = computed(() => props.sticky)
 
-const { t } = useI18n()
+const emit = defineEmits<{ (e: 'select', key: string): void }>()
+
+const expandedGroups = ref(new Set<string>())
+
+watch(
+  () => props.activeKey,
+  (key) => {
+    if (!key)
+      return
+
+    const path = findPath(props.items, key)
+    if (!path)
+      return
+
+    const next = new Set(expandedGroups.value)
+    let updated = false
+
+    for (let index = 0; index < path.length - 1; index += 1) {
+      const groupKey = path[index]
+      if (!next.has(groupKey)) {
+        next.add(groupKey)
+        updated = true
+      }
+    }
+
+    const activeItem = findItemByKey(props.items, key)
+    if (activeItem?.children?.length && !next.has(activeItem.key)) {
+      next.add(activeItem.key)
+      updated = true
+    }
+
+    if (updated)
+      expandedGroups.value = next
+  },
+  { immediate: true },
+)
+
+watch(
+  () => props.items,
+  (items) => {
+    const allowed = new Set<string>()
+    collectKeys(items, allowed)
+
+    const filtered = new Set<string>()
+    let changed = false
+
+    for (const key of expandedGroups.value) {
+      if (allowed.has(key)) {
+        filtered.add(key)
+      } else {
+        changed = true
+      }
+    }
+
+    if (changed)
+      expandedGroups.value = filtered
+  },
+  { deep: true },
+)
+
+function isItemActive(item: SidebarItem, key: string): boolean {
+  if (item.key === key)
+    return true
+
+  if (item.children)
+    return item.children.some(child => isItemActive(child, key))
+
+  return false
+}
+
+function findItemByKey(items: SidebarItem[], key: string): SidebarItem | undefined {
+  for (const item of items) {
+    if (item.key === key)
+      return item
+
+    if (item.children?.length) {
+      const child = findItemByKey(item.children, key)
+      if (child)
+        return child
+    }
+  }
+
+  return undefined
+}
+
+function collectKeys(items: SidebarItem[], target: Set<string>) {
+  for (const item of items) {
+    target.add(item.key)
+    if (item.children?.length)
+      collectKeys(item.children, target)
+  }
+}
+
+function findPath(items: SidebarItem[], key: string, path: string[] = []) {
+  for (const item of items) {
+    const currentPath = [...path, item.key]
+
+    if (item.key === key)
+      return currentPath
+
+    if (item.children?.length) {
+      const childPath = findPath(item.children, key, currentPath)
+      if (childPath)
+        return childPath
+    }
+  }
+
+  return null
+}
+
+function toggleGroup(key: string) {
+  const next = new Set(expandedGroups.value)
+
+  if (next.has(key)) {
+    next.delete(key)
+
+    const item = findItemByKey(props.items, key)
+    if (item?.children?.length) {
+      const descendants = new Set<string>()
+      collectKeys(item.children, descendants)
+
+      for (const childKey of descendants)
+        next.delete(childKey)
+    }
+  } else {
+    next.add(key)
+  }
+
+  expandedGroups.value = next
+}
+
+function expandGroup(key: string) {
+  if (expandedGroups.value.has(key))
+    return
+
+  const next = new Set(expandedGroups.value)
+  next.add(key)
+  expandedGroups.value = next
+}
+
+function isGroupExpanded(key: string) {
+  return expandedGroups.value.has(key)
+}
+
+function handleItemSelect(item: SidebarItem) {
+  emit('select', item.key)
+}
+
 function resolveIconName(name?: string) {
   if (!name)
     return ''
@@ -66,7 +203,6 @@ function resolveIconName(name?: string) {
 
   return name
 }
-const emit = defineEmits<{ (e: 'select', key: string): void }>()
 </script>
 
 <style scoped>
@@ -86,12 +222,23 @@ const emit = defineEmits<{ (e: 'select', key: string): void }>()
   position: sticky;
 }
 
-.sidebar-item {
+.sidebar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar-item { 
   @apply flex items-center justify-between text-left transition;
   padding: 0.75rem 1rem;
   border-radius: calc(var(--radius) + 8px);
   @apply hover:bg-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2;
   --tw-bg-opacity: 0.7;
+}
+
+.sidebar-group:focus-within .sidebar-item {
+  @apply ring-2 ring-primary ring-offset-2;
+  --tw-ring-opacity: 0.7;
 }
 
 .sidebar-item--active {
@@ -110,5 +257,49 @@ const emit = defineEmits<{ (e: 'select', key: string): void }>()
 
 .sidebar-item:focus-visible {
   --tw-ring-opacity: 0.7;
+}
+
+.sidebar-toggle {
+  @apply ml-3 inline-flex h-8 w-8 items-center justify-center rounded-full transition;
+  @apply hover:bg-muted focus-visible:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2;
+  --tw-ring-opacity: 0.7;
+}
+
+.sidebar-toggle-icon {
+  @apply text-muted-foreground transition-transform;
+}
+
+.sidebar-toggle-icon--open {
+  transform: rotate(180deg);
+}
+
+.sidebar-sublist {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-left: var(--sidebar-indent, 3.25rem);
+}
+
+.sidebar-subitem {
+  @apply flex items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-sm transition;
+  color: var(--v-theme-on-surface-variant);
+}
+
+.sidebar-subitem:hover,
+.sidebar-subitem:focus-visible {
+  @apply bg-primary/10 text-foreground;
+}
+
+.sidebar-subitem:focus-visible {
+  @apply outline-none ring-2 ring-primary ring-offset-2;
+  --tw-ring-opacity: 0.7;
+}
+
+.sidebar-subitem--active {
+  @apply bg-primary/15 text-foreground;
+}
+
+.sidebar-subicon {
+  @apply text-muted-foreground;
 }
 </style>

--- a/components/layout/AppSidebarNode.vue
+++ b/components/layout/AppSidebarNode.vue
@@ -1,0 +1,127 @@
+<template>
+  <li :class="['sidebar-group', { 'sidebar-group--nested': level > 0 }]">
+    <component
+      :is="linkTag"
+      v-bind="linkAttrs"
+      :class="linkClasses"
+      :aria-label="ariaLabel"
+      :aria-current="ariaCurrent"
+      @click="handleClick"
+    >
+      <div class="flex items-center gap-3">
+        <Icon
+          v-if="item.icon"
+          :class="iconClass"
+          :name="resolveIconName(item.icon)"
+          :size="iconSize"
+        />
+        <span :class="labelClass">{{ itemLabel }}</span>
+      </div>
+      <button
+        v-if="hasChildren"
+        type="button"
+        class="sidebar-toggle"
+        :aria-controls="`sidebar-group-${item.key}`"
+        :aria-expanded="isExpanded"
+        @click.stop="handleToggle"
+      >
+        <Icon
+          class="sidebar-toggle-icon"
+          name="mdi:chevron-down"
+          :class="{ 'sidebar-toggle-icon--open': isExpanded }"
+        />
+        <span class="sr-only">{{ navigateLabel }}</span>
+      </button>
+      <span v-else-if="item.to" class="sr-only">{{ navigateLabel }}</span>
+    </component>
+
+    <ul
+      v-if="hasChildren"
+      :id="`sidebar-group-${item.key}`"
+      class="sidebar-sublist"
+      :style="indentStyle"
+      v-show="isExpanded"
+    >
+      <AppSidebarNode
+        v-for="child in item.children"
+        :key="child.key"
+        :item="child"
+        :level="level + 1"
+        :active-key="activeKey"
+        :toggle-group="toggleGroup"
+        :expand-group="expandGroup"
+        :is-group-expanded="isGroupExpanded"
+        :is-item-active="isItemActive"
+        :on-select="onSelect"
+        :resolve-icon-name="resolveIconName"
+      />
+    </ul>
+  </li>
+</template>
+
+<script setup lang="ts">
+defineOptions({ name: 'AppSidebarNode' })
+
+import { computed } from 'vue'
+
+import type { SidebarItem } from '@/types/sidebar'
+
+const props = defineProps<{
+  item: SidebarItem
+  level: number
+  activeKey: string
+  toggleGroup: (key: string) => void
+  expandGroup: (key: string) => void
+  isGroupExpanded: (key: string) => boolean
+  isItemActive: (item: SidebarItem, key: string) => boolean
+  onSelect: (item: SidebarItem) => void
+  resolveIconName: (name?: string) => string
+}>()
+
+const { t } = useI18n()
+
+const hasChildren = computed(() => Boolean(props.item.children?.length))
+const isExpanded = computed(() => hasChildren.value && props.isGroupExpanded(props.item.key))
+const isActive = computed(() => props.isItemActive(props.item, props.activeKey))
+const navigateLabel = computed(() => t('layout.sidebar.navigate'))
+const itemLabel = computed(() => t(props.item.label))
+const linkTag = computed(() => (props.item.to ? 'NuxtLink' : 'button'))
+const linkAttrs = computed(() => (props.item.to ? { to: props.item.to } : { type: 'button' }))
+const ariaLabel = computed(() => itemLabel.value)
+const ariaCurrent = computed(() => (isActive.value ? 'page' : undefined))
+const iconSize = computed(() => (props.level === 0 ? 20 : 18))
+const iconClass = computed(() => (props.level === 0 ? 'sidebar-icon' : 'sidebar-subicon'))
+const labelClass = computed(() => {
+  if (props.level === 0)
+    return 'text-sm font-medium text-foreground'
+
+  if (hasChildren.value)
+    return 'text-sm font-medium text-foreground'
+
+  return 'text-sm text-muted-foreground'
+})
+const linkClasses = computed(() => {
+  const baseClass = props.level === 0 ? 'sidebar-item' : 'sidebar-subitem'
+  const activeClass = props.level === 0 ? 'sidebar-item--active' : 'sidebar-subitem--active'
+
+  return [baseClass, { [activeClass]: isActive.value }]
+})
+const indentStyle = computed(() => ({
+  '--sidebar-indent': `${3.25 + Math.max(props.level, 0) * 1.25}rem`,
+}))
+
+function handleClick() {
+  if (hasChildren.value) {
+    if (props.item.to)
+      props.expandGroup(props.item.key)
+    else
+      props.toggleGroup(props.item.key)
+  }
+
+  props.onSelect(props.item)
+}
+
+function handleToggle() {
+  props.toggleGroup(props.item.key)
+}
+</script>

--- a/components/layout/AppSidebarRight.vue
+++ b/components/layout/AppSidebarRight.vue
@@ -31,8 +31,9 @@ const isDark = computed(() => useColorMode().value == "dark");
 interface SidebarItem {
   key: string
   label: string
-  icon: string
-  to: string
+  icon?: string
+  to?: string
+  children?: SidebarItem[]
 }
 
 const props = withDefaults(

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -35,6 +35,10 @@
         "help": "المساعدة",
         "about": "حول",
         "contact": "اتصال"
+      },
+      "groups": {
+        "planning": "التخطيط",
+        "career": "المسار المهني"
       }
     },
     "widgets": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -35,6 +35,10 @@
         "help": "Hilfe",
         "about": "Über uns",
         "contact": "Kontakt"
+      },
+      "groups": {
+        "planning": "Planung",
+        "career": "Karriere"
       }
     },
     "widgets": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -35,6 +35,10 @@
         "help": "Help",
         "about": "About",
         "contact": "Contact"
+      },
+      "groups": {
+        "planning": "Planning",
+        "career": "Career"
       }
     },
     "widgets": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -35,6 +35,10 @@
         "help": "Ayuda",
         "about": "Acerca de",
         "contact": "Contacto"
+      },
+      "groups": {
+        "planning": "Planificación",
+        "career": "Carrera"
       }
     },
     "widgets": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -35,6 +35,10 @@
         "help": "Aide",
         "about": "À propos",
         "contact": "Contact"
+      },
+      "groups": {
+        "planning": "Planification",
+        "career": "Carrière"
       }
     },
     "widgets": {

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -35,6 +35,10 @@
         "help": "Aiuto",
         "about": "Informazioni",
         "contact": "Contatti"
+      },
+      "groups": {
+        "planning": "Pianificazione",
+        "career": "Carriera"
       }
     },
     "widgets": {

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -35,6 +35,10 @@
         "help": "Помощь",
         "about": "О нас",
         "contact": "Контакты"
+      },
+      "groups": {
+        "planning": "Планирование",
+        "career": "Карьера"
       }
     },
     "widgets": {

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -35,6 +35,10 @@
         "help": "帮助",
         "about": "关于",
         "contact": "联系"
+      },
+      "groups": {
+        "planning": "规划",
+        "career": "职业发展"
       }
     },
     "widgets": {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,7 +71,8 @@ import { useDisplay, useTheme } from 'vuetify'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 import AppTopBar from '@/components/layout/AppTopBar.vue'
 import { useRightSidebarData } from '@/composables/useRightSidebarData'
-import AppSidebarRight from "~/components/layout/AppSidebarRight.vue";
+import AppSidebarRight from '@/components/layout/AppSidebarRight.vue'
+import type { SidebarItem } from '@/types/sidebar'
 
 const isDark = computed(() => useColorMode().value == "dark");
 const route = useRoute()
@@ -103,15 +104,38 @@ const appIcons = [
   { name: 'mdi-gamepad-variant-outline', label: 'layout.appIcons.game' },
 ]
 
-const sidebarItems = [
-  { key: 'apps', label: 'layout.sidebar.items.apps', icon: 'mdi-apps', to: '/' },
-  { key: 'calendar', label: 'layout.sidebar.items.calendar', icon: 'mdi-calendar-month', to: '/' },
+const sidebarItems: SidebarItem[] = [
+  {
+    key: 'apps',
+    label: 'layout.sidebar.items.apps',
+    icon: 'mdi-apps',
+    to: '/',
+    children: [
+      {
+        key: 'planning',
+        label: 'layout.sidebar.groups.planning',
+        icon: 'mdi-calendar-month-outline',
+        children: [
+          { key: 'calendar', label: 'layout.sidebar.items.calendar', icon: 'mdi-calendar-month', to: '/' },
+        ],
+      },
+      {
+        key: 'career',
+        label: 'layout.sidebar.groups.career',
+        icon: 'mdi-briefcase-outline',
+        children: [
+          { key: 'cv', label: 'layout.sidebar.items.cv', icon: 'mdi-file-account', to: '/' },
+          { key: 'jobs', label: 'layout.sidebar.items.jobs', icon: 'mdi-briefcase-search', to: '/' },
+        ],
+      },
+    ],
+  },
   { key: 'help', label: 'layout.sidebar.items.help', icon: 'mdi-lifebuoy', to: '/help' },
   { key: 'about', label: 'layout.sidebar.items.about', icon: 'mdi-information-outline', to: '/about' },
   { key: 'contact', label: 'layout.sidebar.items.contact', icon: 'mdi-email-outline', to: '/contact' },
 ]
 
-const activeSidebar = ref('apps')
+const activeSidebar = ref('calendar')
 
 watch(
   isMobile,

--- a/types/sidebar.ts
+++ b/types/sidebar.ts
@@ -1,0 +1,7 @@
+export interface SidebarItem {
+  key: string
+  label: string
+  icon?: string
+  to?: string
+  children?: SidebarItem[]
+}


### PR DESCRIPTION
## Summary
- render the left sidebar with a recursive node component so groups can contain nested sub-parents while keeping expansion state in sync with the active route
- type sidebar definitions with a shared SidebarItem interface and seed the default layout with multi-level groups for apps
- add localized labels for the new sidebar group headings across all supported languages

## Testing
- pnpm lint *(fails: network restrictions prevented downloading pnpm@10.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d7593aac68832691d63d79c044fbb2