### PR TITLE
feat: add Vuetify skeleton loaders to blog views

### DIFF
--- a/components/blog/PostCardSkeleton.vue
+++ b/components/blog/PostCardSkeleton.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-card
+    class="post-skeleton"
+    variant="tonal"
+    elevation="6"
+    rounded="xl"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading post"
+  >
+    <v-skeleton-loader
+      type="list-item-avatar-two-line"
+      class="mb-4"
+    />
+    <v-skeleton-loader
+      type="paragraph@3"
+      class="mb-6"
+    />
+    <div class="post-skeleton__actions">
+      <v-skeleton-loader
+        type="chip"
+        width="140"
+        class="me-2"
+      />
+      <v-skeleton-loader
+        type="chip"
+        width="120"
+      />
+    </div>
+  </v-card>
+</template>
+
+<style scoped>
+.post-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+}
+
+.post-skeleton__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+</style>

--- a/components/content/common/ComponentViewer.vue
+++ b/components/content/common/ComponentViewer.vue
@@ -6,7 +6,7 @@
       </template>
       <template #fallback>
         <div class="p-4">
-          <Spinner class="mx-auto" />
+          <v-skeleton-loader type="card" class="mx-auto" />
         </div>
       </template>
     </Suspense>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -59,9 +59,16 @@
         <template #fallback>
           <div class="pane-scroll px-3 py-4">
             <div class="flex flex-col gap-4">
-              <div class="h-10 rounded-2xl bg-slate-200/60" />
-              <div class="h-24 rounded-2xl bg-slate-200/60" />
-              <div class="h-24 rounded-2xl bg-slate-200/60" />
+              <v-skeleton-loader
+                type="list-item-two-line"
+                class="rounded-2xl"
+              />
+              <v-skeleton-loader
+                v-for="index in 2"
+                :key="index"
+                type="card"
+                class="rounded-2xl"
+              />
             </div>
           </div>
         </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,28 +10,7 @@
     />
 
     <div v-if="pending" class="grid gap-4">
-      <div
-          v-for="index in 4"
-          :key="index"
-          class="flex flex-col gap-6 rounded-[32px] border border-white/80 bg-white/80 p-6 shadow-[0_30px_60px_-40px_rgba(15,23,42,0.55)]"
-      >
-        <div class="flex items-center gap-4">
-          <div class="h-12 w-12 rounded-2xl bg-slate-200/60" />
-          <div class="flex-1 space-y-2">
-            <div class="h-3 w-32 rounded-full bg-slate-200/60" />
-            <div class="h-3 w-24 rounded-full bg-slate-200/60" />
-          </div>
-        </div>
-        <div class="space-y-3">
-          <div class="h-3 w-3/4 rounded-full bg-slate-200/60" />
-          <div class="h-3 w-2/3 rounded-full bg-slate-200/60" />
-          <div class="h-3 w-full rounded-full bg-slate-200/60" />
-        </div>
-        <div class="mt-auto flex gap-3">
-          <div class="h-8 w-32 rounded-full bg-slate-200/60" />
-          <div class="h-8 w-32 rounded-full bg-slate-200/60" />
-        </div>
-      </div>
+      <PostCardSkeleton v-for="index in 4" :key="index" />
     </div>
 
     <template v-else>
@@ -56,6 +35,7 @@ import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
 import { useAuthStore } from "~/composables/useAuthStore";
 import type { BlogPost, ReactionType } from "~/lib/mock/blog";
+import PostCardSkeleton from "~/components/blog/PostCardSkeleton.vue";
 
 definePageMeta({
   showRightWidgets: true,


### PR DESCRIPTION
## Summary
- add a reusable PostCardSkeleton built with Vuetify loaders for blog post placeholders
- replace ad-hoc loading placeholders in the blog index page and default layout with Vuetify skeleton loaders
- update the component viewer fallback to use a Vuetify skeleton loader for a consistent loading state

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d997a6bbe483269e6f42f88eac8afa