### PR TITLE
refactor: align BaseCard variants with Vuetify tokens

### DIFF
--- a/components/ui/BaseCard.vue
+++ b/components/ui/BaseCard.vue
@@ -3,10 +3,11 @@
     :is="props.as"
     v-bind="restAttrs"
     :class="cardClasses"
+    :style="styleBinding"
     data-component="base-card"
     :data-variant="props.variant"
   >
-    <div class="px-4 py-4">
+    <div class="base-card__content">
       <div v-if="hasMedia" :class="mediaClasses" data-test="base-card-media">
         <slot name="media" />
       </div>
@@ -24,10 +25,10 @@
       </footer>
     </div>
     <BorderBeam
-        :size="250"
-        :duration="8"
-        :delay="10"
-        :border-width="2"
+      :size="250"
+      :duration="8"
+      :delay="10"
+      :border-width="2"
     />
   </component>
 </template>
@@ -41,36 +42,94 @@ type CardPadding = 'none' | 'sm' | 'md' | 'lg'
 type CardRounded = 'md' | 'lg' | 'xl'
 type BodySpacing = 'sm' | 'md' | 'lg'
 
-const variantClasses: Record<CardVariant, string> = {
-  solid:
-    'bg-slate-950/70 border border-white/10 shadow-[0_25px_55px_-30px_rgba(15,23,42,0.95)] text-slate-100',
-  muted:
-    'bg-slate-900/60 border border-white/5 shadow-[0_20px_45px_-30px_rgba(15,23,42,0.9)] text-slate-200',
-  outline:
-    'bg-slate-950/40 border border-white/15 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] text-slate-100',
-  glass:
-    'bg-white/8 border border-white/15 backdrop-blur-2xl shadow-[0_35px_65px_-40px_rgba(15,23,42,0.85)] text-slate-100',
-  gradient:
-    'bg-gradient-to-br from-primary/25 via-slate-950/70 to-slate-950/95 border border-primary/30 shadow-[0_35px_75px_-35px_rgba(59,130,246,0.65)] text-white',
+type VariantToken = {
+  background: string
+  color: string
+  borderColor?: string
+  borderStyle?: string
+  borderWidth?: string
+  shadow?: string
+  hoverShadow?: string
+  backdropFilter?: string
+  surfaceOverlay?: string
+  bodyColor?: string
+  footerColor?: string
 }
 
-const paddingClasses: Record<CardPadding, string> = {
-  none: 'p-0',
-  sm: 'p-4',
-  md: 'p-6',
-  lg: 'p-8',
+const variantTokens: Record<CardVariant, VariantToken> = {
+  solid: {
+    background: 'rgba(var(--v-theme-surface), 0.96)',
+    color: 'rgb(var(--v-theme-on-surface))',
+    borderColor: 'rgba(var(--v-theme-outline-variant), 0.6)',
+    shadow: '0 28px 55px rgba(var(--v-theme-shadow), 0.18)',
+    hoverShadow: '0 36px 70px rgba(var(--v-theme-shadow), 0.25)',
+  },
+  muted: {
+    background: 'rgba(var(--v-theme-surface-variant), 0.78)',
+    color: 'rgb(var(--v-theme-on-surface))',
+    borderColor: 'rgba(var(--v-theme-outline), 0.45)',
+    shadow: '0 24px 50px rgba(var(--v-theme-shadow), 0.16)',
+    hoverShadow: '0 34px 75px rgba(var(--v-theme-shadow), 0.22)',
+  },
+  outline: {
+    background: 'rgba(var(--v-theme-surface), 0.58)',
+    color: 'rgb(var(--v-theme-on-surface))',
+    borderColor: 'rgba(var(--v-theme-outline), 0.72)',
+    borderStyle: 'solid',
+    shadow: 'inset 0 1px 0 rgba(var(--v-theme-outline-variant), 0.9)',
+    hoverShadow: '0 28px 55px rgba(var(--v-theme-shadow), 0.2)',
+  },
+  glass: {
+    background: 'rgba(var(--v-theme-surface), 0.18)',
+    color: 'rgb(var(--v-theme-on-surface))',
+    borderColor: 'rgba(var(--v-theme-outline), 0.35)',
+    shadow: '0 35px 70px rgba(var(--v-theme-shadow), 0.24)',
+    hoverShadow: '0 48px 95px rgba(var(--v-theme-shadow), 0.28)',
+    backdropFilter: 'blur(18px)',
+    surfaceOverlay:
+      'linear-gradient(135deg, rgba(var(--v-theme-surface-bright), 0.16), rgba(var(--v-theme-surface), 0.02))',
+  },
+  gradient: {
+    background:
+      'linear-gradient(135deg, rgba(var(--v-theme-primary), 0.28) 0%, rgba(var(--v-theme-surface-light), 0.85) 55%, rgba(var(--v-theme-surface), 0.98) 100%)',
+    color: 'rgb(var(--v-theme-on-primary))',
+    borderColor: 'rgba(var(--v-theme-primary), 0.35)',
+    shadow: '0 38px 80px rgba(var(--v-theme-shadow), 0.32)',
+    hoverShadow: '0 46px 105px rgba(var(--v-theme-shadow), 0.36)',
+    bodyColor: 'rgba(var(--v-theme-on-primary), 0.92)',
+    footerColor: 'rgba(var(--v-theme-on-primary), 0.85)',
+  },
 }
 
-const roundedClasses: Record<CardRounded, string> = {
-  md: 'rounded-2xl',
-  lg: 'rounded-[1.75rem]',
-  xl: 'rounded-3xl',
+const paddingTokens: Record<CardPadding, string> = {
+  none: '0',
+  sm: 'var(--ui-spacing-4)',
+  md: 'var(--ui-spacing-5)',
+  lg: 'var(--ui-spacing-6)',
 }
 
-const spacingClasses: Record<BodySpacing, string> = {
-  sm: 'space-y-3 text-sm',
-  md: 'space-y-4 text-base',
-  lg: 'space-y-6 text-base',
+const roundedTokens: Record<CardRounded, string> = {
+  md: 'var(--ui-radius-lg)',
+  lg: 'calc(var(--ui-radius-xl) + 0.25rem)',
+  xl: 'calc(var(--ui-radius-xl) + 0.75rem)',
+}
+
+const spacingTokens: Record<BodySpacing, { gap: string; fontSize: string; lineHeight: string }> = {
+  sm: {
+    gap: 'var(--ui-spacing-3)',
+    fontSize: 'var(--v-text-body-2-size)',
+    lineHeight: 'var(--v-text-body-2-line-height, 1.6)',
+  },
+  md: {
+    gap: 'var(--ui-spacing-4)',
+    fontSize: 'var(--v-text-body-1-size)',
+    lineHeight: 'var(--v-text-body-1-line-height, 1.6)',
+  },
+  lg: {
+    gap: 'var(--ui-spacing-6)',
+    fontSize: 'var(--v-text-body-1-size)',
+    lineHeight: 'var(--v-text-body-1-line-height, 1.6)',
+  },
 }
 
 const props = withDefaults(
@@ -108,44 +167,178 @@ const attrs = useAttrs()
 const slots = useSlots()
 
 const restAttrs = computed(() => {
-  const { class: _class, ...rest } = attrs as Record<string, unknown> & { class?: unknown }
+  const { class: _class, style: _style, ...rest } = attrs as Record<string, unknown> & {
+    class?: unknown
+    style?: unknown
+  }
   return rest
 })
 
-const hoverClasses =
-  'transition-transform duration-300 hover:-translate-y-1 hover:shadow-[0_35px_85px_-35px_rgba(15,23,42,0.95)]'
+const inlineStyle = computed(() => (attrs as Record<string, unknown> & { style?: unknown }).style)
+
+const cardStyle = computed(() => {
+  const variant = variantTokens[props.variant]
+  const spacing = spacingTokens[props.spacing]
+
+  return {
+    '--card-background': variant.background,
+    '--card-color': variant.color,
+    '--card-border-color': variant.borderColor ?? 'transparent',
+    '--card-border-style': variant.borderStyle ?? 'solid',
+    '--card-border-width': variant.borderWidth ?? '1px',
+    '--card-shadow': variant.shadow ?? 'none',
+    '--card-hover-shadow': variant.hoverShadow ?? variant.shadow ?? 'none',
+    '--card-backdrop-filter': variant.backdropFilter ?? 'none',
+    '--card-surface-overlay': variant.surfaceOverlay ?? 'transparent',
+    '--card-padding': paddingTokens[props.padding],
+    '--card-radius': roundedTokens[props.rounded],
+    '--card-body-gap': spacing.gap,
+    '--card-body-font-size': spacing.fontSize,
+    '--card-body-line-height': spacing.lineHeight,
+    '--card-body-color': variant.bodyColor ?? variant.color,
+    '--card-footer-color': variant.footerColor ?? 'rgba(var(--v-theme-on-surface), 0.74)',
+    '--card-footer-border': props.footerDivider
+      ? '1px solid rgba(var(--v-theme-outline-variant), 0.6)'
+      : '0',
+    '--card-footer-padding': props.footerDivider ? 'var(--ui-spacing-4)' : '0',
+  }
+})
+
+const styleBinding = computed(() =>
+  [cardStyle.value, inlineStyle.value].filter(Boolean) as Array<string | Record<string, string>>,
+)
 
 const cardClasses = computed(() =>
   cn(
-    'relative isolate flex flex-col gap-6 overflow-hidden transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
-    paddingClasses[props.padding],
-    roundedClasses[props.rounded],
-    variantClasses[props.variant],
-    props.hoverable && hoverClasses,
+    'base-card',
+    props.hoverable && 'base-card--hoverable',
     attrs.class as unknown,
   ),
 )
 
-const mediaClasses = computed(() =>
-  cn('overflow-hidden rounded-[1.5rem] border border-white/5 bg-white/5', props.mediaClass),
-)
+const mediaClasses = computed(() => cn('base-card__media', props.mediaClass))
 
-const headerClasses = computed(() =>
-  cn('flex items-start justify-between gap-4 text-left', props.headerClass),
-)
+const headerClasses = computed(() => cn('base-card__header', props.headerClass))
 
-const bodyClasses = computed(() => cn('text-slate-200', spacingClasses[props.spacing], props.bodyClass))
+const bodyClasses = computed(() => cn('base-card__body', props.bodyClass))
 
-const footerClasses = computed(() =>
-  cn(
-    'flex items-center justify-between gap-3 text-sm text-slate-300 transition-colors',
-    props.footerDivider && 'border-t border-white/10 pt-4',
-    props.footerClass,
-  ),
-)
+const footerClasses = computed(() => cn('base-card__footer', props.footerClass))
 
 const hasMedia = computed(() => Boolean(slots.media))
 const hasHeader = computed(() => Boolean(slots.header))
 const hasBody = computed(() => Boolean(slots.default))
 const hasFooter = computed(() => Boolean(slots.footer))
 </script>
+
+<style scoped>
+.base-card {
+  --card-background: rgba(var(--v-theme-surface), 0.96);
+  --card-color: rgb(var(--v-theme-on-surface));
+  --card-border-color: rgba(var(--v-theme-outline-variant), 0.6);
+  --card-border-style: solid;
+  --card-border-width: 1px;
+  --card-shadow: 0 28px 55px rgba(var(--v-theme-shadow), 0.18);
+  --card-hover-shadow: var(--card-shadow);
+  --card-padding: var(--ui-spacing-5);
+  --card-radius: var(--ui-radius-xl);
+  --card-content-gap: var(--ui-spacing-5);
+  --card-body-gap: var(--ui-spacing-4);
+  --card-body-font-size: var(--v-text-body-1-size);
+  --card-body-line-height: var(--v-text-body-1-line-height, 1.6);
+  --card-body-color: rgb(var(--v-theme-on-surface));
+  --card-footer-color: rgba(var(--v-theme-on-surface), 0.74);
+  --card-footer-border: 0;
+  --card-footer-padding: 0;
+  --card-backdrop-filter: none;
+  --card-surface-overlay: transparent;
+
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--card-radius);
+  background: var(--card-background);
+  color: var(--card-color);
+  border-width: var(--card-border-width);
+  border-style: var(--card-border-style);
+  border-color: var(--card-border-color);
+  box-shadow: var(--card-shadow);
+  overflow: hidden;
+  transition: background-color 200ms ease, border-color 200ms ease, box-shadow 250ms ease,
+    color 200ms ease, transform 250ms ease;
+  backdrop-filter: var(--card-backdrop-filter);
+}
+
+.base-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--card-surface-overlay);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.base-card:focus-visible {
+  outline: var(--ui-focus);
+  outline-offset: 2px;
+}
+
+.base-card__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--card-content-gap);
+  padding: var(--card-padding);
+}
+
+.base-card--hoverable {
+  cursor: pointer;
+}
+
+.base-card--hoverable {
+  will-change: transform, box-shadow;
+}
+
+.base-card--hoverable:hover,
+.base-card--hoverable:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: var(--card-hover-shadow);
+}
+
+.base-card__media {
+  overflow: hidden;
+  border-radius: calc(var(--card-radius) - var(--ui-spacing-2));
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.4);
+  background: rgba(var(--v-theme-surface), 0.12);
+}
+
+.base-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ui-spacing-4);
+  text-align: start;
+}
+
+.base-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--card-body-gap);
+  font-size: var(--card-body-font-size);
+  line-height: var(--card-body-line-height);
+  color: var(--card-body-color);
+}
+
+.base-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ui-spacing-3);
+  font-size: var(--v-text-body-2-size);
+  color: var(--card-footer-color);
+  border-top: var(--card-footer-border);
+  padding-top: var(--card-footer-padding);
+  transition: color 200ms ease;
+}
+</style>

