### PR TITLE
Add default right sidebar widgets to layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -50,10 +50,21 @@
         <template #default>
           <div class="pane-scroll px-3 py-4">
             <AppSidebarRight
-                :items="sidebarItems"
-                :active-key="activeSidebar"
-                @select="handleSidebarSelect"
-            />
+              :items="sidebarItems"
+              :active-key="activeSidebar"
+              @select="handleSidebarSelect"
+            >
+              <div class="flex flex-col gap-4">
+                <SidebarWeatherCard v-if="weather" :weather="weather" />
+                <SidebarLeaderboardCard
+                  v-if="leaderboard?.participants?.length"
+                  :title="leaderboard.title"
+                  :live-label="leaderboard.live"
+                  :participants="leaderboard.participants"
+                />
+                <SidebarRatingCard v-if="rating" :rating="rating" />
+              </div>
+            </AppSidebarRight>
           </div>
         </template>
         <template #fallback>
@@ -94,6 +105,9 @@ import { useRightSidebarData } from '@/composables/useRightSidebarData'
 import type { LayoutSidebarItem } from '~/lib/navigation/sidebar'
 import { ADMIN_ROLE_KEYS, buildSidebarItems } from '~/lib/navigation/sidebar'
 import { useAuthSession } from '~/stores/auth-session'
+import SidebarWeatherCard from '~/components/layout/SidebarWeatherCard.vue'
+import SidebarLeaderboardCard from '~/components/layout/SidebarLeaderboardCard.vue'
+import SidebarRatingCard from '~/components/layout/SidebarRatingCard.vue'
 
 const AppSidebarRight = defineAsyncComponent(() => import('~/components/layout/AppSidebarRight.vue'))
 


### PR DESCRIPTION
## Summary
- render the weather, leaderboard, and rating widgets inside the right sidebar slot
- import the sidebar card components into the default layout for direct usage

## Testing
- pnpm dev --host 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68d9b5afe06c8326848b5c697f75ba57