### PR TITLE
feat: sanitize and render blog html content

### DIFF
--- a/components/CommentCard.vue
+++ b/components/CommentCard.vue
@@ -36,9 +36,11 @@
       />
     </template>
 
-    <p class="leading-relaxed text-slate-700">
-      {{ comment.content }}
-    </p>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div
+      class="space-y-2 leading-relaxed text-slate-700 [&_a]:text-primary [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 [&_strong]:font-semibold"
+      v-html="sanitizedContent"
+    ></div>
 
     <div class="flex flex-col gap-3">
       <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-slate-600">
@@ -174,6 +176,7 @@ import { computed, ref, watch } from "vue";
 import CommentMeta from "~/components/blog/CommentMeta.vue";
 import { BaseCard } from "~/components/ui";
 import type { BlogCommentWithReplies, ReactionType } from "~/lib/mock/blog";
+import { sanitizeRichText } from "~/lib/sanitize-html";
 
 defineOptions({ name: "CommentCard" });
 
@@ -210,6 +213,7 @@ const props = defineProps<{
 const { locale, t } = useI18n();
 
 const comment = computed(() => props.comment);
+const sanitizedContent = computed(() => sanitizeRichText(comment.value.content));
 const depth = computed(() => props.depth ?? 0);
 const avatarFallback = computed(() => props.defaultAvatar || "https://bro-world-space.com/img/person.png");
 const reactionTypes = computed(() => Object.keys(props.reactionEmojis) as ReactionType[]);

--- a/components/blog/BlogCommentCard.vue
+++ b/components/blog/BlogCommentCard.vue
@@ -17,9 +17,11 @@
         :default-avatar="defaultAvatar"
         :published-label="publishedDisplay"
     />
-    <p class="mt-2 text-sm leading-relaxed text-slate-700 whitespace-pre-line">
-      {{ comment.content }}
-    </p>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <div
+      class="mt-2 text-sm leading-relaxed text-slate-700 [&_a]:text-primary [&_a]:underline [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 [&_strong]:font-semibold"
+      v-html="sanitizedContent"
+    ></div>
     <div class="mt-3 flex flex-wrap items-center gap-4 border-t border-slate-200 pt-3 text-xs text-slate-500">
         <span
             :aria-label="t('blog.reactions.comment.reactions', { count: formatNumber(comment.reactions_count) })"
@@ -46,6 +48,7 @@ import type { BlogCommentPreview } from "~/lib/mock/blog";
 import { computed } from "vue";
 import CommentMeta from "~/components/blog/CommentMeta.vue";
 import { BaseCard } from "~/components/ui";
+import { sanitizeRichText } from "~/lib/sanitize-html";
 
 
 defineOptions({
@@ -99,6 +102,7 @@ function formatNumber(value: number | null | undefined) {
 }
 
 const comment = computed(() => props.comment);
+const sanitizedContent = computed(() => sanitizeRichText(comment.value.content));
 const publishedDisplay = computed(() => {
   const relative = formatRelativeTime(comment.value.publishedAt);
   return relative || formatDateTime(comment.value.publishedAt);

--- a/components/blog/BlogPostCard.vue
+++ b/components/blog/BlogPostCard.vue
@@ -37,14 +37,14 @@
         <h4 v-if="post.title" class="text-xl font-semibold text-slate-900 sm:text-2xl">
           {{ post.title }}
         </h4>
-        <div v-if="bodyParagraphs.length" class="space-y-3 leading-relaxed">
-          <p
-            v-for="(paragraph, index) in bodyParagraphs"
-            :key="index"
-            class="whitespace-pre-line"
-          >
-            {{ paragraph }}
-          </p>
+        <div
+          v-if="sanitizedSummary || sanitizedBody"
+          class="space-y-4 leading-relaxed text-slate-700 [&_a]:text-primary [&_a]:underline [&_h1]:text-2xl [&_h1]:font-semibold [&_h2]:text-xl [&_h2]:font-semibold [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5 [&_strong]:font-semibold"
+        >
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-if="sanitizedSummary" v-html="sanitizedSummary"></div>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-if="sanitizedBody" v-html="sanitizedBody"></div>
         </div>
       </div>
     </div>
@@ -86,8 +86,9 @@
 import { computed } from "vue";
 import BlogCommentCard from "./BlogCommentCard.vue";
 import PostMeta from "./PostMeta.vue";
+import { BaseCard } from "~/components/ui";
 import type { BlogPost, ReactionType } from "~/lib/mock/blog";
-import {BaseCard} from "~/components/ui";
+import { sanitizeRichText } from "~/lib/sanitize-html";
 
 const props = defineProps<{ post: BlogPost }>();
 
@@ -195,21 +196,6 @@ function openDelete() {
   /* no-op */
 }
 
-const bodyParagraphs = computed(() => {
-  const paragraphs = (props.post.content ?? "")
-    .split(/\n\s*\n/)
-    .map((paragraph) => paragraph.trim())
-    .filter(Boolean);
-
-  if (props.post.summary) {
-    paragraphs.unshift(props.post.summary);
-  }
-
-  return paragraphs;
-});
-
-const postActions = computed(() => [
-  { id: "like", icon: "👍", label: t("blog.reactions.reactionTypes.like") },
-  { id: "comment", icon: "💬", label: t("blog.comments.reply") },
-]);
+const sanitizedSummary = computed(() => sanitizeRichText(props.post.summary ?? ""));
+const sanitizedBody = computed(() => sanitizeRichText(props.post.content ?? ""));
 </script>

--- a/lib/sanitize-html.ts
+++ b/lib/sanitize-html.ts
@@ -1,0 +1,227 @@
+const SAFE_TAGS = new Set([
+  'a',
+  'abbr',
+  'b',
+  'blockquote',
+  'br',
+  'code',
+  'em',
+  'figure',
+  'figcaption',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'hr',
+  'i',
+  'img',
+  'li',
+  'ol',
+  'p',
+  'pre',
+  's',
+  'span',
+  'strong',
+  'sub',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'th',
+  'thead',
+  'tr',
+  'u',
+  'ul',
+]);
+
+const SELF_CLOSING_TAGS = new Set(['br', 'hr', 'img']);
+
+const GLOBAL_ATTRIBUTES = new Set([
+  'aria-label',
+  'aria-hidden',
+  'aria-live',
+  'dir',
+  'lang',
+  'role',
+  'title',
+]);
+
+const TAG_ATTRIBUTES: Record<string, Set<string>> = {
+  a: new Set(['href', 'rel', 'target']),
+  img: new Set(['alt', 'src', 'width', 'height', 'loading']),
+  table: new Set(['summary']),
+  th: new Set(['scope']),
+  td: new Set(['colspan', 'rowspan']),
+};
+
+const ALLOWED_URI_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
+const ALLOWED_IMG_SCHEMES = new Set(['http', 'https', 'data']);
+
+const ATTRIBUTE_PATTERN = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'>`]+)))?/g;
+
+function escapeAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function isUriAllowed(tag: string, attribute: string, value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (trimmed.startsWith('#')) {
+    return true;
+  }
+
+  const lowerValue = trimmed.toLowerCase();
+
+  if (lowerValue.startsWith('javascript:')) {
+    return false;
+  }
+
+  if (lowerValue.startsWith('data:')) {
+    if (tag === 'img' && attribute === 'src') {
+      return /^data:image\/(png|jpe?g|gif|webp);/i.test(lowerValue);
+    }
+
+    return false;
+  }
+
+  const schemeMatch = lowerValue.match(/^([a-z0-9+.-]+):/);
+  if (!schemeMatch) {
+    return true;
+  }
+
+  const scheme = schemeMatch[1];
+  if (tag === 'img' && attribute === 'src') {
+    return ALLOWED_IMG_SCHEMES.has(scheme);
+  }
+
+  return ALLOWED_URI_SCHEMES.has(scheme);
+}
+
+function buildAttributes(tag: string, rawAttributes: string): string {
+  if (!rawAttributes) {
+    return '';
+  }
+
+  const allowedAttributes = new Set([
+    ...GLOBAL_ATTRIBUTES,
+    ...(TAG_ATTRIBUTES[tag] ?? new Set<string>()),
+  ]);
+
+  if (allowedAttributes.size === 0) {
+    return '';
+  }
+
+  ATTRIBUTE_PATTERN.lastIndex = 0;
+
+  const collected: string[] = [];
+  let hasRelAttribute = false;
+  let hasTargetBlank = false;
+
+  let match: RegExpExecArray | null;
+  while ((match = ATTRIBUTE_PATTERN.exec(rawAttributes)) !== null) {
+    const name = match[1]?.toLowerCase();
+    if (!name) {
+      continue;
+    }
+
+    if (name.startsWith('on') || name.startsWith('data-')) {
+      continue;
+    }
+
+    if (!allowedAttributes.has(name)) {
+      continue;
+    }
+
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+
+    if (name === 'href' || name === 'src') {
+      if (!isUriAllowed(tag, name, value)) {
+        continue;
+      }
+    }
+
+    if (name === 'target') {
+      const normalisedTarget = value.trim().toLowerCase();
+      if (!['_self', '_blank', '_parent', '_top'].includes(normalisedTarget)) {
+        continue;
+      }
+
+      if (normalisedTarget === '_blank') {
+        hasTargetBlank = true;
+      }
+    }
+
+    if (name === 'rel') {
+      hasRelAttribute = true;
+    }
+
+    const escapedValue = escapeAttribute(value);
+    if (!escapedValue && name !== 'alt') {
+      continue;
+    }
+
+    collected.push(`${name}="${escapedValue}"`);
+  }
+
+  if (tag === 'a' && hasTargetBlank && !hasRelAttribute) {
+    collected.push('rel="noopener noreferrer"');
+  }
+
+  if (!collected.length) {
+    return '';
+  }
+
+  return ` ${collected.join(' ')}`;
+}
+
+function sanitizeNode(match: string, closingSlash: string, tagName: string, rawAttributes: string, original: string): string {
+  const tag = tagName.toLowerCase();
+
+  if (!SAFE_TAGS.has(tag)) {
+    return '';
+  }
+
+  if (closingSlash) {
+    return `</${tag}>`;
+  }
+
+  const isSelfClosing = SELF_CLOSING_TAGS.has(tag) || /\/>\s*$/.test(original);
+  const attributes = buildAttributes(tag, rawAttributes ?? '');
+  const closing = isSelfClosing ? ' />' : '>';
+
+  return `<${tag}${attributes}${closing}`;
+}
+
+const TAG_PATTERN = /<(\/)?([a-zA-Z0-9:-]+)([^>]*)>/g;
+const SCRIPT_STYLE_PATTERN = /<(script|style)[^>]*>[\s\S]*?<\/\1>/gi;
+const COMMENT_PATTERN = /<!--([\s\S]*?)-->/g;
+
+export function sanitizeRichText(input: unknown): string {
+  if (typeof input !== 'string') {
+    return '';
+  }
+
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const withoutDangerousBlocks = trimmed
+    .replace(COMMENT_PATTERN, '')
+    .replace(SCRIPT_STYLE_PATTERN, '');
+
+  const sanitized = withoutDangerousBlocks.replace(TAG_PATTERN, (match, closingSlash, tagName, rawAttributes) =>
+    sanitizeNode(match, closingSlash ?? '', tagName ?? '', rawAttributes ?? '', match),
+  );
+
+  return sanitized;
+}


### PR DESCRIPTION
## Summary
- sanitize and render blog comment content with rich text styling
- render blog post summaries and bodies as sanitized HTML output
- add a reusable sanitizeRichText helper to filter allowed tags and attributes

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files and missing remote assets)*

------
https://chatgpt.com/codex/tasks/task_e_68d93f63409883269d8db29031d36fe4