### PR TITLE
Fix runtimeConfig initialization order in auth store

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -62,6 +62,12 @@ export const useAuthSession = defineStore('auth-session', () => {
   const mercureTokenState = useState<MercureTokenState | null>('auth-mercure-token', () => null)
   const sessionTokenState = useState<string | null>('auth-session-token', () => null)
 
+  const loginPendingState = ref(false)
+  const loginErrorState = ref<string | null>(null)
+  const sessionMessageState = ref<string | null>(null)
+  const handlingUnauthorizedState = ref(false)
+
+  const runtimeConfig = useRuntimeConfig()
   const sessionTokenCookie = useCookie<string | null>(
     runtimeConfig.auth?.sessionTokenCookieName ?? 'auth_session_token',
     {
@@ -70,13 +76,6 @@ export const useAuthSession = defineStore('auth-session', () => {
       watch: false,
     },
   )
-
-  const loginPendingState = ref(false)
-  const loginErrorState = ref<string | null>(null)
-  const sessionMessageState = ref<string | null>(null)
-  const handlingUnauthorizedState = ref(false)
-
-  const runtimeConfig = useRuntimeConfig()
   const presenceCookie = useCookie<string | null>(runtimeConfig.auth?.tokenPresenceCookieName ?? 'auth_token_present', {
     sameSite: 'strict',
     secure: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Summary
- move runtimeConfig initialization ahead of cookie usage in auth session store
- ensure the session cookie setup no longer references an uninitialized value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9533b93a48326a999a1178647696a