### PR TITLE
Sync auth token availability with cookie state

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -97,6 +97,7 @@ export const useAuthSession = defineStore('auth-session', () => {
 
   if (sessionTokenCookie.value) {
     sessionTokenState.value = sessionTokenCookie.value
+    tokenAvailableState.value = true
   }
 
   if (import.meta.client) {
@@ -116,6 +117,7 @@ export const useAuthSession = defineStore('auth-session', () => {
       sessionTokenState,
       (value) => {
         sessionTokenCookie.value = value
+        tokenAvailableState.value = Boolean(value)
       },
       { immediate: true },
     )
@@ -145,6 +147,7 @@ export const useAuthSession = defineStore('auth-session', () => {
   function setSessionToken(token: string | null) {
     sessionTokenState.value = token
     sessionTokenCookie.value = token
+    tokenAvailableState.value = Boolean(token)
   }
 
   function setSessionMessage(message: string | null) {


### PR DESCRIPTION
## Summary
- ensure the auth session store marks the token as available when a session cookie is present
- keep the in-memory token availability flag in sync when the session token changes

## Testing
- pnpm exec eslint stores/auth-session.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9681ad458832694965c40fc192028