### PR TITLE
Refactor blog post dialogs into async components

### DIFF
--- a/components/blog/BlogPostCard.vue
+++ b/components/blog/BlogPostCard.vue
@@ -238,124 +238,33 @@
     </template>
   </BaseCard>
 
-  <teleport to="body">
-    <transition name="fade-scale">
-      <div
-          v-if="editModalOpen"
-          class="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur"
-          aria-modal="true"
-          role="dialog"
-          :aria-label="editModalTitle"
-          @keydown="handleEditKeydown"
-      >
-        <div
-            ref="editDialogRef"
-            class="w-full max-w-2xl rounded-3xl border border-white/10 bg-slate-950/95 p-6 text-left text-slate-100 shadow-xl"
-            tabindex="-1"
-        >
-          <header class="space-y-1">
-            <h2 class="text-xl font-semibold">{{ editModalTitle }}</h2>
-            <p class="text-sm text-slate-400">{{ editModalDescription }}</p>
-          </header>
-          <form class="mt-6 space-y-5" @submit.prevent="handleSaveEdit">
-            <label class="flex flex-col gap-2 text-sm">
-              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.title') }}</span>
-              <input
-                  ref="editTitleRef"
-                  v-model="editForm.title"
-                  type="text"
-                  class="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
-            </label>
-            <label class="flex flex-col gap-2 text-sm">
-              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.summary') }}</span>
-              <textarea
-                  ref="editSummaryRef"
-                  v-model="editForm.summary"
-                  class="min-h-[120px] w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
-            </label>
-            <label class="flex flex-col gap-2 text-sm">
-              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.content') }}</span>
-              <textarea
-                  v-model="editForm.content"
-                  class="min-h-[180px] w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
-              />
-            </label>
-            <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
-              <button
-                  type="button"
-                  class="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                  @click="closeEditModal"
-              >
-                {{ editModalCancelLabel }}
-              </button>
-              <button
-                  type="submit"
-                  class="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
-                  :disabled="saveLoading"
-              >
-                <span v-if="saveLoading" class="inline-flex items-center gap-2">
-                  <span class="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" aria-hidden="true" />
-                  <span>{{ editModalSaveLabel }}</span>
-                </span>
-                <span v-else>{{ editModalSaveLabel }}</span>
-              </button>
-            </div>
-          </form>
-        </div>
-      </div>
-    </transition>
-  </teleport>
+  <component
+      :is="BlogPostEditDialog"
+      v-if="editModalOpen"
+      :post="post"
+      :title="editModalTitle"
+      :description="editModalDescription"
+      :save-label="editModalSaveLabel"
+      :cancel-label="editModalCancelLabel"
+      @close="handleEditDialogClose"
+      @saved="handleEditDialogClose"
+  />
 
-  <teleport to="body">
-    <transition name="fade-scale">
-      <div
-          v-if="deleteDialogOpen"
-          class="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur"
-          role="alertdialog"
-          :aria-label="deleteDialogTitle"
-          aria-modal="true"
-          @keydown="handleDeleteKeydown"
-      >
-        <div
-            ref="deleteDialogRef"
-            class="w-full max-w-lg rounded-3xl border border-white/10 bg-slate-950/95 p-6 text-left text-slate-100 shadow-xl"
-            tabindex="-1"
-        >
-          <header class="space-y-2">
-            <h2 class="text-xl font-semibold text-rose-200">{{ deleteDialogTitle }}</h2>
-            <p class="text-sm text-slate-400">{{ deleteDialogDescription }}</p>
-          </header>
-          <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <button
-                type="button"
-                class="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
-                @click="closeDeleteDialog"
-            >
-              {{ deleteDialogCancelLabel }}
-            </button>
-            <button
-                type="button"
-                class="inline-flex items-center justify-center rounded-full bg-rose-600 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
-                :disabled="deleteLoading"
-                @click="handleDeletePost"
-            >
-              <span v-if="deleteLoading" class="inline-flex items-center gap-2">
-                <span class="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" aria-hidden="true" />
-                <span>{{ deleteDialogConfirmLabel }}</span>
-              </span>
-              <span v-else>{{ deleteDialogConfirmLabel }}</span>
-            </button>
-          </div>
-        </div>
-      </div>
-    </transition>
-  </teleport>
+  <component
+      :is="BlogPostDeleteDialog"
+      v-if="deleteDialogOpen"
+      :post="post"
+      :title="deleteDialogTitle"
+      :description="deleteDialogDescription"
+      :confirm-label="deleteDialogConfirmLabel"
+      :cancel-label="deleteDialogCancelLabel"
+      @close="handleDeleteDialogClose"
+      @deleted="handleDeleteDialogClose"
+  />
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, reactive, ref, shallowRef, watch } from "vue";
+import { computed, defineAsyncComponent, nextTick, ref, shallowRef, watch } from "vue";
 import { useElementVisibility } from "@vueuse/core";
 
 import CommentCard from "~/components/blog/BlogCommentCard.vue";
