### PR TITLE
feat: show auth navigation in app bar

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -88,6 +88,21 @@
       <LayoutSearchButton />
     </div>
 
+    <nav
+      v-if="navigationLinks.length"
+      class="flex items-center gap-3 px-6"
+      :aria-label="t('layout.actions.profile')"
+    >
+      <NuxtLinkLocale
+        v-for="link in navigationLinks"
+        :key="link.path"
+        :to="localePath(link.path)"
+        :aria-label="link.label"
+        class="rounded-full px-3 py-2 text-sm font-medium transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2"
+      >
+        {{ link.label }}
+      </NuxtLinkLocale>
+    </nav>
     <UiButton
         v-if="isAuthenticated"
         variant="ghost"
@@ -261,6 +276,11 @@ type HeaderLink = {
   menuItems?: HeaderLinkMenuItem[]
 }
 
+type NavigationLink = {
+  path: string
+  label: string
+}
+
 const props = defineProps<{
   appIcons: AppIcon[]
   isDark: boolean
@@ -308,6 +328,32 @@ const auth = useAuthSession()
 const isAuthenticated = computed(() => auth.isAuthenticated.value)
 
 const loggingOut = ref(false)
+
+const navigationLinks = computed<NavigationLink[]>(() => {
+  if (isAuthenticated.value) {
+    return [
+      {
+        path: '/profile',
+        label: t('layout.actions.viewProfile'),
+      },
+      {
+        path: '/logout',
+        label: t('auth.signOut'),
+      },
+    ]
+  }
+
+  return [
+    {
+      path: '/login',
+      label: t('auth.Login'),
+    },
+    {
+      path: '/register',
+      label: t('auth.Register'),
+    },
+  ]
+})
 
 function resolveIconName(name?: string) {
   if (!name)

--- a/pages/logout.vue
+++ b/pages/logout.vue
@@ -1,0 +1,42 @@
+<template>
+  <main
+    class="flex min-h-[calc(100vh-var(--app-bar-height))] flex-col items-center justify-center gap-4 px-6 py-12 text-center"
+    aria-live="polite"
+  >
+    <v-progress-circular
+      v-if="isProcessing"
+      indeterminate
+      color="primary"
+      size="36"
+      :aria-label="t('auth.signOut')"
+    />
+    <div class="space-y-2">
+      <h1 class="text-2xl font-semibold">{{ t('auth.signOut') }}</h1>
+      <p class="text-muted-foreground">
+        {{ statusMessage }}
+      </p>
+    </div>
+  </main>
+</template>
+
+<script setup lang="ts">
+definePageMeta({
+  middleware: 'auth',
+  title: 'logout',
+})
+
+const auth = useAuthSession()
+const router = useRouter()
+const { t } = useI18n()
+const { localePath } = useI18nDocs()
+
+const isProcessing = ref(true)
+const statusMessage = ref(t('auth.signOut'))
+
+onMounted(async () => {
+  await auth.logout({ redirect: false })
+  statusMessage.value = t('auth.logoutMessage')
+  isProcessing.value = false
+  await router.replace(localePath('/login'))
+})
+</script>


### PR DESCRIPTION
## Summary
- add localized authentication navigation links to the top app bar for authenticated and guest users
- create a dedicated logout route that signs users out then redirects to the localized login page

## Testing
- pnpm dev --host 0.0.0.0 --port 3000


------
https://chatgpt.com/codex/tasks/task_e_68d94dd9847c8326889f9221aa7af4f7