### PR TITLE
Enhance default layout background styling

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -117,6 +117,18 @@ const cssVars = computed(() => ({
   '--pink-shadow': isDark.value
     ? '0px 16px 32px rgba(243, 126, 205, 0.18)'
     : '0px 20px 45px rgba(243, 126, 205, 0.28)',
+  '--surface-gradient-start': isDark.value
+    ? 'rgba(120, 106, 255, 0.28)'
+    : 'rgba(125, 196, 255, 0.45)',
+  '--surface-gradient-end': isDark.value
+    ? 'rgba(255, 153, 214, 0.24)'
+    : 'rgba(255, 183, 236, 0.4)',
+  '--surface-base': isDark.value ? 'rgba(12, 14, 24, 0.9)' : 'rgba(244, 247, 252, 0.95)',
+  '--card-bg': isDark.value ? 'rgba(20, 22, 33, 0.94)' : 'rgba(255, 255, 255, 0.92)',
+  '--card-border': isDark.value ? 'rgba(255, 255, 255, 0.08)' : 'rgba(15, 23, 42, 0.08)',
+  '--card-shadow': isDark.value
+    ? '0 28px 60px -30px rgba(12, 14, 24, 0.9)'
+    : '0 28px 60px -30px rgba(15, 23, 42, 0.45)',
 }))
 
 const appIcons = [
@@ -246,8 +258,25 @@ function matchesRoute(path: string, target: string) {
 
 <style scoped>
 .app-surface {
+  position: relative;
+  display: flex;
   border-color: transparent;
   min-height: 100vh;
+  background: var(--surface-base);
+  overflow: hidden;
+}
+
+.app-surface::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, var(--surface-gradient-start) 0%, transparent 60%),
+    radial-gradient(circle at 85% 90%, var(--surface-gradient-end) 0%, transparent 55%);
+  opacity: 0.9;
+  pointer-events: none;
+  transform: translateZ(0);
+  z-index: 0;
 }
 
 .app-drawer {
@@ -260,8 +289,44 @@ function matchesRoute(path: string, target: string) {
 }
 
 .app-container {
+  position: relative;
+  z-index: 1;
   margin: 0 auto;
-  width: 100%;
-  max-width: 1440px;
+  width: min(100%, 1200px);
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 28px;
+  box-shadow: var(--card-shadow);
+  padding: clamp(20px, 5vw, 48px);
+  backdrop-filter: blur(16px);
+}
+
+.main-scroll {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: clamp(24px, 4vw, 64px) clamp(16px, 5vw, 72px);
+  overflow-y: auto;
+}
+
+@media (max-width: 960px) {
+  .app-container {
+    border-radius: 24px;
+    padding: clamp(20px, 6vw, 32px);
+  }
+}
+
+@media (max-width: 600px) {
+  .main-scroll {
+    padding: 16px;
+  }
+
+  .app-container {
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: var(--card-shadow);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- add theme-aware CSS variables that drive a gradient surface and elevated card treatment
- restyle the main content wrapper to present a centered card with responsive padding and blur
- introduce responsive tweaks so the layout spacing adapts cleanly on tablet and mobile widths

## Testing
- pnpm dev --host 0.0.0.0 --port 3000


------
https://chatgpt.com/codex/tasks/task_e_68d9b421c7c483269495998ef707a8ae