### PR TITLE
Fix post store snapshot cloning for optimistic updates

### DIFF
--- a/stores/posts.ts
+++ b/stores/posts.ts
@@ -29,6 +29,14 @@ interface PostsStorePost extends BlogPost {
   __optimistic?: boolean;
 }
 
+function clonePost(post: PostsStorePost) {
+  try {
+    return structuredClone(post) as PostsStorePost;
+  } catch {
+    return JSON.parse(JSON.stringify(post)) as PostsStorePost;
+  }
+}
+
 function createOptimisticPost(id: string, content: string, overrides?: Partial<BlogPost>): PostsStorePost {
   const timestamp = new Date().toISOString();
 
@@ -448,7 +456,7 @@ export const usePostsStore = defineStore("posts", () => {
       return existing;
     }
 
-    const snapshot = structuredClone(existing) as PostsStorePost;
+    const snapshot = clonePost(existing);
     items.value = {
       ...items.value,
       [trimmedId]: { ...existing, ...updates, __optimistic: true },
@@ -506,7 +514,7 @@ export const usePostsStore = defineStore("posts", () => {
       return;
     }
 
-    const snapshot = structuredClone(existing) as PostsStorePost;
+    const snapshot = clonePost(existing);
     const previousIndex = removePostFromState(trimmedId);
 
     deleting.value = {


### PR DESCRIPTION
## Summary
- add a safe post clone helper that falls back when structuredClone cannot copy reactive state
- use the helper when taking snapshots for optimistic post updates and deletions to prevent edit failures

## Testing
- pnpm vitest --run tests/unit/postsStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9838772488326bc0a69fbcea63610