--- a/components/ui/stories/BaseCardStory.vue
+++ b/components/ui/stories/BaseCardStory.vue
@@ -1,95 +1,183 @@
 <template>
-  <div class="story-grid">
-    <BaseCard hoverable>
-      <template #header>
-        <div class="flex items-center gap-3">
-          <div class="h-12 w-12 rounded-2xl bg-white/10" />
-          <div>
-            <p class="text-sm font-semibold text-white">Default solid</p>
-            <p class="text-xs text-slate-300">Hover to see elevation</p>
-          </div>
-        </div>
-        <span class="rounded-full border border-white/10 px-3 py-1 text-xs text-slate-200">Nouvelle</span>
-      </template>
+  <div class="card-story">
+    <section
+      v-for="theme in themes"
+      :key="theme.key"
+      :class="['card-story__theme', theme.class]"
+      :data-theme="theme.key"
+    >
+      <h3 class="card-story__title">{{ theme.label }}</h3>
+      <div class="card-story__grid">
+        <BaseCard
+          v-for="variant in variants"
+          :key="`${theme.key}-${variant.variant}`"
+          :variant="variant.variant"
+          :hoverable="variant.hoverable ?? true"
+          :padding="variant.padding ?? 'md'"
+          :rounded="variant.rounded ?? 'xl'"
+          :spacing="variant.spacing ?? 'md'"
+        >
+          <template v-if="variant.media" #media>
+            <div class="card-story__media" />
+          </template>
 
