### PR TITLE
Refactor post and comment cards to use BaseCard

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -1,42 +1,52 @@
 <template>
-  <article
+  <BaseCard
+    as="article"
+    variant="solid"
+    padding="md"
+    rounded="lg"
+    spacing="sm"
     :class="[
-      'flex flex-col gap-4 rounded-2xl border border-white/5 bg-gradient-to-br from-slate-950/80 via-slate-900/60 to-slate-950/80 px-5 py-5 shadow-[0_20px_50px_-35px_rgba(15,23,42,1)] backdrop-blur transition-all duration-300 hover:-translate-y-0.5 hover:border-primary/40',
-      depth > 0 ? 'ml-6 border-l border-white/10 pl-5' : '',
+      'w-full border border-slate-200 bg-white text-slate-800 shadow-sm transition-transform duration-200 hover:-translate-y-0.5',
+      depth > 0 ? 'ml-6 border-l border-slate-200/70 pl-6' : '',
     ]"
+    header-class="items-center gap-3"
+    body-class="space-y-3 text-sm text-slate-700"
+    :footer-divider="false"
   >
-    <div class="flex items-center gap-3">
-      <div class="h-10 w-10 overflow-hidden rounded-xl border border-white/10 bg-white/10 shadow-[0_12px_25px_-20px_rgba(15,23,42,1)]">
-        <img
-          :src="comment.user.photo ?? avatarFallback"
-          :alt="`${comment.user.firstName} ${comment.user.lastName}`"
-          class="h-full w-full object-cover"
-          loading="lazy"
-        />
+    <template #header>
+      <div class="flex items-center gap-3">
+        <div class="h-10 w-10 overflow-hidden rounded-xl border border-slate-200 bg-slate-100 shadow-sm">
+          <img
+            :src="comment.user.photo ?? avatarFallback"
+            :alt="`${comment.user.firstName} ${comment.user.lastName}`"
+            class="h-full w-full object-cover"
+            loading="lazy"
+          />
+        </div>
+        <div>
+          <p class="text-sm font-semibold text-slate-900">
+            {{ comment.user.firstName }} {{ comment.user.lastName }}
+          </p>
+          <p class="text-[11px] uppercase tracking-[0.35em] text-slate-500">
+            {{ formatDateTime(comment.publishedAt) }}
+          </p>
+        </div>
       </div>
-      <div>
-        <p class="text-sm font-semibold text-slate-100">
-          {{ comment.user.firstName }} {{ comment.user.lastName }}
-        </p>
-        <p class="text-[11px] uppercase tracking-[0.35em] text-slate-400">
-          {{ formatDateTime(comment.publishedAt) }}
-        </p>
-      </div>
-    </div>
+    </template>
 
-    <p class="text-sm leading-relaxed text-slate-200/90">
+    <p class="leading-relaxed text-slate-700">
       {{ comment.content }}
     </p>
 
     <div class="flex flex-col gap-3">
-      <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-300">
+      <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-600">
         <div class="flex flex-wrap items-center gap-2">
           <button
             v-for="type in reactionTypes"
             :key="type"
             type="button"
             :aria-label="reactionLabels[type]"
-            class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-gradient-to-br from-white/15 via-white/5 to-transparent text-base text-slate-100 shadow-[0_12px_25px_-20px_rgba(15,23,42,1)] transition-colors hover:border-primary/60 hover:bg-primary/15 hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+            class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-base text-slate-600 transition-colors hover:border-primary hover:bg-primary/10 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
             :disabled="!!reactingType"
             @click="handleReact(type)"
           >
@@ -46,7 +56,7 @@
           <div
             v-if="hasReactionPreview"
             :aria-label="reactionCountLabel"
-            class="inline-flex items-center gap-1 rounded-full border border-white/5 bg-white/10 px-3 py-1.5 text-slate-100 shadow-[0_15px_35px_-28px_rgba(15,23,42,1)]"
+            class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-600 shadow-sm"
           >
             <span v-for="reaction in comment.reactions_preview" :key="reaction.id" class="text-sm" aria-hidden="true">
               {{ reactionEmojis[reaction.type] }}
@@ -58,21 +68,21 @@
         <div class="flex flex-wrap items-center gap-2">
           <span
             :aria-label="reactionCountLabel"
-            class="inline-flex items-center gap-1 rounded-full border border-white/5 bg-white/10 px-3 py-1.5 text-slate-100 shadow-[0_15px_35px_-28px_rgba(15,23,42,1)]"
+            class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-600 shadow-sm"
           >
             <span aria-hidden="true">👍</span>
             <span aria-hidden="true">{{ formatNumber(comment.reactions_count) }}</span>
           </span>
           <span
             :aria-label="replyCountLabel"
