### PR TITLE
feat: redesign login experience

### DIFF
--- a/components/auth/Social.vue
+++ b/components/auth/Social.vue
@@ -1,30 +1,18 @@
 <template>
-  <div class="auth-social text-center text-white px-6 pb-6">
-    <p class="text-subtitle-1 font-weight-medium mb-2">
-      {{ t('auth.socialTitle') }}
-    </p>
-    <p class="text-body-2 text-white text-opacity-80 mb-5">
-      {{ t('auth.socialSubtitle') }}
-    </p>
-
-    <v-row class="justify-center align-center" dense>
-      <v-col
-          v-for="button in buttons"
-          :key="button.provider"
-          cols="auto"
-          class="d-flex"
-      >
-        <v-btn
-            variant="flat"
-            class="font-weight-bold rounded-xl text-body-2"
-            :loading="props.loading"
-            :disabled="props.loading"
-            @click="handleRedirect(button.provider)"
-        >
-          <Icon :name="button.icon" />
-        </v-btn>
-      </v-col>
-    </v-row>
+  <div :class="socialClasses">
+    <button
+      v-for="button in buttons"
+      :key="button.provider"
+      type="button"
+      class="auth-social__button"
+      :class="{ 'auth-social__button--compact': isCompact }"
+      :style="{ background: button.gradient }"
+      :aria-label="button.label"
+      :disabled="props.loading"
+      @click="handleRedirect(button.provider)"
+    >
+      <Icon :name="button.icon" :size="isCompact ? 20 : 24" :color="button.iconColor" />
+    </button>
   </div>
 </template>
 
@@ -34,9 +22,16 @@ import { useI18n } from 'vue-i18n'
 
 import type { SocialProvider } from '~/lib/auth/social'
 
