### PR TITLE
Clean up lint issues and tighten dev tooling

### DIFF
--- a/lib/contact/validation.ts
+++ b/lib/contact/validation.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 
-const trimmedString = () => z.string().trim()
+function trimmedString() {
+  return z.string().trim()
+}
 
 const contactSchema = z
   .object({

--- a/middleware/admin.ts
+++ b/middleware/admin.ts
@@ -1,8 +1,10 @@
-import { useAuthSession } from "~/stores/auth-session";
 import { createError } from '#imports'
 import { ADMIN_ROLE_KEYS } from '~/lib/navigation/sidebar'
+import { useAuthSession } from '~/stores/auth-session'
 
-export default defineNuxtRouteMiddleware(async (_to) => {
+type MiddlewareResult = ReturnType<typeof defineNuxtRouteMiddleware>
+
+export default defineNuxtRouteMiddleware(async (_to): MiddlewareResult => {
   const auth = useAuthSession()
   await auth.initialize()
 
@@ -13,7 +15,7 @@ export default defineNuxtRouteMiddleware(async (_to) => {
     return
   }
 
-  if (process.server) {
+  if (import.meta.server) {
     return abortNavigation(
       createError({
         statusCode: 403,

--- a/pages/admin/blog.vue
+++ b/pages/admin/blog.vue
@@ -94,7 +94,7 @@
           <v-skeleton-loader type="table-row@5" />
         </template>
 
-        <template #item.title="{ item }">
+        <template #[`item.title`]="{ item }">
           <div class="d-flex flex-column gap-1">
             <div class="d-flex align-center gap-2">
               <span class="text-body-1 font-weight-medium text-high-emphasis">{{ item.title }}</span>
@@ -112,23 +112,23 @@
           </div>
         </template>
 
-        <template #item.author="{ item }">
+        <template #[`item.author`]="{ item }">
           <span class="text-body-2 text-medium-emphasis">{{ item.author }}</span>
         </template>
 
-        <template #item.publishedTimestamp="{ item }">
+        <template #[`item.publishedTimestamp`]="{ item }">
           <span class="text-body-2 text-medium-emphasis">{{ item.publishedLabel }}</span>
         </template>
 
-        <template #item.reactions="{ item }">
+        <template #[`item.reactions`]="{ item }">
           <span class="text-body-2 font-weight-medium">{{ formatNumber(item.reactions) }}</span>
         </template>
 
-        <template #item.comments="{ item }">
+        <template #[`item.comments`]="{ item }">
           <span class="text-body-2 font-weight-medium">{{ formatNumber(item.comments) }}</span>
         </template>
 
-        <template #item.actions="{ item }">
+        <template #[`item.actions`]="{ item }">
           <div class="d-flex justify-end gap-1">
             <v-btn
               variant="text"

--- a/pages/admin/user-management.vue
+++ b/pages/admin/user-management.vue
@@ -59,18 +59,18 @@
           :search="search"
           class="user-table"
         >
-          <template #item.user="{ item }">
+          <template #[`item.user`]="{ item }">
             <div class="d-flex flex-column">
               <span class="text-body-1 font-weight-medium">{{ item.displayName }}</span>
               <span class="text-body-2 text-medium-emphasis">@{{ item.username }}</span>
             </div>
           </template>
 
-          <template #item.email="{ item }">
+          <template #[`item.email`]="{ item }">
             <span class="text-body-2">{{ item.email }}</span>
           </template>
 
-          <template #item.status="{ item }">
+          <template #[`item.status`]="{ item }">
             <v-chip
               :color="item.enabled ? 'success' : 'warning'"
               size="small"
@@ -81,7 +81,7 @@
             </v-chip>
           </template>
 
-          <template #item.roles="{ item }">
+          <template #[`item.roles`]="{ item }">
             <div class="d-flex flex-wrap gap-2">
               <v-chip
                 v-for="role in item.roles"
@@ -96,11 +96,11 @@
             </div>
           </template>
 
-          <template #item.updatedAt="{ item }">
+          <template #[`item.updatedAt`]="{ item }">
             <span class="text-body-2 text-medium-emphasis">{{ formatDate(item.updatedAt) }}</span>
           </template>
 
-          <template #item.actions="{ item }">
+          <template #[`item.actions`]="{ item }">
             <div class="d-flex gap-2">
               <v-btn
                 icon="mdi-pencil"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,13 @@
 <template>
   <main aria-labelledby="blog-heading">
 
-    <NewPost v-if="isAuthenticated"
-             :avatar="user.avatarUrl"
-             :userName="user.name"
-             @submit="createPost"
-             @attach="onAttach" />
+    <NewPost
+        v-if="isAuthenticated"
+        :avatar="user.avatarUrl"
+        :user-name="user.name"
+        @submit="createPost"
+        @attach="onAttach"
+    />
 
     <div v-if="pending" class="grid gap-4">
       <div

--- a/pages/logout.vue
+++ b/pages/logout.vue
@@ -20,6 +20,8 @@
 </template>
 
 <script setup lang="ts">
+import { useAuthSession } from '~/stores/auth-session'
+
 definePageMeta({
   middleware: 'auth',
   title: 'logout',

--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 
 type StateRef<T> = ReturnType<typeof ref<T>>
 
-const stateRegistry = new Map<string, StateRef<any>>()
+const stateRegistry = new Map<string, StateRef<unknown>>()
 
 export function useState<T>(key: string, init: () => T): StateRef<T> {
   if (!stateRegistry.has(key)) {

--- a/tests/unit/i18nPages.spec.ts
+++ b/tests/unit/i18nPages.spec.ts
@@ -118,8 +118,15 @@ const requiredKeys = [
   'seo.contact.description',
 ] as const
 
-function getValue(message: Record<string, any>, path: string) {
-  return path.split('.').reduce((acc, part) => (acc ? acc[part] : undefined), message)
+type LocaleMessages = Record<string, unknown>
+
+function getValue(message: LocaleMessages, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc && typeof acc === 'object' && part in acc) {
+      return (acc as LocaleMessages)[part]
+    }
+    return undefined
+  }, message)
 }
 
 describe('page translations', () => {
@@ -127,7 +134,7 @@ describe('page translations', () => {
     describe(code, () => {
       for (const key of requiredKeys) {
         it(`includes translation for ${key}`, () => {
-          const value = getValue(messages as Record<string, any>, key)
+          const value = getValue(messages as LocaleMessages, key)
           expect(value, `Missing key ${key} for locale ${code}`).toBeTruthy()
         })
       }

--- a/tests/unit/postsStore.spec.ts
+++ b/tests/unit/postsStore.spec.ts
@@ -50,32 +50,34 @@ describe('posts store', () => {
     expect(listRef).toBeDefined()
     expect(timestampsRef).toBeDefined()
 
-    const makePost = (id: string, overrides: Partial<BlogPost> = {}): BlogPost => ({
-      id,
-      title: `Title ${id}`,
-      summary: `Summary ${id}`,
-      content: `Content ${id}`,
-      url: null,
-      slug: `slug-${id}`,
-      medias: [],
-      isReacted: null,
-      publishedAt: new Date(2024, 0, Number(id.replace('post-', '')) + 1).toISOString(),
-      sharedFrom: null,
-      reactions_count: 1,
-      totalComments: 0,
-      user: {
-        id: `user-${id}`,
-        firstName: 'Jane',
-        lastName: 'Doe',
-        username: `jane-${id}`,
-        email: 'jane@example.com',
-        enabled: true,
-        photo: null,
-      },
-      reactions_preview: [],
-      comments_preview: [],
-      ...overrides,
-    })
+    function makePost(id: string, overrides: Partial<BlogPost> = {}): BlogPost {
+      return {
+        id,
+        title: `Title ${id}`,
+        summary: `Summary ${id}`,
+        content: `Content ${id}`,
+        url: null,
+        slug: `slug-${id}`,
+        medias: [],
+        isReacted: null,
+        publishedAt: new Date(2024, 0, Number(id.replace('post-', '')) + 1).toISOString(),
+        sharedFrom: null,
+        reactions_count: 1,
+        totalComments: 0,
+        user: {
+          id: `user-${id}`,
+          firstName: 'Jane',
+          lastName: 'Doe',
+          username: `jane-${id}`,
+          email: 'jane@example.com',
+          enabled: true,
+          photo: null,
+        },
+        reactions_preview: [],
+        comments_preview: [],
+        ...overrides,
+      }
+    }
 
     const post1 = makePost('post-1')
     const post2 = makePost('post-2')

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -18,7 +18,7 @@ config.global.stubs = {
 }
 
 if (!('visualViewport' in window)) {
-  const noop = () => {}
+  function noop() {}
   const mockViewport = {
     width: window.innerWidth,
     height: window.innerHeight,


### PR DESCRIPTION
## Summary
- sanitize the Icon component and update the UI playground to use stricter typing, proper theme handling, and lint-friendly slot markup
- fix admin table slot usage, logout imports, and middleware server checks to comply with project lint rules
- replace arrow helpers in validation and tests to satisfy func-style and no-explicit-any requirements

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d99192ae5483269160530b4d2687a9