### PR TITLE
Align comment API calls with platform endpoints

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -425,8 +425,13 @@ export default defineNuxtConfig({
       NUXT_CLARITY_ID: process.env.NUXT_CLARITY_ID,
       NUXT_ADSENSE_ACCOUNT: process.env.NUXT_ADSENSE_ACCOUNT,
       blogApiEndpoint: process.env.NUXT_PUBLIC_BLOG_API_ENDPOINT ?? "https://blog.bro-world.org/public/post",
+      blogCommentApiEndpoint:
+        process.env.NUXT_PUBLIC_BLOG_COMMENT_API_ENDPOINT ?? "https://blog.bro-world.org/public/comment",
       blogPrivateApiEndpoint:
-        process.env.NUXT_PUBLIC_BLOG_PRIVATE_API_ENDPOINT ?? "https://blog.bro-world.org/v1/private/post",
+        process.env.NUXT_PUBLIC_BLOG_PRIVATE_API_ENDPOINT ?? "https://blog.bro-world.org/v1/platform/post",
+      blogPrivateCommentApiEndpoint:
+        process.env.NUXT_PUBLIC_BLOG_PRIVATE_COMMENT_API_ENDPOINT ??
+        "https://blog.bro-world.org/v1/platform/comment",
       baseUrl: process.env.NUXT_PUBLIC_BASE_URL ?? "https://bro-world-space.com",
       apiBase: process.env.NUXT_PUBLIC_API_BASE ?? "/api",
     },

--- a/server/api/posts/[id]/comments.get.ts
+++ b/server/api/posts/[id]/comments.get.ts
@@ -1,0 +1,1 @@
+export { default } from "../../v1/posts/[id]/comments/index.get";

--- a/server/api/v1/posts/[id]/comments/index.get.ts
+++ b/server/api/v1/posts/[id]/comments/index.get.ts
@@ -1,0 +1,30 @@
+import { createError } from "h3";
+import { fetchPostCommentsFromSource } from "~/server/utils/posts/api";
+
+export default defineEventHandler(async (event) => {
+  const { id } = event.context.params ?? {};
+  const trimmedId = typeof id === "string" ? id.trim() : "";
+
+  if (!trimmedId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Post identifier is required.",
+    });
+  }
+
+  try {
+    const comments = await fetchPostCommentsFromSource(event, trimmedId);
+
+    return comments;
+  } catch (error) {
+    console.error(`Failed to fetch comments for post ${trimmedId}`, error);
+
+    throw createError({
+      statusCode: 502,
+      statusMessage: "Unable to load comments.",
+      data: {
+        message: error instanceof Error ? error.message : String(error ?? ""),
+      },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- update runtime configuration to expose dedicated platform post/comment endpoints
- route authenticated post and comment mutations through the new platform APIs and add helpers to fetch comment trees
- expose an authenticated API handler and store helper to retrieve full post comment hierarchies

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d95ebf7c9c8326ae90390bfa8321d6