### PR TITLE
Fix color mode storage to use cookies

### DIFF
--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -90,12 +90,21 @@ export function useThemes() {
     }
   }
 
+  const colorModeCookie = useCookie<'light' | 'dark' | 'auto'>('color-mode', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
   const colorMode = useColorMode({
-    storage: 'cookie',
     storageKey: 'color-mode',
-    cookieOptions: {
-      sameSite: 'lax',
-      secure: process.env.NODE_ENV === 'production',
+    storage: {
+      getItem: () => colorModeCookie.value ?? 'auto',
+      setItem: (_, value) => {
+        colorModeCookie.value = value as typeof colorModeCookie.value
+      },
+      removeItem: () => {
+        colorModeCookie.value = null
+      },
     },
   })
   const isDark = computed(() => colorMode.value === 'dark')


### PR DESCRIPTION
## Summary
- replace the invalid string storage configuration passed to `useColorMode`
- persist color mode selection via a cookie-backed storage shim

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d959c978208326bede06190e3fd2a2