### PR TITLE
Render right sidebar cards in default layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -56,7 +56,18 @@
                 :active-key="activeSidebar"
                 :eager="rightDrawer"
                 @select="handleSidebarSelect"
-              />
+              >
+                <div class="flex flex-col gap-4">
+                  <SidebarWeatherCard v-if="weather" :weather="weather" />
+                  <SidebarLeaderboardCard
+                    v-if="leaderboard"
+                    :title="leaderboard.title"
+                    :live-label="leaderboard.live"
+                    :participants="leaderboard.participants"
+                  />
+                  <SidebarRatingCard v-if="rating" :rating="rating" />
+                </div>
+              </AppSidebarRight>
             </div>
             <template #fallback>
               <div class="pane-scroll px-3 py-4">


### PR DESCRIPTION
## Summary
- convert the default layout's AppSidebarRight invocation into an explicit slot
- render the weather, leaderboard, and rating cards inside the right sidebar slot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9cb92d5908326a1ca26c81fe8eaa6