-      <p>
-        Créez des cartes riches en contenu avec des sections de header, body et footer en utilisant les slots fournis.
-        Cette variante solide fonctionne parfaitement pour des panneaux d'information.
-      </p>
+          <template #header>
+            <div class="card-story__header">
+              <div>
+                <p class="card-story__heading">{{ variant.label }}</p>
+                <p class="card-story__subtitle">{{ variant.subtitle }}</p>
+              </div>
+              <span v-if="variant.badge" class="card-story__badge">{{ variant.badge }}</span>
+            </div>
+          </template>
 
-      <template #footer>
-        <span class="text-xs text-slate-300">Mis à jour il y a 2 heures</span>
-        <div class="flex items-center gap-2">
-          <div class="h-8 w-8 rounded-full bg-white/10" />
-          <div class="h-8 w-20 rounded-full bg-white/10" />
-        </div>
-      </template>
-    </BaseCard>
+          <p>{{ variant.description }}</p>
 
-    <BaseCard variant="glass" hoverable media-class="p-0">
-      <template #media>
-        <div class="aspect-video w-full rounded-[1.5rem] bg-gradient-to-br from-primary/30 via-white/10 to-transparent" />
-      </template>
-      <template #header>
-        <div>
-          <p class="text-sm font-semibold text-white">Glass card</p>
-          <p class="text-xs text-slate-200">Utilise un effet de verre dépoli</p>
-        </div>
-      </template>
-      <p>
-        Idéale pour mettre en avant des visuels. Combinez le slot <code>media</code> avec le contenu principal pour créer une
-        mise en page immersive.
-      </p>
-      <template #footer>
-        <span class="text-xs text-slate-200">Voir plus</span>
-        <span class="h-9 w-24 rounded-full bg-white/10" />
-      </template>
-    </BaseCard>
-
-    <BaseCard variant="outline" padding="lg" spacing="lg">
-      <template #header>
-        <div>
-          <p class="text-sm font-semibold text-white">Outline</p>
-          <p class="text-xs text-slate-300">Parfaite pour les résumés</p>
-        </div>
-      </template>
-      <p>
-        Définissez facilement la densité du contenu grâce à la prop <code>spacing</code>. Les sections optionnelles sont
-        rendues uniquement lorsqu'elles sont utilisées.
-      </p>
-      <ul class="list-disc space-y-2 pl-5 text-sm text-slate-300">
-        <li>Slots nommés pour media, header et footer.</li>
-        <li>Contrôles pour les rayons, le padding et l'effet hover.</li>
-        <li>Compatibles avec les loaders dédiés.</li>
-      </ul>
-    </BaseCard>
-
-    <BaseCard variant="gradient" hoverable rounded="lg" padding="sm">
-      <template #header>
-        <div class="flex flex-col">
-          <p class="text-sm font-semibold text-white">Gradient</p>
-          <p class="text-xs text-slate-100">Accent color</p>
-        </div>
-      </template>
-      <p class="text-sm text-slate-100">
-        Utilisez la variante gradient pour les mises en avant de sections clés ou les call-to-action.
-      </p>
-      <template #footer>
-        <span class="text-xs text-slate-100">CTA</span>
-        <div class="h-8 w-20 rounded-full bg-white/20" />
-      </template>
-    </BaseCard>
+          <template #footer>
+            <span class="card-story__footer">{{ variant.footer }}</span>
+            <div class="card-story__pill" />
+          </template>
+        </BaseCard>
+      </div>
+    </section>
   </div>
 </template>
 
 <script setup lang="ts">
 import { BaseCard } from '../index'
