### PR TITLE
Improve layout icon rendering performance

### DIFF
--- a/components/layout/AppIcon.vue
+++ b/components/layout/AppIcon.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-icon
+    v-if="resolved.type === 'mdi'"
+    v-bind="attrs"
+    :icon="resolved.value"
+    :size="size"
+  />
+  <Icon
+    v-else-if="resolved.type === 'other'"
+    v-bind="attrs"
+    :name="resolved.value"
+    :size="size"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    name?: string
+    size?: number | string
+  }>(),
+  {
+    name: '',
+    size: 24,
+  },
+)
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+
+const resolved = computed(() => {
+  const rawName = props.name?.trim() ?? ''
+
+  if (!rawName)
+    return { type: 'none' as const, value: '' }
+
+  if (rawName.startsWith('mdi:'))
+    return { type: 'mdi' as const, value: `mdi-${rawName.slice(4)}` }
+
+  if (rawName.startsWith('mdi-'))
+    return { type: 'mdi' as const, value: rawName }
+
+  return { type: 'other' as const, value: rawName }
+})
+
+const size = computed(() => props.size)
+</script>

--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -17,10 +17,10 @@
             @click="handleParentSelect(item)"
           >
             <div class="flex items-center gap-3">
-              <Icon
+              <AppIcon
                 v-if="item.icon"
                 class="sidebar-icon"
-                :name="resolveIconName(item.icon)"
+                :name="item.icon"
                 :size="20"
               />
               <span class="text-sm font-medium text-foreground">{{ t(item.label) }}</span>
@@ -59,10 +59,10 @@
                 :aria-current="child.key === activeKey ? 'page' : undefined"
                 @click="emit('select', child.key)"
               >
-                <Icon
+                <AppIcon
                   v-if="child.icon"
                   class="sidebar-subicon"
-                  :name="resolveIconName(child.icon)"
+                  :name="child.icon"
                   :size="18"
                 />
                 <span class="text-sm text-muted-foreground">{{ t(child.label) }}</span>
@@ -160,18 +160,6 @@ function handleParentSelect(item: SidebarItem) {
     toggleGroup(item.key)
 }
 
-function resolveIconName(name?: string) {
-  if (!name)
-    return ''
-
-  if (name.includes(':'))
-    return name
-
-  if (name.startsWith('mdi-'))
-    return `mdi:${name.slice(4)}`
-
-  return name
-}
 const emit = defineEmits<{ (e: 'select', key: string): void }>()
 </script>
 

--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -1,13 +1,13 @@
 <template>
   <v-app-bar
       class="app-top-bar"
-      :class="isDark ? 'text-white' : 'text-black'"
+      :class="isDarkMode ? 'text-white' : 'text-black'"
       :color="textGradient"
       app
       :elevation="10" rounded
       height="50"
   >
-    <template v-slot:image>
+    <template #image>
       <v-img
           cover
           :gradient="gradient"
@@ -21,7 +21,7 @@
         :aria-label="t('layout.actions.openNavigation')"
         @click="emit('toggle-left')"
       >
-        <Icon
+        <AppIcon
           name="mdi:menu"
           :size="24"
         />
@@ -45,7 +45,7 @@
             :aria-label="t('layout.actions.goBack')"
             @click="emit('go-back')"
         >
-          <Icon
+          <AppIcon
               name="mdi:arrow-left"
               :size="22"
           />
@@ -56,7 +56,7 @@
             :aria-label="t('layout.actions.refresh')"
             @click="emit('refresh')"
         >
-          <Icon
+          <AppIcon
               name="mdi:refresh"
               :size="22"
           />
@@ -68,7 +68,7 @@
             :aria-label="t('layout.actions.openNavigation')"
             @click="emit('toggle-left')"
         >
-          <Icon
+          <AppIcon
               name="mdi-format-align-justify"
               :size="22"
           />
@@ -99,22 +99,22 @@
               v-bind="tooltipProps"
               :aria-label="t(icon.label)"
           >