@@ -386,8 +295,6 @@ const {
   addComment,
   reactToComment,
   getComments,
-  updatePost,
-  deletePost,
 } = usePostsStore();
 const {
   currentUser,
@@ -536,17 +443,17 @@ const commentsActivationPending = computed(() => !commentsActivated.value && !co
 
 const editModalOpen = ref(false);
 const deleteDialogOpen = ref(false);
-const editForm = reactive({
-  title: post.value.title,
-  summary: post.value.summary,
-  content: post.value.content,
-});
-const saveLoading = ref(false);
-const deleteLoading = ref(false);
-const editDialogRef = ref<HTMLDivElement | null>(null);
-const deleteDialogRef = ref<HTMLDivElement | null>(null);
-const editTitleRef = ref<HTMLInputElement | null>(null);
 const previousFocusedElement = ref<HTMLElement | null>(null);
+
+const BlogPostEditDialog = defineAsyncComponent({
+  loader: () => import("~/components/blog/BlogPostEditDialog.vue"),
+  suspensible: false,
+});
+
+const BlogPostDeleteDialog = defineAsyncComponent({
+  loader: () => import("~/components/blog/BlogPostDeleteDialog.vue"),
+  suspensible: false,
+});
 
 const editModalTitle = computed(() => t("blog.posts.actions.editTitle"));
 const editModalDescription = computed(() => t("blog.posts.actions.editDescription"));
@@ -556,54 +463,6 @@ const deleteDialogTitle = computed(() => t("blog.posts.actions.deleteTitle"));
 const deleteDialogDescription = computed(() => t("blog.posts.actions.deleteDescription"));
 const deleteDialogConfirmLabel = computed(() => t("blog.posts.actions.deleteConfirm"));
 const deleteDialogCancelLabel = computed(() => t("blog.posts.actions.cancel"));
-
-watch(
-    post,
-    () => {
-      if (!editModalOpen.value) {
-        editForm.title = post.value.title;
-        editForm.summary = post.value.summary;
-        editForm.content = post.value.content;
-      }
-    },
-    { immediate: true },
-);
-
-watch(editModalOpen, (open) => {
-  if (open) {
-    previousFocusedElement.value = document.activeElement as HTMLElement | null;
-
-    nextTick(() => {
-      editTitleRef.value?.focus();
-    });
-
-    return;
-  }
-
-  if (previousFocusedElement.value) {
-    nextTick(() => {
-      previousFocusedElement.value?.focus();
-    });
-  }
-});
-
-watch(deleteDialogOpen, (open) => {
-  if (open) {
-    previousFocusedElement.value = document.activeElement as HTMLElement | null;
-
-    nextTick(() => {
-      deleteDialogRef.value?.focus();
-    });
-
-    return;
-  }
-
-  if (previousFocusedElement.value) {
-    nextTick(() => {
-      previousFocusedElement.value?.focus();
-    });
-  }
-});
 
 watch(
     () => post.value.id,
@@ -616,124 +475,14 @@ watch(
     },
 );
 
-function trapFocus(event: KeyboardEvent, container: HTMLElement | null) {
-  if (!container || event.key !== "Tab") {
-    return;
-  }
-
-  const focusable = container.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
-  );
-
-  if (focusable.length === 0) {
-    event.preventDefault();
-    return;
-  }
-
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  const active = document.activeElement as HTMLElement | null;
-
-  if (event.shiftKey) {
-    if (active === first || !active) {
-      event.preventDefault();
-      last.focus();
-    }
-
-    return;
-  }
-
-  if (active === last) {
-    event.preventDefault();
-    first.focus();
-  }
-}
-
-function closeEditModal() {
-  editModalOpen.value = false;
-}
-
-function closeDeleteDialog() {
-  deleteDialogOpen.value = false;
-}
-
 function openEditModal() {
-  editForm.title = post.value.title;
-  editForm.summary = post.value.summary;
-  editForm.content = post.value.content;
+  previousFocusedElement.value = document.activeElement as HTMLElement | null;
   editModalOpen.value = true;
 }
 
 function openDeleteDialog() {
+  previousFocusedElement.value = document.activeElement as HTMLElement | null;
   deleteDialogOpen.value = true;
-}
-
-async function handleSaveEdit() {
-  if (saveLoading.value) {
-    return;
-  }
-
-  saveLoading.value = true;
-
-  try {
-    const payload = {
-      title: editForm.title,
-      summary: editForm.summary,
-      content: editForm.content,
-    };
-
-    await updatePost(post.value.id, payload);
-
-    $notify({
-      type: "success",
-      title: t("blog.posts.actions.editSuccessTitle"),
-      message: t("blog.posts.actions.editSuccessDescription"),
-    });
-
-    closeEditModal();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error ?? "");
-
-    $notify({
-      type: "error",
-      title: t("blog.posts.actions.editErrorTitle"),
-      message: message || t("blog.posts.actions.editErrorDescription"),
-      timeout: null,
-    });
-  } finally {
-    saveLoading.value = false;
-  }
-}
-
-async function handleDeletePost() {
-  if (deleteLoading.value) {
-    return;
-  }
-
-  deleteLoading.value = true;
-
-  try {
-    await deletePost(post.value.id);
-
-    $notify({
-      type: "success",
-      title: t("blog.posts.actions.deleteSuccessTitle"),
-      message: t("blog.posts.actions.deleteSuccessDescription"),
-    });
-
-    closeDeleteDialog();
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error ?? "");
-
-    $notify({
-      type: "error",
-      title: t("blog.posts.actions.deleteErrorTitle"),
-      message: message || t("blog.posts.actions.deleteErrorDescription"),
-      timeout: null,
-    });
-  } finally {
-    deleteLoading.value = false;
-  }
 }
 
 async function handleFollow() {
@@ -762,26 +511,6 @@ async function handleFollow() {
       timeout: null,
     });
   }