+
+const themes = [
+  { key: 'light', label: 'Thème clair', class: 'v-theme--light' },
+  { key: 'dark', label: 'Thème sombre', class: 'v-theme--dark dark' },
+] as const
+
+const variants = [
+  {
+    variant: 'solid',
+    label: 'Solid',
+    subtitle: 'Surface principale',
+    description:
+      'La variante solide repose sur la surface principale du thème et convient aux contenus riches et structurés.',
+    footer: 'Mis à jour il y a 2 heures',
+    badge: 'Nouveau',
+  },
+  {
+    variant: 'muted',
+    label: 'Muted',
+    subtitle: 'Surface atténuée',
+    description:
+      'Utilisez-la pour des encarts secondaires ou des résumés, elle reste lisible tout en étant plus discrète.',
+    footer: 'Rappel prévu demain',
+  },
+  {
+    variant: 'outline',
+    label: 'Outline',
+    subtitle: 'Contour marqué',
+    description:
+      'Met en avant les séparations et fonctionne bien pour des listes d’actions ou des aperçus de contenus.',
+    footer: 'Détails disponibles',
+  },
+  {
+    variant: 'glass',
+    label: 'Glass',
+    subtitle: 'Effet verre dépoli',
+    description:
+      'Combine un arrière-plan translucide et une bordure douce, idéal pour superposer du contenu visuel.',
+    footer: 'Voir la galerie',
+    media: true,
+  },
+  {
+    variant: 'gradient',
+    label: 'Gradient',
+    subtitle: 'Accent primaire',
+    description:
+      'Parfaite pour mettre en avant une action ou une annonce importante avec un dégradé basé sur le thème.',
+    footer: 'Appel à l’action',
+    rounded: 'lg',
+    padding: 'sm',
+  },
+] as const
 </script>
 
 <style scoped>
