### PR TITLE
Ensure auth session persists across refresh

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -265,10 +265,8 @@ export const useAuthSession = defineStore('auth-session', () => {
       return isAuthenticated.value
     }
 
-    if (!tokenAvailableState.value) {
-      clearSession()
-      readyState.value = true
-      return false
+    if (!tokenAvailableState.value && presenceCookie.value === '1') {
+      tokenAvailableState.value = true
     }
 
     const fetcher = resolveFetcher()


### PR DESCRIPTION
## Summary
- rehydrate the auth token presence from the cookie before refreshing the session
- always verify the session with the backend before clearing local state so refreshes keep valid logins

## Testing
- pnpm lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d94bcc8c9883268367ed899825e3a4