### PR TITLE
Persist auth and theme settings in cookies

### DIFF
--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -1,0 +1,175 @@
+import { computed, watch } from 'vue'
+import { useColorMode } from '@vueuse/core'
+import type { Theme } from 'shadcn-docs-nuxt/lib/themes'
+import { themes } from 'shadcn-docs-nuxt/lib/themes'
+
+interface ThemeCookieConfig {
+  theme: Theme['name']
+  radius: number
+}
+
+function parseHslComponents(hsl?: string) {
+  if (!hsl) {
+    return null
+  }
+
+  const trimmed = hsl.trim().replace(/^hsl\(/i, '').replace(/\)$/i, '')
+  const match = trimmed.match(
+    /^(-?\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%(?:\s*\/\s*(\d+(?:\.\d+)?)%)?$/,
+  )
+
+  if (!match) {
+    return null
+  }
+
+  const [, hue, saturation, lightness] = match
+
+  return {
+    hue: ((Number(hue) % 360) + 360) % 360,
+    saturation: Number(saturation),
+    lightness: Number(lightness),
+  }
+}
+
+function hslToHex({ hue, saturation, lightness }: NonNullable<ReturnType<typeof parseHslComponents>>) {
+  const s = Math.max(0, Math.min(100, saturation)) / 100
+  const l = Math.max(0, Math.min(100, lightness)) / 100
+
+  const chroma = (1 - Math.abs(2 * l - 1)) * s
+  const hueSegment = hue / 60
+  const intermediate = chroma * (1 - Math.abs((hueSegment % 2) - 1))
+
+  let red = 0
+  let green = 0
+  let blue = 0
+
+  if (hueSegment >= 0 && hueSegment < 1) {
+    red = chroma
+    green = intermediate
+  } else if (hueSegment >= 1 && hueSegment < 2) {
+    red = intermediate
+    green = chroma
+  } else if (hueSegment >= 2 && hueSegment < 3) {
+    green = chroma
+    blue = intermediate
+  } else if (hueSegment >= 3 && hueSegment < 4) {
+    green = intermediate
+    blue = chroma
+  } else if (hueSegment >= 4 && hueSegment < 5) {
+    red = intermediate
+    blue = chroma
+  } else {
+    red = chroma
+    blue = intermediate
+  }
+
+  const matchLightness = l - chroma / 2
+
+  function toHex(value: number) {
+    return Math.round((value + matchLightness) * 255)
+      .toString(16)
+      .padStart(2, '0')
+  }
+
+  return `#${toHex(red)}${toHex(green)}${toHex(blue)}`
+}
+
+export function useThemes() {
+  const config = useConfig()
+
+  function resolveThemeDefaults(): ThemeCookieConfig {
+    const defaults = config.value.theme ?? {}
+    const fallbackThemeName =
+      (defaults.color as Theme['name'] | undefined) ?? themes[0]?.name ?? 'zinc'
+    const fallbackRadius =
+      typeof defaults.radius === 'number' ? defaults.radius : 0.75
+
+    return {
+      theme: fallbackThemeName,
+      radius: fallbackRadius,
+    }
+  }
+
+  const colorMode = useColorMode({
+    storage: 'cookie',
+    storageKey: 'color-mode',
+    cookieOptions: {
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    },
+  })
+  const isDark = computed(() => colorMode.value === 'dark')
+
+  const themeCookie = useCookie<ThemeCookieConfig>('theme', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    default: resolveThemeDefaults,
+  })
+
+  const theme = computed<Theme['name']>(() => themeCookie.value?.theme ?? resolveThemeDefaults().theme)
+  const radius = computed(() => themeCookie.value?.radius ?? resolveThemeDefaults().radius)
+  const themeClass = computed(() => `theme-${theme.value}`)
+
+  function setTheme(themeName: Theme['name']) {
+    themeCookie.value = {
+      ...resolveThemeDefaults(),
+      ...themeCookie.value,
+      theme: themeName,
+    }
+  }
+
+  function setRadius(newRadius: number) {
+    themeCookie.value = {
+      ...resolveThemeDefaults(),
+      ...themeCookie.value,
+      radius: newRadius,
+    }
+  }
+
+  const primarySource = computed(() => {
+    const selectedTheme = themes.find((candidate) => candidate.name === theme.value)
+    const palette = selectedTheme?.cssVars[isDark.value ? 'dark' : 'light']
+    const primary = palette?.primary
+
+    return primary ? `hsl(${primary})` : null
+  })
+
+  const themePrimary = computed(() => primarySource.value ?? undefined)
+
+  const themePrimaryHex = computed(() => {
+    const components = parseHslComponents(primarySource.value ?? undefined)
+
+    if (!components) {
+      return undefined
+    }
+
+    return hslToHex(components)
+  })
+
+  const themePrimaryCookie = useCookie<string | null>('theme-primary', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  if (!themePrimaryCookie.value && themePrimaryHex.value) {
+    themePrimaryCookie.value = themePrimaryHex.value
+  }
+
+  watch(
+    themePrimaryHex,
+    (value) => {
+      themePrimaryCookie.value = value ?? null
+    },
+    { immediate: true },
+  )
+
+  return {
+    themeClass,
+    theme,
+    setTheme,
+    radius,
+    setRadius,
+    themePrimary,
+    themePrimaryHex,
+  }
+}

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -5,7 +5,6 @@ import { VDateInput } from 'vuetify/labs/VDateInput'
 import { createVuetify } from 'vuetify'
 import * as vuetifyComponents from 'vuetify/components'
 import * as vuetifyDirectives from 'vuetify/directives'
-import { useStorage } from '@vueuse/core'
 import { aliases } from 'vuetify/iconsets/mdi'
 import DateFnsAdapter from '@date-io/date-fns'
 import enUSLocale from 'date-fns/locale/en-US'
@@ -18,17 +17,20 @@ import arLocale from 'date-fns/locale/ar-SA'
 
 export type DataTableHeaders = VDataTable['$props']['headers']
 
-function getStoredValue<T>(key: string, fallback: T): T {
-  if (import.meta.client) {
-    return useStorage<T>(key, fallback).value
-  }
-
-  return fallback
-}
-
 export default defineNuxtPlugin((nuxtApp) => {
-  const primary = getStoredValue('theme-primary', '#E91E63')
-  const locale = getStoredValue('locale', 'en')
+  const primaryCookie = useCookie<string | null>('theme-primary', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    watch: false,
+  })
+  const primary = primaryCookie.value ?? '#E91E63'
+
+  const localeCookie = useCookie<string | null>('i18n_redirected', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    watch: false,
+  })
+  const locale = localeCookie.value ?? 'en'
   const nuxtIconComponent = nuxtApp.vueApp.component('Icon')
 
   const vuetify = createVuetify({


### PR DESCRIPTION
## Summary
- store the authenticated session token in an HTTP cookie instead of relying on sessionStorage
- introduce a local `useThemes` composable that persists theme, radius and derived primary color values in cookies (and ensures color mode also uses cookie storage)
- have the Vuetify plugin read the primary color and locale preferences from cookies so the runtime picks up the saved configuration

## Testing
- pnpm lint *(fails: existing lint violations unrelated to the touched files)*
- pnpm exec eslint composables/useThemes.ts stores/auth-session.ts plugins/vuetify.ts


------
https://chatgpt.com/codex/tasks/task_e_68d95051f5c88326bea2a3d4f0260e8c