### PR TITLE
Hide sidebar child links until group expanded

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -43,7 +43,13 @@
             <span v-else-if="item.to" class="sr-only">{{ t('layout.sidebar.navigate') }}</span>
           </component>
 
-          <ul v-if="item.children?.length" class="sidebar-sublist">
+          <ul
+            v-if="item.children?.length"
+            v-show="isGroupExpanded(item.key)"
+            :id="`sidebar-group-${item.key}`"
+            class="sidebar-sublist"
+            :aria-hidden="!isGroupExpanded(item.key)"
+          >
             <li v-for="child in item.children" :key="child.key">
               <NuxtLink
                 :to="child.to"


### PR DESCRIPTION
## Summary
- hide sidebar child links until their parent group is expanded
- keep submenu aria attributes in sync with the toggle button state

## Testing
- pnpm exec eslint components/layout/AppSidebar.vue

------
https://chatgpt.com/codex/tasks/task_e_68d87bdb9dc88326be7cf9c23af8e6df