-const props = withDefaults(defineProps<{ loading?: boolean }>(), {
-  loading: false,
-})
+const props = withDefaults(
+  defineProps<{
+    loading?: boolean
+    size?: 'default' | 'compact'
+  }>(),
+  {
+    loading: false,
+    size: 'default',
+  },
+)
 
 const emit = defineEmits<{
   (e: 'redirect', provider: SocialProvider): void
@@ -44,24 +39,96 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const buttons = computed(() => [
-  { provider: 'google', icon: 'mdi-google' },
-  { provider: 'github', icon: 'mdi-github' },
-  { provider: 'microsoft', icon: 'mdi-microsoft' },
-] as const satisfies ReadonlyArray<{ provider: SocialProvider; icon: string }>)
+const baseButtons = [
+  {
+    provider: 'google',
+    icon: 'mdi-google',
+    gradient: 'linear-gradient(135deg, #ff8a00 0%, #ff2d55 100%)',
+    iconColor: '#ffffff',
+  },
+  {
+    provider: 'github',
+    icon: 'mdi-github',
+    gradient: 'linear-gradient(135deg, #232526 0%, #414345 100%)',
+    iconColor: '#ffffff',
+  },
+  {
+    provider: 'microsoft',
+    icon: 'mdi-microsoft',
+    gradient: 'linear-gradient(135deg, #00b4db 0%, #0083b0 100%)',
+    iconColor: '#ffffff',
+  },
+] as const satisfies ReadonlyArray<{
+  provider: SocialProvider
+  icon: string
+  gradient: string
+  iconColor: string
+}>
+
+const buttons = computed(() =>
+  baseButtons.map((button) => ({
+    ...button,
+    label: t(`auth.social.${button.provider}`),
+  })),
+)
+
+const isCompact = computed(() => props.size === 'compact')
+const socialClasses = computed(() => [
+  'auth-social',
+  { 'auth-social--compact': isCompact.value },
+])
 
 function handleRedirect(provider: SocialProvider) {
+  if (props.loading) return
+
   emit('redirect', provider)
 }
 </script>
 
 <style scoped>
 .auth-social {
-  position: relative;
-  z-index: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1.1rem;
 }
 
-.text-opacity-80 {
-  opacity: 0.8;
+.auth-social--compact {
+  gap: 0.75rem;
+}
+
+.auth-social__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  border: none;
+  color: #ffffff;
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.auth-social__button--compact {
+  width: 2.75rem;
+  height: 2.75rem;
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.18);
+}
+
+.auth-social__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.auth-social__button:not(:disabled):hover {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 44px rgba(236, 72, 153, 0.28);
+}
+
+.auth-social__button:not(:disabled):active {
+  transform: translateY(-1px);
 }
 </style>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -123,6 +123,8 @@
     "Register": "إنشاء حساب",
     "usernameOrEmail": "البريد الإلكتروني أو اسم المستخدم",
     "password": "كلمة المرور",
+    "showPassword": "إظهار كلمة المرور",
+    "hidePassword": "إخفاء كلمة المرور",
     "signIn": "تسجيل الدخول",
     "signUpPrompt": "لا تملك حسابًا؟",
     "signUp": "إنشاء حساب",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -123,6 +123,8 @@
     "Register": "Registrieren",
     "usernameOrEmail": "E-Mail-Adresse oder Benutzername",
     "password": "Passwort",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort verbergen",
     "signIn": "Anmelden",
     "signUpPrompt": "Noch kein Konto?",
     "signUp": "Jetzt registrieren",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -123,6 +123,8 @@
     "Register": "Register",
     "usernameOrEmail": "Email address or username",
     "password": "Password",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "signIn": "Sign in",
     "signUpPrompt": "Don't have an account?",
     "signUp": "Create one",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -342,6 +342,8 @@
     "Register": "Registrarse",
     "usernameOrEmail": "Correo electrónico o nombre de usuario",
     "password": "Contraseña",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña",
     "signIn": "Iniciar sesión",
     "signUpPrompt": "¿No tienes una cuenta?",
     "signUp": "Crea una",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -123,6 +123,8 @@
     "Register": "Inscription",
     "usernameOrEmail": "Adresse e-mail ou nom d'utilisateur",
     "password": "Mot de passe",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe",
     "signIn": "Se connecter",
     "signUpPrompt": "Pas encore de compte ?",
     "signUp": "Créer un compte",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -342,6 +342,8 @@
     "Register": "Registrati",
     "usernameOrEmail": "Indirizzo email o nome utente",
     "password": "Password",
+    "showPassword": "Mostra password",
+    "hidePassword": "Nascondi password",
     "signIn": "Accedi",
     "signUpPrompt": "Non hai un account?",
     "signUp": "Creane uno",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -342,6 +342,8 @@
     "Register": "Регистрация",
     "usernameOrEmail": "Email или имя пользователя",
     "password": "Пароль",
+    "showPassword": "Показать пароль",
+    "hidePassword": "Скрыть пароль",
     "signIn": "Войти",
     "signUpPrompt": "Нет аккаунта?",
     "signUp": "Создать",

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -123,6 +123,8 @@
     "Register": "注册",
     "usernameOrEmail": "邮箱地址或用户名",
     "password": "密码",
+    "showPassword": "显示密码",
+    "hidePassword": "隐藏密码",
     "signIn": "登录",
     "signUpPrompt": "还没有账号？",
     "signUp": "立即注册",

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,43 +1,33 @@
 <template>
-  <v-card
-    :loading="isRedirecting"
-    class="auth-card border-radius-xl overflow-visible"
-    rounded="xl"
-    elevation="24"
-  >
-    <v-sheet
-      class="mx-auto"
-      elevation="12"
-      max-width="calc(100% - 32px)"
-      rounded="lg"
-      color="primary"
-      style="z-index: 2; top: -44px; position: relative;"
-    >
-      <div class="mt-4 py-3">
-        <div class="text-h4 font-weight-bold d-flex justify-center text-white">
-          Bro World
-        </div>
+  <div class="login-page">
+    <div class="login-card" :class="{ 'login-card--loading': isRedirecting }">
+      <span class="login-card__glow" />
+      <div class="login-card__header">
+        <h1 class="login-card__title">Bro World</h1>
+        <p class="login-card__subtitle">{{ t('auth.socialSubtitle') }}</p>
+        <AuthSocial
+          class="login-card__socials"
+          :loading="isRedirecting"
+          @redirect="handleSocialRedirect"
+        />
       </div>
-      <AuthSocial :loading="isRedirecting" @redirect="handleSocialRedirect" />
-    </v-sheet>
 
-    <div class="pa-6">
-      <v-progress-circular
-        v-if="isRedirecting"
-        indeterminate
-        color="primary"
-        size="80"
-        class="mx-auto d-block"
-      />
-      <div v-else class="auth-card__form">
-        <AuthLoginForm />
+      <div class="login-card__form">
+        <AuthLoginForm :disabled="isRedirecting" />
       </div>
+
+      <transition name="login-card__overlay-fade">
+        <div v-if="isRedirecting" class="login-card__overlay">
+          <v-progress-circular indeterminate color="primary" size="64" />
+        </div>
+      </transition>
     </div>
-  </v-card>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 
 import AuthLoginForm from '~/components/auth/LoginForm.vue'
 import AuthSocial from '~/components/auth/Social.vue'
@@ -49,6 +39,7 @@ definePageMeta({
   breadcrumb: 'disabled',
 })
 
+const { t } = useI18n()
 const isRedirecting = ref(false)
 
 function handleSocialRedirect(provider: SocialProvider) {
@@ -65,12 +56,95 @@ function handleSocialRedirect(provider: SocialProvider) {
 </script>
 
 <style scoped>
-.auth-card {
-  max-width: 450px;
-  margin-inline: auto;
+.login-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1.5rem, 3vw, 3rem);
 }
 
-.auth-card__form {
-  margin-top: -80px;
+.login-card {
+  position: relative;
+  width: min(100%, 420px);
+  border-radius: 28px;
+  padding: clamp(2.25rem, 4vw, 2.75rem) clamp(1.75rem, 4vw, 2.5rem) clamp(2.5rem, 4vw, 3rem);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.96));
+  box-shadow: 0 28px 60px rgba(236, 72, 153, 0.25), 0 18px 40px rgba(30, 41, 59, 0.12);
+  overflow: hidden;
+}
+
+.login-card--loading {
+  pointer-events: none;
+}
+
+.login-card__glow {
+  position: absolute;
+  inset: -35% auto auto -35%;
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle at center, rgba(236, 72, 153, 0.35), transparent 70%);
+  filter: blur(0);
+  z-index: 0;
+}
+
+.login-card__header {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.login-card__title {
+  font-size: clamp(2rem, 4vw, 2.4rem);
+  font-weight: 800;
+  letter-spacing: 0.02em;
+  color: rgb(15, 23, 42);
+  margin: 0;
+}
+
+.login-card__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.login-card__socials {
+  margin-top: 0.5rem;
+}
+
+.login-card__form {
+  position: relative;
+  z-index: 1;
+  margin-top: clamp(1.75rem, 4vw, 2.25rem);
+}
+
+.login-card__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.68);
+  z-index: 5;
+}
+
+.login-card__overlay-fade-enter-active,
+.login-card__overlay-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.login-card__overlay-fade-enter-from,
+.login-card__overlay-fade-leave-to {
+  opacity: 0;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    width: 100%;
+    padding-inline: clamp(1.25rem, 4vw, 1.75rem);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- restyle the shared login form with a modern pill design and support for compact usage
- refresh the login page hero card with prominent branding, social icons, and loading overlay
- show the redesigned login card in the right sidebar for guests and add supporting translations

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d951f8b820832692dbebf92cc3a141