### PR TITLE
feat: align Vuetify and Tailwind typography

### DIFF
--- a/assets/styles/README.md
+++ b/assets/styles/README.md
@@ -91,19 +91,26 @@ Une ombre de focus harmonisée est également disponible via `--ui-focus` (`0 0 
 
 ## Typographie
 
-- Police par défaut (`$body-font-family`) : `var(--v-font-family-base)` → `Inter` (fallback systèmes).
-- Police display (`var(--v-font-family-display)`) pour les titres : `Plus Jakarta Sans`.
-- Tailles :
-  - `h1` → `var(--v-text-h1-size)` (3.25rem), line-height 1.2.
-  - `h2` → `var(--v-text-h2-size)` (2.5rem), line-height 1.25.
-  - `h3` → `var(--v-text-h3-size)` (2rem), line-height 1.3.
-  - `h4` → `var(--v-text-h4-size)` (1.5rem), line-height 1.35.
-  - `h5` → `var(--v-text-h5-size)` (1.25rem), line-height 1.4.
-  - `h6` → `var(--v-text-h6-size)` (1rem), line-height 1.45.
-  - Corps (`body-1`) → `var(--v-text-body-1-size)` (1rem), line-height 1.6.
-  - Corps secondaire (`body-2`) → `var(--v-text-body-2-size)` (0.875rem), line-height 1.6.
+- Police par défaut (`$body-font-family` / `var(--v-font-family-base)`) : `Manrope`, avec retours `Inter`, `Helvetica Neue`, `Arial`, `sans-serif`.
+- Police display (`var(--v-font-family-display)`) pour les titres : `Bricolage Grotesque`, retombant sur `Manrope`, `Inter`, puis les fontes systèmes.
+- Les fontes sont chargées via `assets/styles/index.css` (Google Fonts, `font-display: swap`) et appliquées globalement au `<body>`.
 
-Les lettres-spacing et poids (`var(--v-text-*-letter-spacing|weight)`) sont également exposés.
+### Échelle commune Vuetify ↔ Tailwind
+
+Les tokens Vuetify sont repris tels quels côté Tailwind via des utilitaires (`text-h1`, `text-body-1`, etc.). Utilisez-les pour aligner tout le contenu typographique, quelle que soit la techno utilisée.
+
+| Rôle | Token Vuetify | Classe Tailwind | Taille | Line-height | Letter-spacing | Poids |
+| --- | --- | --- | --- | --- | --- | --- |
+| Affichage XL | `--v-text-h1-*` | `text-h1` | 3.25rem | 1.2 | -0.02em | 600 |
+| Affichage LG | `--v-text-h2-*` | `text-h2` | 2.5rem | 1.25 | -0.015em | 600 |
+| Affichage MD | `--v-text-h3-*` | `text-h3` | 2rem | 1.3 | -0.01em | 600 |
+| Affichage SM | `--v-text-h4-*` | `text-h4` | 1.5rem | 1.35 | -0.005em | 600 |
+| Affichage XS | `--v-text-h5-*` | `text-h5` | 1.25rem | 1.4 | -0.0025em | 600 |
+| Sur-titre | `--v-text-h6-*` | `text-h6` | 1rem | 1.45 | 0 | 600 |
+| Corps | `--v-text-body-1-*` | `text-body-1` | 1rem | 1.6 | 0 | 400 |
+| Corps secondaire | `--v-text-body-2-*` | `text-body-2` | 0.875rem | 1.6 | 0 | 400 |
+
+Les variables `var(--v-text-*-letter-spacing)` et `var(--v-text-*-weight)` sont injectées dans la configuration Tailwind afin de rester synchronisées même si les valeurs évoluent dans le thème.
 
 ## Formulaires et boutons
 

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@500;600;700&family=Manrope:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -5,6 +7,17 @@
 html,
 body {
   min-height: 100%;
+}
+
+body {
+  font-family: var(
+    --v-font-family-base,
+    'Manrope',
+    'Inter',
+    'Helvetica Neue',
+    Arial,
+    sans-serif
+  );
 }
 
 :root {

--- a/assets/styles/variables/_typography.scss
+++ b/assets/styles/variables/_typography.scss
@@ -1,4 +1,7 @@
-$body-font-family: var(--v-font-family-base, 'Inter, sans-serif');
+$body-font-family: var(
+  --v-font-family-base,
+  'Manrope, "Inter", "Helvetica Neue", Arial, sans-serif'
+);
 $font-size-root: var(--v-font-size-root, 16px);
 
 $headings: (
@@ -6,42 +9,60 @@ $headings: (
     'size': var(--v-text-h1-size, 3.25rem),
     'line-height': var(--v-text-h1-line-height, 1.2),
     'letter-spacing': var(--v-text-h1-letter-spacing, -0.02em),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h1-weight, 600),
   ),
   'h2': (
     'size': var(--v-text-h2-size, 2.5rem),
     'line-height': var(--v-text-h2-line-height, 1.25),
     'letter-spacing': var(--v-text-h2-letter-spacing, -0.015em),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h2-weight, 600),
   ),
   'h3': (
     'size': var(--v-text-h3-size, 2rem),
     'line-height': var(--v-text-h3-line-height, 1.3),
     'letter-spacing': var(--v-text-h3-letter-spacing, -0.01em),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h3-weight, 600),
   ),
   'h4': (
     'size': var(--v-text-h4-size, 1.5rem),
     'line-height': var(--v-text-h4-line-height, 1.35),
     'letter-spacing': var(--v-text-h4-letter-spacing, -0.005em),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h4-weight, 600),
   ),
   'h5': (
     'size': var(--v-text-h5-size, 1.25rem),
     'line-height': var(--v-text-h5-line-height, 1.4),
     'letter-spacing': var(--v-text-h5-letter-spacing, -0.0025em),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h5-weight, 600),
   ),
   'h6': (
     'size': var(--v-text-h6-size, 1rem),
     'line-height': var(--v-text-h6-line-height, 1.45),
     'letter-spacing': var(--v-text-h6-letter-spacing, 0),
-    'font-family': var(--v-font-family-display, 'Plus Jakarta Sans, sans-serif'),
+    'font-family': var(
+      --v-font-family-display,
+      'Bricolage Grotesque, "Manrope", "Inter", sans-serif'
+    ),
     'font-weight': var(--v-text-h6-weight, 600),
   ),
 );

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -81,8 +81,9 @@ export default defineNuxtPlugin((nuxtApp) => {
   const nuxtIconComponent = nuxtApp.vueApp.component('Icon')
 
   const sharedVariables = {
-    'font-family-base': "'Inter', 'Helvetica Neue', Arial, sans-serif",
-    'font-family-display': "'Plus Jakarta Sans', 'Inter', sans-serif",
+    'font-family-base': "'Manrope', 'Inter', 'Helvetica Neue', Arial, sans-serif",
+    'font-family-display':
+      "'Bricolage Grotesque', 'Manrope', 'Inter', 'Helvetica Neue', Arial, sans-serif",
     'font-size-root': '16px',
     'line-height-base': 1.5,
     'text-h1-size': '3.25rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,11 +62,96 @@ export default {
       // => @media (min-width: 640px) { ... }
     },
     fontFamily: {
-      heading: ["Bricolage Grotesque", "Manrope"],
-      sans: ["Manrope"],
+      heading: [
+        "Bricolage Grotesque",
+        "Manrope",
+        "Inter",
+        "Helvetica Neue",
+        "Arial",
+        "sans-serif",
+      ],
+      sans: [
+        "Manrope",
+        "Inter",
+        "Helvetica Neue",
+        "Arial",
+        "sans-serif",
+      ],
       mono: ["monospace"],
     },
     extend: {
+      fontSize: {
+        h1: [
+          "var(--v-text-h1-size)",
+          {
+            lineHeight: "var(--v-text-h1-line-height)",
+            letterSpacing: "var(--v-text-h1-letter-spacing)",
+            fontWeight: "var(--v-text-h1-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        h2: [
+          "var(--v-text-h2-size)",
+          {
+            lineHeight: "var(--v-text-h2-line-height)",
+            letterSpacing: "var(--v-text-h2-letter-spacing)",
+            fontWeight: "var(--v-text-h2-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        h3: [
+          "var(--v-text-h3-size)",
+          {
+            lineHeight: "var(--v-text-h3-line-height)",
+            letterSpacing: "var(--v-text-h3-letter-spacing)",
+            fontWeight: "var(--v-text-h3-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        h4: [
+          "var(--v-text-h4-size)",
+          {
+            lineHeight: "var(--v-text-h4-line-height)",
+            letterSpacing: "var(--v-text-h4-letter-spacing)",
+            fontWeight: "var(--v-text-h4-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        h5: [
+          "var(--v-text-h5-size)",
+          {
+            lineHeight: "var(--v-text-h5-line-height)",
+            letterSpacing: "var(--v-text-h5-letter-spacing)",
+            fontWeight: "var(--v-text-h5-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        h6: [
+          "var(--v-text-h6-size)",
+          {
+            lineHeight: "var(--v-text-h6-line-height)",
+            letterSpacing: "var(--v-text-h6-letter-spacing)",
+            fontWeight: "var(--v-text-h6-weight)",
+            fontFamily: "var(--v-font-family-display)",
+          },
+        ],
+        "body-1": [
+          "var(--v-text-body-1-size)",
+          {
+            lineHeight: "var(--v-text-body-1-line-height)",
+            fontWeight: "var(--v-text-body-1-weight, 400)",
+            fontFamily: "var(--v-font-family-base)",
+          },
+        ],
+        "body-2": [
+          "var(--v-text-body-2-size)",
+          {
+            lineHeight: "var(--v-text-body-2-line-height)",
+            fontWeight: "var(--v-text-body-2-weight, 400)",
+            fontFamily: "var(--v-font-family-base)",
+          },
+        ],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- switch Vuetify to Manrope for body text and Bricolage Grotesque for headings, and mirror the same font stack in Tailwind
- import the font files with swap-friendly loading and wire Tailwind font-size utilities to Vuetify typography tokens
- document the shared typography scale and usage in the theme README

## Testing
- ⚠️ `pnpm lint` *(cancelled after hanging for an extended time)*

------
https://chatgpt.com/codex/tasks/task_e_68d9c0f9be548326a6c1e6c97543c246