-}
-
-function handleEditKeydown(event: KeyboardEvent) {
-  if (event.key === "Escape") {
-    event.preventDefault();
-    closeEditModal();
-    return;
-  }
-
-  trapFocus(event, editDialogRef.value);
-}
-
-function handleDeleteKeydown(event: KeyboardEvent) {
-  if (event.key === "Escape") {
-    event.preventDefault();
-    closeDeleteDialog();
-    return;
-  }
-
-  trapFocus(event, deleteDialogRef.value);
 }
 
 async function handleTogglePostReaction() {
@@ -1006,6 +735,26 @@ watch(
     },
     { immediate: true },
 );
+
+function handleEditDialogClose() {
+  editModalOpen.value = false;
+
+  if (previousFocusedElement.value) {
+    nextTick(() => {
+      previousFocusedElement.value?.focus();
+    });
+  }
+}
+
+function handleDeleteDialogClose() {
+  deleteDialogOpen.value = false;
+
+  if (previousFocusedElement.value) {
+    nextTick(() => {
+      previousFocusedElement.value?.focus();
+    });
+  }
+}
 </script>
 
 <style scoped>

--- a/components/blog/BlogPostDeleteDialog.vue
+++ b/components/blog/BlogPostDeleteDialog.vue
@@ -1,0 +1,145 @@
+<template>
+  <teleport to="body">
+    <transition name="fade-scale">
+      <div
+          class="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur"
+          role="alertdialog"
+          :aria-label="title"
+          aria-modal="true"
+          @keydown="handleKeydown"
+      >
+        <div
+            ref="dialogRef"
+            class="w-full max-w-lg rounded-3xl border border-white/10 bg-slate-950/95 p-6 text-left text-slate-100 shadow-xl"
+            tabindex="-1"
+        >
+          <header class="space-y-2">
+            <h2 class="text-xl font-semibold text-rose-200">{{ title }}</h2>
+            <p class="text-sm text-slate-400">{{ description }}</p>
+          </header>
+          <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                @click="emitClose"
+            >
+              {{ cancelLabel }}
+            </button>
+            <button
+                type="button"
+                class="inline-flex items-center justify-center rounded-full bg-rose-600 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-rose-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 disabled:cursor-not-allowed disabled:opacity-60"
+                :disabled="deleteLoading"
+                @click="handleDelete"
+            >
+              <span v-if="deleteLoading" class="inline-flex items-center gap-2">
+                <span class="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" aria-hidden="true" />
+                <span>{{ confirmLabel }}</span>
+              </span>
+              <span v-else>{{ confirmLabel }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </transition>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, ref, toRef } from "vue";
+
+import { usePostEditing } from "~/composables/usePostEditing";
+import type { BlogPost } from "~/lib/mock/blog";
+
+const props = defineProps<{
+  post: BlogPost;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}>();
+
+const emit = defineEmits<{
+  (event: "close"): void;
+  (event: "deleted"): void;
+}>();
+
+const dialogRef = ref<HTMLDivElement | null>(null);
+
+const { deleteLoading, handleDeletePost } = usePostEditing(toRef(props, "post"));
+
+onMounted(() => {
+  nextTick(() => {
+    dialogRef.value?.focus();
+  });
+});
+
+function emitClose() {
+  emit("close");
+}
+
+async function handleDelete() {
+  const success = await handleDeletePost();
+
+  if (success) {
+    emit("deleted");
+  }
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    emitClose();
+    return;
+  }
+
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const container = dialogRef.value;
+
+  if (!container) {
+    return;
+  }
+
+  const focusable = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+  );
+
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+
+  if (event.shiftKey) {
+    if (active === first || !active) {
+      event.preventDefault();
+      last.focus();
+    }
+
+    return;
+  }
+
+  if (active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+<style scoped>
+.fade-scale-enter-active,
+.fade-scale-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-scale-enter-from,
+.fade-scale-leave-to {
+  opacity: 0;
+  transform: scale(0.96);
+}
+</style>

--- a/components/blog/BlogPostEditDialog.vue
+++ b/components/blog/BlogPostEditDialog.vue
@@ -1,0 +1,176 @@
+<template>
+  <teleport to="body">
+    <transition name="fade-scale">
+      <div
+          class="fixed inset-0 z-40 flex items-center justify-center bg-slate-950/70 p-4 backdrop-blur"
+          aria-modal="true"
+          role="dialog"
+          :aria-label="title"
+          @keydown="handleKeydown"
+      >
+        <div
+            ref="dialogRef"
+            class="w-full max-w-2xl rounded-3xl border border-white/10 bg-slate-950/95 p-6 text-left text-slate-100 shadow-xl"
+            tabindex="-1"
+        >
+          <header class="space-y-1">
+            <h2 class="text-xl font-semibold">{{ title }}</h2>
+            <p class="text-sm text-slate-400">{{ description }}</p>
+          </header>
+          <form class="mt-6 space-y-5" @submit.prevent="handleSubmit">
+            <label class="flex flex-col gap-2 text-sm">
+              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.title') }}</span>
+              <input
+                  ref="titleRef"
+                  v-model="editForm.title"
+                  type="text"
+                  class="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+            </label>
+            <label class="flex flex-col gap-2 text-sm">
+              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.summary') }}</span>
+              <textarea
+                  v-model="editForm.summary"
+                  class="min-h-[120px] w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+            </label>
+            <label class="flex flex-col gap-2 text-sm">
+              <span class="font-medium text-slate-200">{{ t('blog.posts.actions.fields.content') }}</span>
+              <textarea
+                  v-model="editForm.content"
+                  class="min-h-[180px] w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+            </label>
+            <div class="flex flex-col gap-3 pt-2 sm:flex-row sm:justify-end">
+              <button
+                  type="button"
+                  class="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+                  @click="emitClose"
+              >
+                {{ cancelLabel }}
+              </button>
+              <button
+                  type="submit"
+                  class="inline-flex items-center justify-center rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:cursor-not-allowed disabled:opacity-60"
+                  :disabled="saveLoading"
+              >
+                <span v-if="saveLoading" class="inline-flex items-center gap-2">
+                  <span class="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" aria-hidden="true" />
+                  <span>{{ saveLabel }}</span>
+                </span>
+                <span v-else>{{ saveLabel }}</span>
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </transition>
+  </teleport>
+</template>
+
+<script setup lang="ts">
+import { nextTick, onMounted, ref, toRef } from "vue";
+
+import { useI18n } from "#imports";
+
+import { usePostEditing } from "~/composables/usePostEditing";
+import type { BlogPost } from "~/lib/mock/blog";
+
+const props = defineProps<{
+  post: BlogPost;
+  title: string;
+  description: string;
+  saveLabel: string;
+  cancelLabel: string;
+}>();
+
+const emit = defineEmits<{
+  (event: "close"): void;
+  (event: "saved"): void;
+}>();
+
+const { t } = useI18n();
+
+const dialogRef = ref<HTMLDivElement | null>(null);
+const titleRef = ref<HTMLInputElement | null>(null);
+
+const { editForm, saveLoading, handleSaveEdit, syncFormFromPost } = usePostEditing(toRef(props, "post"));
+
+onMounted(() => {
+  syncFormFromPost();
+
+  nextTick(() => {
+    titleRef.value?.focus();
+  });
+});
+
+function emitClose() {
+  emit("close");
+}
+
+async function handleSubmit() {
+  const success = await handleSaveEdit();
+
+  if (success) {
+    emit("saved");
+  }
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    emitClose();
+    return;
+  }
+
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const container = dialogRef.value;
+
+  if (!container) {
+    return;
+  }
+
+  const focusable = container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])',
+  );
+
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+
+  if (event.shiftKey) {
+    if (active === first || !active) {
+      event.preventDefault();
+      last.focus();
+    }
+
+    return;
+  }
+
+  if (active === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+</script>
+
+<style scoped>
+.fade-scale-enter-active,
+.fade-scale-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.fade-scale-enter-from,
+.fade-scale-leave-to {
+  opacity: 0;
+  transform: scale(0.96);
+}
+</style>

--- a/composables/usePostEditing.ts
+++ b/composables/usePostEditing.ts
@@ -1,0 +1,161 @@
+import { nextTick, reactive, ref, type Ref, watch } from "vue";
+
+import { useNuxtApp } from "#app";
+
+import { useI18n } from "#imports";
+
+import { usePostsStore } from "~/composables/usePostsStore";
+import type { BlogPost } from "~/lib/mock/blog";
+
+interface EditFormState {
+  title: string;
+  summary: string;
+  content: string;
+}
+
+export function usePostEditing(postSource: Ref<BlogPost | null | undefined> | Ref<BlogPost>) {
+  const post = postSource as Ref<BlogPost | null | undefined>;
+  const { t } = useI18n();
+  const { $notify } = useNuxtApp();
+  const { updatePost, deletePost } = usePostsStore();
+
+  const editForm = reactive<EditFormState>({
+    title: "",
+    summary: "",
+    content: "",
+  });
+
+  const saveLoading = ref(false);
+  const deleteLoading = ref(false);
+
+  function resolvePost(): BlogPost | null {
+    const current = post.value ?? null;
+
+    if (current && typeof current === "object") {
+      return current as BlogPost;
+    }
+
+    return null;
+  }
+
+  function syncFormFromPost() {
+    const currentPost = resolvePost();
+
+    if (!currentPost) {
+      editForm.title = "";
+      editForm.summary = "";
+      editForm.content = "";
+      return;
+    }
+
+    editForm.title = currentPost.title ?? "";
+    editForm.summary = currentPost.summary ?? "";
+    editForm.content = currentPost.content ?? "";
+  }
+
+  watch(
+      () => post.value,
+      () => {
+        if (!saveLoading.value) {
+          syncFormFromPost();
+        }
+      },
+      { immediate: true, deep: true },
+  );
+
+  async function handleSaveEdit() {
+    if (saveLoading.value) {
+      return false;
+    }
+
+    const currentPost = resolvePost();
+
+    if (!currentPost?.id) {
+      return false;
+    }
+
+    saveLoading.value = true;
+
+    try {
+      const payload = {
+        title: editForm.title,
+        summary: editForm.summary,
+        content: editForm.content,
+      };
+
+      await updatePost(currentPost.id, payload);
+
+      $notify({
+        type: "success",
+        title: t("blog.posts.actions.editSuccessTitle"),
+        message: t("blog.posts.actions.editSuccessDescription"),
+      });
+
+      await nextTick();
+      syncFormFromPost();
+
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error ?? "");
+
+      $notify({
+        type: "error",
+        title: t("blog.posts.actions.editErrorTitle"),
+        message: message || t("blog.posts.actions.editErrorDescription"),
+        timeout: null,
+      });
+
+      return false;
+    } finally {
+      saveLoading.value = false;
+    }
+  }
+
+  async function handleDeletePost() {
+    if (deleteLoading.value) {
+      return false;
+    }
+
+    const currentPost = resolvePost();
+
+    if (!currentPost?.id) {
+      return false;
+    }
+
+    deleteLoading.value = true;
+
+    try {
+      await deletePost(currentPost.id);
+
+      $notify({
+        type: "success",
+        title: t("blog.posts.actions.deleteSuccessTitle"),
+        message: t("blog.posts.actions.deleteSuccessDescription"),
+      });
+
+      return true;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error ?? "");
+
+      $notify({
+        type: "error",
+        title: t("blog.posts.actions.deleteErrorTitle"),
+        message: message || t("blog.posts.actions.deleteErrorDescription"),
+        timeout: null,
+      });
+
+      return false;
+    } finally {
+      deleteLoading.value = false;
+    }
+  }
+
+  return {
+    editForm,
+    saveLoading,
+    deleteLoading,
+    syncFormFromPost,
+    handleSaveEdit,
+    handleDeletePost,
+  };
+}

