### PR TITLE
Optimize right sidebar loading

### DIFF
--- a/components/layout/AppSidebarRight.vue
+++ b/components/layout/AppSidebarRight.vue
@@ -8,6 +8,7 @@
 
     <div v-if="!isAuthenticated" class="sidebar-login-card">
       <ParticlesBg
+        v-if="shouldRenderParticles"
         class="sidebar-login-card__particles"
         :quantity="120"
         :ease="120"
@@ -37,13 +38,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import { computed, defineAsyncComponent, onMounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-
-import AuthLoginForm from '~/components/auth/LoginForm.vue'
-import AuthSocial from '~/components/auth/Social.vue'
 import { resolveSocialRedirect, type SocialProvider } from '~/lib/auth/social'
 import { useAuthSession } from '~/stores/auth-session'
+
+const HaloSearch = defineAsyncComponent(() => import('~/components/content/inspira/ui/halo-search/HaloSearch.vue'))
+const ParticlesBg = defineAsyncComponent(() => import('~/components/content/inspira/ui/particles-bg/ParticlesBg.vue'))
+const AuthLoginForm = defineAsyncComponent(() => import('~/components/auth/LoginForm.vue'))
+const AuthSocial = defineAsyncComponent(() => import('~/components/auth/Social.vue'))
 
 interface SidebarItem {
   key: string
@@ -71,6 +74,28 @@ const isAuthenticated = computed(() => auth.isAuthenticated.value)
 const { t } = useI18n()
 
 const isRedirecting = ref(false)
+const shouldRenderParticles = ref(false)
+
+onMounted(() => {
+  if (!import.meta.client) {
+    return
+  }
+
+  function enableParticles() {
+    shouldRenderParticles.value = true
+  }
+
+  const idleWindow = window as typeof window & {
+    requestIdleCallback?: (callback: () => void) => number
+  }
+
+  if (typeof idleWindow.requestIdleCallback === 'function') {
+    idleWindow.requestIdleCallback(enableParticles)
+    return
+  }
+
+  window.setTimeout(enableParticles, 200)
+})
 
 watch(
   () => auth.isAuthenticated.value,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -46,13 +46,26 @@
       width="340"
       class="app-drawer"
     >
-      <div class="pane-scroll px-3 py-4">
-        <AppSidebarRight
-            :items="sidebarItems"
-            :active-key="activeSidebar"
-            @select="handleSidebarSelect"
-        />
-      </div>
+      <Suspense>
+        <template #default>
+          <div class="pane-scroll px-3 py-4">
+            <AppSidebarRight
+                :items="sidebarItems"
+                :active-key="activeSidebar"
+                @select="handleSidebarSelect"
+            />
+          </div>
+        </template>
+        <template #fallback>
+          <div class="pane-scroll px-3 py-4">
+            <div class="flex flex-col gap-4">
+              <div class="h-10 rounded-2xl bg-slate-200/60" />
+              <div class="h-24 rounded-2xl bg-slate-200/60" />
+              <div class="h-24 rounded-2xl bg-slate-200/60" />
+            </div>
+          </div>
+        </template>
+      </Suspense>
     </v-navigation-drawer>
 
     <v-main class="app-surface">
@@ -66,12 +79,13 @@
 </template>
 
 <script setup lang="ts">
-import { watch, computed, ref } from 'vue'
+import { watch, computed, ref, defineAsyncComponent } from 'vue'
 import { useDisplay, useTheme } from 'vuetify'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 import AppTopBar from '@/components/layout/AppTopBar.vue'
 import { useRightSidebarData } from '@/composables/useRightSidebarData'
-import AppSidebarRight from "~/components/layout/AppSidebarRight.vue";
+
+const AppSidebarRight = defineAsyncComponent(() => import('~/components/layout/AppSidebarRight.vue'))
 
 interface LayoutSidebarItem {
   key: string


### PR DESCRIPTION
## Summary
- lazy load the right sidebar drawer content with a suspense fallback to avoid blocking the initial render
- convert the sidebar login card dependencies to async components and only mount the particle background when the browser is idle

## Testing
- pnpm exec eslint components/layout/AppSidebarRight.vue layouts/default.vue
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d95c32bdfc8326a98054b058a00c03