### PR TITLE
Refactor new post dialog to load asynchronously

### DIFF
--- a/components/blog/NewPost.vue
+++ b/components/blog/NewPost.vue
@@ -14,6 +14,7 @@
           rounded="pill"
           :ripple="false"
           :disabled="!isAuthenticated"
+          data-test="new-post-trigger"
           @click="openDialog()"
       >
         {{ placeholderText }}
@@ -55,112 +56,33 @@
     />
   </v-card>
 
-  <!-- Modal: Créer un post -->
-  <v-dialog v-model="dialog" max-width="680" persistent>
-    <v-card class="rounded-xl">
-      <v-card-title class="d-flex align-center justify-space-between">
-        <span class="text-h6 font-weight-semibold">{{ dialogTitle }}</span>
-        <v-btn icon="mdi-close" variant="text" @click="closeDialog()">
-          <Icon name="mdi-close" />
-        </v-btn>
-      </v-card-title>
-
-      <v-divider />
-
-      <v-card-text class="pt-4">
-        <!-- Entête auteur + audience -->
-        <div class="d-flex align-start ga-3 mb-2">
-          <v-avatar size="40">
-            <v-img :src="avatar" alt="Avatar" />
-          </v-avatar>
-          <div class="d-flex flex-column">
-            <div class="text-subtitle-2 font-weight-medium">{{ userName }}</div>
-
-            <v-menu>
-              <template #activator="{ props: p }">
-                <v-btn
-                    v-bind="p"
-                    size="small"
-                    variant="tonal"
-                    rounded="pill"
-                    prepend-icon="mdi-account-multiple"
-                    class="text-capitalize"
-                >
-                  <Icon name="mdi-account-multiple" class="me-2" />
-                  {{ audienceLabel }}
-                </v-btn>
-              </template>
-              <v-list density="compact">
-                <v-list-item v-for="opt in audienceOptions" :key="opt.value" @click="audience = opt.value">
-                  <template #prepend><Icon :name="opt.icon" class="mr-2" /></template>
-                  <v-list-item-title>{{ opt.label }}</v-list-item-title>
-                </v-list-item>
-              </v-list>
-            </v-menu>
-          </div>
-        </div>
-
-        <!-- Zone de saisie -->
-        <v-textarea
-            v-model="message"
-            variant="plain"
-            auto-grow
-            :rows="5"
-            class="text-body-1"
-            :placeholder="placeholderText"
-        />
-
-        <div class="d-flex justify-end text-caption text-medium-emphasis">
-          {{ message.length }}/{{ maxLength }}
-        </div>
-        <v-card
-            variant="outlined"
-            class="rounded-xl my-2"
-        >
-          <div class="d-flex align-center justify-space-between px-3 py-2">
-            <div class="text-medium-emphasis text-body-2">{{ addToPostLabel }}</div>
-            <div class="d-flex ga-1">
-              <v-btn icon variant="text" :title="attachmentLabels.media" @click="onAttach('media')">
-                <Icon name="mdi-image-multiple" />
-              </v-btn>
-              <v-btn icon variant="text" :title="attachmentLabels.tag" @click="onAttach('tag')">
-                <Icon name="mdi-account-plus-outline" />
-              </v-btn>
-              <v-btn icon variant="text" :title="attachmentLabels.feeling" @click="onAttach('feeling')">
-                <Icon name="mdi-emoticon-happy-outline" />
-              </v-btn>
-              <v-btn icon variant="text" :title="attachmentLabels.location" @click="onAttach('location')">
-                <Icon name="mdi-map-marker" />
-              </v-btn>
-              <v-btn icon variant="text" :title="attachmentLabels.gif" @click="onAttach('gif')">
-                <Icon name="mdi-gif" />
-              </v-btn>
-              <v-menu>
-                <template #activator="{ props: p }">
-                  <v-btn icon variant="text" v-bind="p"><v-icon icon="mdi-dots-horizontal" /></v-btn>
-                </template>
-                <v-list density="compact">
-                  <v-list-item :title="attachmentLabels.poll" @click="onAttach('poll')" />
-                </v-list>
-              </v-menu>
-            </div>
-          </div>
-        </v-card>
-      </v-card-text>
-
-      <v-card-actions class="px-2 pb-2">
-        <v-btn block color="primary" :disabled="!canPost" @click="submitPost">
-          {{ postButtonLabel }}
-        </v-btn>
-      </v-card-actions>
-    </v-card>
-  </v-dialog>
+  <Suspense v-if="dialog && isAuthenticated">
+    <template #default>
+      <NewPostDialog
+          v-model:open="dialog"
+          :avatar="avatar"
+          :user-name="userName"
+          :placeholder="placeholderText"
+          :max-length="maxLength"
+          @submit="handleDialogSubmit"
+          @close="handleDialogClose"
+          @attach="handleAttach"
+      />
+    </template>
+    <template #fallback>
+      <div class="d-flex align-center justify-center py-8" data-test="new-post-dialog-loading">
+        <v-progress-circular indeterminate color="primary" />
+      </div>
+    </template>
+  </Suspense>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, defineAsyncComponent, ref } from 'vue'
 import { useI18n, useNuxtApp } from '#imports'
 import { useAuthStore } from '~/composables/useAuthStore'
