### PR TITLE
Require authentication for blog UI interactions

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -200,6 +200,11 @@
         "poll": "إضافة استطلاع"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "like": "إعجاب",
       "love": "محبة",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -200,6 +200,11 @@
         "poll": "Umfrage hinzufügen"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Veröffentlicht am {date}",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -200,6 +200,11 @@
         "poll": "Add poll"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Published on {date}",

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -419,6 +419,11 @@
         "poll": "Agregar encuesta"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Publicado el {date}",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -200,6 +200,11 @@
         "poll": "Ajouter un sondage"
       }
     },
+    "auth": {
+      "postRequired": "Connectez-vous pour partager vos idées.",
+      "reactionRequired": "Connectez-vous pour réagir aux publications.",
+      "commentRequired": "Connectez-vous pour participer à la discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Publié le {date}",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -419,6 +419,11 @@
         "poll": "Aggiungi sondaggio"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Pubblicato il {date}",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -419,6 +419,11 @@
         "poll": "Добавить опрос"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "post": {
         "publishedOn": "Опубликовано {date}",

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -203,6 +203,11 @@
         "poll": "添加投票"
       }
     },
+    "auth": {
+      "postRequired": "Sign in to share what's on your mind.",
+      "reactionRequired": "Sign in to react to posts.",
+      "commentRequired": "Sign in to join the discussion."
+    },
     "reactions": {
       "like": "点赞",
       "love": "喜爱",


### PR DESCRIPTION
## Summary
- disable the new post composer controls for signed-out visitors and surface a login prompt
- block comment and reaction interactions on posts and comments when unauthenticated while showing clear feedback
- add localization strings for the new authentication prompts across all locales

## Testing
- pnpm exec eslint components/blog/BlogPostCard.vue components/blog/BlogCommentCard.vue components/blog/NewPost.vue

------
https://chatgpt.com/codex/tasks/task_e_68d9864a26488326b998696e778617e9