-            class="inline-flex items-center gap-1 rounded-full border border-white/5 bg-white/10 px-3 py-1.5 text-slate-100 shadow-[0_15px_35px_-28px_rgba(15,23,42,1)]"
+            class="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-slate-600 shadow-sm"
           >
             <span aria-hidden="true">💬</span>
             <span aria-hidden="true">{{ formatNumber(comment.totalComments) }}</span>
           </span>
           <button
             type="button"
-            class="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-1.5 font-semibold text-slate-100 transition-colors hover:border-primary/60 hover:bg-primary/10 hover:text-primary disabled:cursor-not-allowed disabled:opacity-60"
+            class="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-1.5 font-semibold text-slate-700 transition-colors hover:border-primary hover:bg-primary/10 hover:text-primary disabled:cursor-not-allowed disabled:opacity-50"
             @click="toggleReply"
           >
             <span v-if="replying">{{ t('blog.comments.cancelReply') }}</span>
@@ -81,42 +91,42 @@
         </div>
       </div>
 
-      <p v-if="reactionError" class="text-xs text-rose-300">
+      <p v-if="reactionError" class="text-xs text-rose-500">
         {{ reactionError }}
       </p>
     </div>
 
     <form
       v-if="replying"
-      class="flex flex-col gap-3 rounded-2xl border border-white/5 bg-slate-950/60 p-4 shadow-[0_18px_45px_-30px_rgba(15,23,42,0.95)]"
+      class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
       @submit.prevent="handleReplySubmit"
     >
-      <label class="flex flex-col gap-2 text-xs text-slate-200">
+      <label class="flex flex-col gap-2 text-xs text-slate-600">
         <span class="sr-only">{{ t('blog.comments.replyPlaceholder') }}</span>
         <textarea
           v-model="replyContent"
-          class="min-h-[96px] w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-white placeholder:text-slate-500 shadow-inner focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          class="min-h-[96px] w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 placeholder:text-slate-400 shadow-inner focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
           :placeholder="t('blog.comments.replyPlaceholder')"
         />
       </label>
       <div class="flex flex-col gap-2 text-xs sm:flex-row sm:items-center sm:justify-between">
         <p
           v-if="replyFeedback"
-          :class="replyFeedback.type === 'success' ? 'text-emerald-300' : 'text-rose-300'"
+          :class="replyFeedback.type === 'success' ? 'text-emerald-500' : 'text-rose-500'"
         >
           {{ replyFeedback.message }}
         </p>
         <div class="flex items-center gap-2 sm:justify-end">
           <button
             type="button"
-            class="inline-flex items-center justify-center rounded-full border border-white/10 bg-white/5 px-4 py-1.5 font-semibold text-slate-200 transition-colors hover:border-white/30 hover:bg-white/10 hover:text-slate-50"
+            class="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-1.5 font-semibold text-slate-600 transition-colors hover:border-slate-300 hover:bg-slate-50"
             @click="cancelReply"
           >
             {{ t('blog.comments.cancelReply') }}
           </button>
           <button
             type="submit"
-            class="inline-flex items-center justify-center rounded-full bg-primary px-4 py-1.5 font-semibold text-white shadow-[0_18px_35px_-22px_hsl(var(--primary)/0.9)] transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            class="inline-flex items-center justify-center rounded-full bg-primary px-4 py-1.5 font-semibold text-white shadow-sm transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
             :disabled="submittingReply"
           >
             <span v-if="submittingReply">{{ t('blog.comments.replying') }}</span>
@@ -139,11 +149,12 @@
         :depth="depth + 1"
       />
     </div>
-  </article>
+  </BaseCard>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { BaseCard } from "~/components/ui";
 import type { BlogCommentWithReplies, ReactionType } from "~/lib/mock/blog";
 
 defineOptions({ name: "CommentCard" });


### PR DESCRIPTION
## Summary
- rebuild the PostCard layout around the shared BaseCard component with lighter styling, reorganized sections, and refreshed reaction/comment areas
- restyle the comment preview list and reaction preview chips to match the updated BaseCard presentation
- move CommentCard to BaseCard for threaded replies with consistent button, badge, and form treatments

## Testing
- Not run (vitest configuration excludes e2e/PostCard.spec.ts)


------
https://chatgpt.com/codex/tasks/task_e_68d87e74acf083269732c1935bbe5333