-.story-grid {
+.card-story {
+  display: grid;
+  gap: var(--ui-spacing-6);
+}
+
+.card-story__theme {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ui-spacing-5);
+  padding: var(--ui-spacing-6);
+  border-radius: var(--ui-radius-lg);
+  background: rgb(var(--v-theme-background));
+  color: rgb(var(--v-theme-on-background));
+  box-shadow: 0 20px 55px rgba(var(--v-theme-shadow), 0.12);
+}
+
+.card-story__title {
+  font-size: var(--v-text-h5-size);
+  font-weight: var(--v-text-h5-weight, 600);
+  letter-spacing: var(--v-text-h5-letter-spacing, -0.0025em);
+}
+
+.card-story__grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.5rem;
+  gap: var(--ui-spacing-5);
+}
+
+.card-story__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ui-spacing-4);
+}
+
+.card-story__heading {
+  font-size: var(--v-text-body-1-size);
+  font-weight: 600;
+  margin: 0;
+}
+
+.card-story__subtitle {
+  margin: 0;
+  margin-top: 0.25rem;
+  font-size: var(--v-text-body-2-size);
+  color: rgba(var(--v-theme-on-surface-variant), 0.85);
+}
+
+.card-story__badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--ui-radius-pill);
+  padding-inline: var(--ui-spacing-3);
+  padding-block: 0.25rem;
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.5);
+  font-size: 0.75rem;
+}
+
+.card-story__media {
+  aspect-ratio: 16 / 9;
+  width: 100%;
+  border-radius: calc(var(--ui-radius-xl) - var(--ui-spacing-2));
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.45);
+  background: linear-gradient(
+    135deg,
+    rgba(var(--v-theme-primary), 0.24),
+    rgba(var(--v-theme-surface-bright), 0.12)
+  );
+}
+
+.card-story__footer {
+  font-size: var(--v-text-body-2-size);
+}
+
+.card-story__pill {
+  height: 2.25rem;
+  width: 5.5rem;
+  border-radius: var(--ui-radius-pill);
+  background: rgba(var(--v-theme-on-surface), 0.08);
 }
 </style>