+
+const NewPostDialog = defineAsyncComponent(() => import('./NewPostDialog.vue'))
 
 interface Props {
   userName?: string
@@ -183,9 +105,6 @@ const emit = defineEmits<{
 }>()
 
 const dialog = ref(false)
-const message = ref('')
-const audience = ref<'friends' | 'public' | 'private'>('friends')
-
 const { t } = useI18n()
 const { $notify } = useNuxtApp()
 const authStore = useAuthStore()
@@ -197,27 +116,9 @@ const quickActions = computed(() => [
   { key: 'photoVideo', label: t('blog.newPost.quickActions.photoVideo'), icon: 'mdi:image-multiple', color: 'secondary' },
   { key: 'feelingActivity', label: t('blog.newPost.quickActions.feelingActivity'), icon: 'mdi:emoticon-happy-outline', color: 'default' },
 ])
-const audienceOptions = computed(() => [
-  { value: 'public', label: t('blog.newPost.audience.public'), icon: 'mdi-earth' },
-  { value: 'friends', label: t('blog.newPost.audience.friends'), icon: 'mdi-account-multiple' },
-  { value: 'private', label: t('blog.newPost.audience.private'), icon: 'mdi-lock' },
-])
-const attachmentLabels = computed(() => ({
-  media: t('blog.newPost.attachments.media'),
-  tag: t('blog.newPost.attachments.tag'),
-  feeling: t('blog.newPost.attachments.feeling'),
-  location: t('blog.newPost.attachments.location'),
-  gif: t('blog.newPost.attachments.gif'),
-  poll: t('blog.newPost.attachments.poll'),
-}))
-const dialogTitle = computed(() => t('blog.newPost.dialog.title'))
-const addToPostLabel = computed(() => t('blog.newPost.dialog.addToPost'))
-const postButtonLabel = computed(() => t('blog.newPost.dialog.postButton'))
 const loginToPostMessage = computed(() => t('blog.auth.postRequired'))
 
-const audienceLabel = computed(() => audienceOptions.value.find(a => a.value === audience.value)?.label ?? audienceOptions.value[0]?.label ?? '')
 const maxLength = computed(() => props.maxLength)
-const canPost = computed(() => isAuthenticated.value && message.value.trim().length > 0 && message.value.length <= maxLength.value)
 
 function openDialog() {
   if (!isAuthenticated.value) {
@@ -232,28 +133,14 @@ function openDialog() {
   dialog.value = true
   emit('open')
 }
-function closeDialog() {
-  dialog.value = false
+function handleDialogSubmit(payload: { text: string; audience: string }) {
+  emit('submit', payload)
+}
+function handleDialogClose() {
   emit('close')
 }
-function onAttach(type: string) {
+function handleAttach(type: string) {
   emit('attach', type)
-}
-function submitPost() {
-  if (!isAuthenticated.value) {
-    $notify({
-      type: 'info',
-      title: t('blog.newPost.dialog.title'),
-      message: loginToPostMessage.value,
-    })
-    return
-  }
-
-  if (!canPost.value) return
-  emit('submit', { text: message.value.trim(), audience: audience.value })
-  // ici tu peux réinitialiser/fermer
-  message.value = ''
-  closeDialog()
 }
 </script>
 

--- a/components/blog/NewPostDialog.vue
+++ b/components/blog/NewPostDialog.vue
@@ -1,0 +1,192 @@
+<template>
+  <v-dialog
+      v-model="dialogOpen"
+      max-width="680"
+      persistent
+      scrollable
+      data-test="new-post-dialog"
+  >
+    <v-card class="rounded-xl">
+      <v-card-title class="d-flex align-center justify-space-between">
+        <span class="text-h6 font-weight-semibold">{{ dialogTitle }}</span>
+        <v-btn icon="mdi-close" variant="text" @click="handleClose">
+          <Icon name="mdi-close" />
+        </v-btn>
+      </v-card-title>
+
+      <v-divider />
+
+      <v-card-text class="pt-4">
+        <div class="d-flex align-start ga-3 mb-2">
+          <v-avatar size="40">
+            <v-img :src="avatar" alt="Avatar" />
+          </v-avatar>
+          <div class="d-flex flex-column">
+            <div class="text-subtitle-2 font-weight-medium">{{ userName }}</div>
+
+            <v-menu>
+              <template #activator="{ props: menuProps }">
+                <v-btn
+                    v-bind="menuProps"
+                    size="small"
+                    variant="tonal"
+                    rounded="pill"
+                    prepend-icon="mdi-account-multiple"
+                    class="text-capitalize"
+                >
+                  <Icon name="mdi-account-multiple" class="me-2" />
+                  {{ audienceLabel }}
+                </v-btn>
+              </template>
+              <v-list density="compact">
+                <v-list-item v-for="opt in audienceOptions" :key="opt.value" @click="audience = opt.value">
+                  <template #prepend><Icon :name="opt.icon" class="mr-2" /></template>
+                  <v-list-item-title>{{ opt.label }}</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </div>
+        </div>
+
+        <v-textarea
+            v-model="message"
+            variant="plain"
+            auto-grow
+            :rows="5"
+            class="text-body-1"
+            :placeholder="placeholder"
+            data-test="new-post-message"
+        />
+
+        <div class="d-flex justify-end text-caption text-medium-emphasis">
+          {{ message.length }}/{{ maxLength }}
+        </div>
+        <v-card
+            variant="outlined"
+            class="rounded-xl my-2"
+        >
+          <div class="d-flex align-center justify-space-between px-3 py-2">
+            <div class="text-medium-emphasis text-body-2">{{ addToPostLabel }}</div>
+            <div class="d-flex ga-1">
+              <v-btn icon variant="text" :title="attachmentLabels.media" @click="handleAttach('media')">
+                <Icon name="mdi-image-multiple" />
+              </v-btn>
+              <v-btn icon variant="text" :title="attachmentLabels.tag" @click="handleAttach('tag')">
+                <Icon name="mdi-account-plus-outline" />
+              </v-btn>
+              <v-btn icon variant="text" :title="attachmentLabels.feeling" @click="handleAttach('feeling')">
+                <Icon name="mdi-emoticon-happy-outline" />
+              </v-btn>
+              <v-btn icon variant="text" :title="attachmentLabels.location" @click="handleAttach('location')">
+                <Icon name="mdi-map-marker" />
+              </v-btn>
+              <v-btn icon variant="text" :title="attachmentLabels.gif" @click="handleAttach('gif')">
+                <Icon name="mdi-gif" />
+              </v-btn>
+              <v-menu>
+                <template #activator="{ props: menuProps }">
+                  <v-btn icon variant="text" v-bind="menuProps"><v-icon icon="mdi-dots-horizontal" /></v-btn>
+                </template>
+                <v-list density="compact">
+                  <v-list-item :title="attachmentLabels.poll" @click="handleAttach('poll')" />
+                </v-list>
+              </v-menu>
+            </div>
+          </div>
+        </v-card>
+      </v-card-text>
+
+      <v-card-actions class="px-2 pb-2">
+        <v-btn block color="primary" :disabled="!canPost" data-test="new-post-submit" @click="handleSubmit">
+          {{ postButtonLabel }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useI18n } from '#imports'
+
+type AudienceOption = 'friends' | 'public' | 'private'
+
+interface Props {
+  open: boolean
+  userName: string
+  avatar: string
+  placeholder: string
+  maxLength: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  open: false,
+  userName: 'Rami Aouinti',
+  avatar: '/avatar.png',
+  placeholder: '',
+  maxLength: 5000,
+})
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void
+  (e: 'submit', payload: { text: string; audience: AudienceOption }): void
+  (e: 'close'): void
+  (e: 'attach', type: string): void
+}>()
+
+const dialogOpen = computed({
+  get: () => props.open,
+  set: value => emit('update:open', value),
+})
+
+const message = ref('')
+const audience = ref<AudienceOption>('friends')
+
+const { t } = useI18n()
+
+const audienceOptions = computed(() => [
+  { value: 'public' as const, label: t('blog.newPost.audience.public'), icon: 'mdi-earth' },
+  { value: 'friends' as const, label: t('blog.newPost.audience.friends'), icon: 'mdi-account-multiple' },
+  { value: 'private' as const, label: t('blog.newPost.audience.private'), icon: 'mdi-lock' },
+])
+
+const attachmentLabels = computed(() => ({
+  media: t('blog.newPost.attachments.media'),
+  tag: t('blog.newPost.attachments.tag'),
+  feeling: t('blog.newPost.attachments.feeling'),
+  location: t('blog.newPost.attachments.location'),
+  gif: t('blog.newPost.attachments.gif'),
+  poll: t('blog.newPost.attachments.poll'),
+}))
+
+const dialogTitle = computed(() => t('blog.newPost.dialog.title'))
+const addToPostLabel = computed(() => t('blog.newPost.dialog.addToPost'))
+const postButtonLabel = computed(() => t('blog.newPost.dialog.postButton'))
+
+const audienceLabel = computed(() => audienceOptions.value.find(a => a.value === audience.value)?.label ?? audienceOptions.value[0]?.label ?? '')
+
+const maxLength = computed(() => props.maxLength)
+const canPost = computed(() => message.value.trim().length > 0 && message.value.length <= maxLength.value)
+
+watch(() => props.open, (value, oldValue) => {
+  if (!value && oldValue) {
+    emit('close')
+  }
+})
+
+function handleAttach(type: string) {
+  emit('attach', type)
+}
+
+function handleClose() {
+  dialogOpen.value = false
+}
+
+function handleSubmit() {
+  if (!canPost.value) return
+
+  emit('submit', { text: message.value.trim(), audience: audience.value })
+  message.value = ''
+  dialogOpen.value = false
+}
+</script>

--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { vi } from 'vitest'
 
 type StateRef<T> = ReturnType<typeof ref<T>>
 
@@ -29,10 +30,38 @@ export function useLocalePath() {
   return (path: string) => path
 }
 
+const notifyMock = vi.fn()
+
+export function useNuxtApp() {
+  return {
+    $notify: notifyMock,
+  }
+}
+
+export function useI18n() {
+  return {
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params && 'name' in params) {
+        return `${key}:${(params as { name: string }).name}`
+      }
+
+      return key
+    },
+  }
+}
+
 export function __resetNuxtStateMocks() {
   stateRegistry.clear()
 }
 
 export function __getNuxtStateRef<T>(key: string): StateRef<T> | undefined {
   return stateRegistry.get(key) as StateRef<T> | undefined
+}
+
+export function __getNotifyMock() {
+  return notifyMock
+}
+
+export function __resetNuxtNotifyMock() {
+  notifyMock.mockReset()
 }

--- a/tests/unit/NewPost.spec.ts
+++ b/tests/unit/NewPost.spec.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick, ref } from 'vue'
+
+import NewPost from '~/components/blog/NewPost.vue'
+import { __getNotifyMock, __resetNuxtNotifyMock } from '#imports'
+
+const notifyMock = __getNotifyMock()
+const authState = ref(false)
+
+vi.mock('~/composables/useAuthStore', () => ({
+  useAuthStore: () => ({
+    isAuthenticated: authState,
+  }),
+}))
+
+function mountComponent() {
+  return mount(NewPost, {
+    props: {
+      userName: 'Test User',
+      avatar: '/avatar.png',
+    },
+    global: {
+      stubs: {
+        Icon: true,
+        BorderBeam: true,
+        VDialog: { template: '<div data-test="stub-dialog"><slot /></div>' },
+      },
+    },
+  })
+}
+
+async function resolveAsyncComponents() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+describe('NewPost', () => {
+  beforeEach(() => {
+    authState.value = false
+    __resetNuxtNotifyMock()
+  })
+
+  it('notifies unauthenticated users when they attempt to open the dialog', async () => {
+    const wrapper = mountComponent()
+
+    const vm = wrapper.vm as unknown as { openDialog: () => void }
+    vm.openDialog()
+    await nextTick()
+
+    expect(notifyMock).toHaveBeenCalledTimes(1)
+    expect(wrapper.find('[data-test="new-post-dialog"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
+  it('loads the dialog asynchronously and emits submit events', async () => {
+    authState.value = true
+    const wrapper = mountComponent()
+
+    const trigger = wrapper.get('[data-test="new-post-trigger"]')
+    await trigger.trigger('click')
+
+    expect(wrapper.find('[data-test="new-post-dialog-loading"]').exists()).toBe(true)
+    expect((wrapper.vm as unknown as { dialog: boolean }).dialog).toBe(true)
+
+    await resolveAsyncComponents()
+
+    const handleDialogSubmit = (wrapper.vm as unknown as {
+      handleDialogSubmit: (payload: { text: string; audience: string }) => void
+    }).handleDialogSubmit
+
+    handleDialogSubmit({ text: 'Hello world', audience: 'friends' })
+
+    await resolveAsyncComponents()
+
+    const submitEvents = wrapper.emitted('submit')
+    expect(submitEvents).toBeTruthy()
+    expect(submitEvents?.[0]?.[0]).toEqual({
+      text: 'Hello world',
+      audience: 'friends',
+    })
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- extract the new post modal into a dedicated NewPostDialog component and lazy load it with a suspense fallback
- gate dialog instantiation behind authentication and dialog state while re-emitting submit/close/attach events
- expand nuxt mocks and add unit tests covering unauthenticated notifications, fallback rendering, and submit propagation

## Testing
- `pnpm vitest run tests/unit/NewPost.spec.ts --config vitest.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d99b9707f08326b3364373496620df