### PR TITLE
feat(posts): fetch private posts when authenticated

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -425,6 +425,8 @@ export default defineNuxtConfig({
       NUXT_CLARITY_ID: process.env.NUXT_CLARITY_ID,
       NUXT_ADSENSE_ACCOUNT: process.env.NUXT_ADSENSE_ACCOUNT,
       blogApiEndpoint: process.env.NUXT_PUBLIC_BLOG_API_ENDPOINT ?? "https://blog.bro-world.org/public/post",
+      blogPrivateApiEndpoint:
+        process.env.NUXT_PUBLIC_BLOG_PRIVATE_API_ENDPOINT ?? "https://blog.bro-world.org/v1/private/post",
       baseUrl: process.env.NUXT_PUBLIC_BASE_URL ?? "https://bro-world-space.com",
       apiBase: process.env.NUXT_PUBLIC_API_BASE ?? "/api",
     },


### PR DESCRIPTION
## Summary
- add a dedicated runtime setting for the private blog API endpoint
- fetch private posts when a session token is present and fall back to public posts on authorization failures
- separate cached post listings by authentication scope to avoid leaking private data

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9456ea6cc8326a5cad47d5c1e6d50