--- a/components/ui/tests/BaseCard.spec.ts
+++ b/components/ui/tests/BaseCard.spec.ts
@@ -2,6 +2,14 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import BaseCard from '../BaseCard.vue'
 
+const variants: Array<'solid' | 'muted' | 'outline' | 'glass' | 'gradient'> = [
+  'solid',
+  'muted',
+  'outline',
+  'glass',
+  'gradient',
+]
+
 describe('BaseCard', () => {
   it('renders optional slot sections when provided', () => {
     const wrapper = mount(BaseCard, {
@@ -19,7 +27,7 @@ describe('BaseCard', () => {
     expect(wrapper.find('[data-test="base-card-footer"]').text()).toContain('Footer')
   })
 
-  it('applies gradient variant and hoverable classes', () => {
+  it('applies gradient variant tokens and hoverable behaviour', () => {
     const wrapper = mount(BaseCard, {
       props: {
         variant: 'gradient',
@@ -31,11 +39,13 @@ describe('BaseCard', () => {
     })
 
     expect(wrapper.attributes('data-variant')).toBe('gradient')
-    expect(wrapper.classes()).toContain('bg-gradient-to-br')
-    expect(wrapper.classes()).toContain('hover:-translate-y-1')
+    expect(wrapper.classes()).toContain('base-card')
+    expect(wrapper.classes()).toContain('base-card--hoverable')
+    expect(wrapper.element.style.getPropertyValue('--card-background')).toContain('linear-gradient')
+    expect(wrapper.element.style.getPropertyValue('--card-color')).toContain('--v-theme-on-primary')
   })
 
-  it('supports custom root element and merges attributes', () => {
+  it('supports custom root element, attributes and spacing tokens', () => {
     const wrapper = mount(BaseCard, {
       props: {
         as: 'section',
@@ -56,9 +66,34 @@ describe('BaseCard', () => {
     expect(wrapper.element.tagName).toBe('SECTION')
     expect(wrapper.attributes('id')).toBe('custom-card')
     expect(wrapper.classes()).toContain('custom-card')
-    expect(wrapper.classes()).toContain('p-8')
+    expect(wrapper.element.style.getPropertyValue('--card-padding')).toBe('var(--ui-spacing-6)')
+    expect(wrapper.element.style.getPropertyValue('--card-footer-border')).toBe('0')
     const footer = wrapper.find('[data-test="base-card-footer"]')
-    expect(footer.classes()).not.toContain('border-t')
+    expect(footer.exists()).toBe(true)
     expect(footer.find('[data-test="footer"]').exists()).toBe(true)
+  })
+
+  it.each(variants)('uses Vuetify tokens for %s variant', (variant) => {
+    const wrapper = mount(BaseCard, {
+      props: { variant },
+      slots: { default: 'Variant body' },
+    })
+
+    const styles = wrapper.element.style
+    expect(wrapper.attributes('data-variant')).toBe(variant)
+    expect(styles.getPropertyValue('--card-background')).toMatch(/var\(--v-theme-/)
+    expect(styles.getPropertyValue('--card-color')).toMatch(/var\(--v-theme-/)
+    expect(styles.getPropertyValue('--card-border-color')).toMatch(/var\(--v-theme-/)
+  })
+
+  it('applies spacing tokens on body content', () => {
+    const wrapper = mount(BaseCard, {
+      props: { spacing: 'sm' },
+      slots: { default: '<p>Body</p>' },
+    })
+
+    const body = wrapper.find('[data-test="base-card-body"]')
+    expect(body.classes()).toContain('base-card__body')
+    expect(wrapper.element.style.getPropertyValue('--card-body-gap')).toBe('var(--ui-spacing-3)')
   })
 })


### PR DESCRIPTION
## Summary
- refactor `BaseCard` to derive styles from Vuetify theme tokens instead of hard-coded Tailwind classes
- document all card variants in light and dark themes through the storybook showcase
- expand unit coverage to assert token bindings for every variant

## Testing
- `pnpm test:unit` *(fails: existing e2e suites require i18n/plugins and PostCard fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d9beb0c33883269b16db37a40f65df