-            <Icon
-                :name="resolveIconName(icon.name)"
+            <AppIcon
+                :name="icon.name"
                 :size="26"
             />
           </v-btn>
         </template>
       </v-tooltip>
     </div>
-    <template v-slot:append>
+    <template #append>
       <div class="flex items-center gap-3">
         <button
             type="button"
             :class="iconTriggerClasses"
             :aria-label="t('layout.actions.notifications')"
         >
-          <Icon
+          <AppIcon
               name="mdi:bell-outline"
               :size="22"
           />
@@ -124,7 +124,7 @@
             :class="iconTriggerClasses"
             :aria-label="t('layout.actions.cart')"
         >
-          <Icon
+          <AppIcon
               name="mdi:shopping-outline"
               :size="22"
           />
@@ -137,7 +137,7 @@
                 :aria-label="t('layout.actions.profile')"
                 v-bind="profileProps"
             >
-              <Icon
+              <AppIcon
                   name="mdi:person-outline"
                   :size="22"
               />
@@ -152,7 +152,7 @@
                 @click="handleUserMenuSelect(item)"
             >
               <template #prepend>
-                <Icon
+                <AppIcon
                     :name="item.icon"
                     :size="20"
                 />
@@ -168,7 +168,7 @@
                 :aria-label="t('layout.actions.changeLanguage', { locale: localeLabel })"
                 v-bind="languageProps"
             >
-              <Icon
+              <AppIcon
                   name="mdi:flag-outline"
                   :size="22"
               />
@@ -193,7 +193,7 @@
             :aria-label="t('layout.actions.openWidgets')"
             @click="emit('toggle-right')"
         >
-          <Icon
+          <AppIcon
               name="mdi:dots-vertical"
               :size="22"
           />
@@ -207,7 +207,7 @@
             :aria-label="t('layout.actions.openWidgets')"
             @click="emit('toggle-right')"
         >
-          <Icon
+          <AppIcon
               name="mdi-format-align-justify"
               :size="22"
           />
@@ -219,8 +219,6 @@
 
 <script setup lang="ts">
 import { useAuthSession } from '~/stores/auth-session'
-
-const isDark = computed(() => useColorMode().value == "dark");
 
 interface AppIcon {
   name: string
@@ -260,6 +258,8 @@ const props = defineProps<{
   showRightToggle: boolean
 }>()
 
+const isDarkMode = computed(() => props.isDark)
+
 const emit = defineEmits([
   'toggle-left',
   'toggle-right',
@@ -278,8 +278,8 @@ const { t } = useI18n()
 const config = useConfig()
 
 const { i18nEnabled, localePath } = useI18nDocs()
-const gradient = computed(() => (isDark.value ? "#000" : "#fff"));
-const textGradient = computed(() => (isDark.value ? "#fff" : "#000"));
+const gradient = computed(() => (isDarkMode.value ? "#000" : "#fff"))
+const textGradient = computed(() => (isDarkMode.value ? "#fff" : "#000"))
 
 const showInlineSearch = computed(
   () => !config.value.search.inAside && config.value.search.style === 'input',
@@ -328,19 +328,6 @@ const userMenuItems = computed<UserMenuItem[]>(() => {
     },
   ]
 })
-
-function resolveIconName(name?: string) {
-  if (!name)
-    return ''
-
-  if (name.includes(':'))
-    return name
-
-  if (name.startsWith('mdi-'))
-    return `mdi:${name.slice(4)}`
-
-  return name
-}
 
 const localeFlags: Record<string, string> = {
   en: '🇬🇧',


### PR DESCRIPTION
## Summary
- add an `AppIcon` helper that uses Vuetify's built-in mdi font before falling back to nuxt-icon
- update the top bar and sidebar layouts to render icons through `AppIcon`, removing the async resolve helper and aligning the dark-mode toggle logic

## Testing
- pnpm exec eslint components/layout/AppTopBar.vue components/layout/AppSidebar.vue components/layout/AppIcon.vue

------
https://chatgpt.com/codex/tasks/task_e_68d9607608708326a2f15a8bc682a41a