--- a/tests/unit/BlogPostCard.spec.ts
+++ b/tests/unit/BlogPostCard.spec.ts
@@ -138,6 +138,12 @@ function mountComponent() {
         CommentCard: {
           template: "<div data-test='comment-card'></div>",
         },
+        BlogPostEditDialog: {
+          template: "<div data-test='edit-dialog-stub'></div>",
+        },
+        BlogPostDeleteDialog: {
+          template: "<div data-test='delete-dialog-stub'></div>",
+        },
         teleport: true,
       },
     },

--- a/tests/unit/usePostEditing.spec.ts
+++ b/tests/unit/usePostEditing.spec.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, ref } from "vue";
+
+import { usePostEditing } from "~/composables/usePostEditing";
+import type { BlogPost } from "~/lib/mock/blog";
+
+const updatePostMock = vi.fn<(postId: string, payload: Record<string, unknown>) => Promise<void>>();
+const deletePostMock = vi.fn<(postId: string) => Promise<void>>();
+const notifyMock = vi.fn();
+
+vi.mock("~/composables/usePostsStore", () => ({
+  usePostsStore: () => ({
+    updatePost: updatePostMock,
+    deletePost: deletePostMock,
+  }),
+}));
+
+vi.mock("#app", () => ({
+  useNuxtApp: () => ({
+    $notify: notifyMock,
+  }),
+}));
+
+vi.mock("#imports", () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("usePostEditing", () => {
+  const basePost: BlogPost = {
+    id: "post-1",
+    title: "Initial title",
+    summary: "Initial summary",
+    content: "Initial content",
+    url: null,
+    slug: "post-1",
+    medias: [],
+    isReacted: false,
+    publishedAt: new Date().toISOString(),
+    sharedFrom: null,
+    reactions_count: 0,
+    totalComments: 0,
+    user: {
+      id: "user-1",
+      firstName: "Jane",
+      lastName: "Doe",
+      username: "jane",
+      email: "jane@example.com",
+      enabled: true,
+      photo: null,
+    },
+    reactions_preview: [],
+    comments_preview: [],
+  };
+
+  beforeEach(() => {
+    updatePostMock.mockReset().mockResolvedValue();
+    deletePostMock.mockReset().mockResolvedValue();
+    notifyMock.mockReset();
+  });
+
+  it("initialises the form with the post content", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+
+    const { editForm } = usePostEditing(postRef);
+
+    await nextTick();
+
+    expect(editForm.title).toBe(basePost.title);
+    expect(editForm.summary).toBe(basePost.summary);
+    expect(editForm.content).toBe(basePost.content);
+  });
+
+  it("saves changes and shows a success notification", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+    const { editForm, handleSaveEdit } = usePostEditing(postRef);
+
+    editForm.title = "Updated title";
+    editForm.summary = "Updated summary";
+
+    const result = await handleSaveEdit();
+
+    expect(result).toBe(true);
+    expect(updatePostMock).toHaveBeenCalledWith(basePost.id, {
+      title: "Updated title",
+      summary: "Updated summary",
+      content: basePost.content,
+    });
+    expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "success",
+          title: "blog.posts.actions.editSuccessTitle",
+        }),
+    );
+  });
+
+  it("reports errors when saving fails", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+    updatePostMock.mockRejectedValueOnce(new Error("Save failed"));
+
+    const { handleSaveEdit } = usePostEditing(postRef);
+
+    const result = await handleSaveEdit();
+
+    expect(result).toBe(false);
+    expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          title: "blog.posts.actions.editErrorTitle",
+        }),
+    );
+  });
+
+  it("deletes the post and notifies success", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+
+    const { handleDeletePost } = usePostEditing(postRef);
+
+    const result = await handleDeletePost();
+
+    expect(result).toBe(true);
+    expect(deletePostMock).toHaveBeenCalledWith(basePost.id);
+    expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "success",
+          title: "blog.posts.actions.deleteSuccessTitle",
+        }),
+    );
+  });
+
+  it("reports delete errors", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+    deletePostMock.mockRejectedValueOnce(new Error("Delete failed"));
+
+    const { handleDeletePost } = usePostEditing(postRef);
+
+    const result = await handleDeletePost();
+
+    expect(result).toBe(false);
+    expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          title: "blog.posts.actions.deleteErrorTitle",
+        }),
+    );
+  });
+
+  it("refreshes the form when the post changes", async () => {
+    const postRef = ref<BlogPost>({ ...basePost });
+
+    const { editForm } = usePostEditing(postRef);
+
+    await nextTick();
+
+    postRef.value = {
+      ...basePost,
+      id: "post-2",
+      title: "Another title",
+    };
+
+    await nextTick();
+
+    expect(editForm.title).toBe("Another title");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the inline blog post edit/delete modals with async dialog components and load them only when opened
- share editing state, persistence, and notifications through a new `usePostEditing` composable
- update the existing card test stubs and add unit coverage for the post editing composable

## Testing
- pnpm vitest run tests/unit/BlogPostCard.spec.ts
- pnpm vitest run tests/unit/usePostEditing.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d9b366419883269e1a57e7a444053a