### PR TITLE
Fix dark mode detection when using cookie color mode

### DIFF
--- a/components/content/common/ComponentIndex.vue
+++ b/components/content/common/ComponentIndex.vue
@@ -51,6 +51,7 @@
 
 <script setup lang="ts">
 import type { QueryBuilderParams } from "@nuxt/content";
+import { useCookieColorMode } from "#imports";
 
 interface Badge {
   type: "default" | "info" | "warning" | "success" | "danger" | "lime" | undefined;
@@ -106,7 +107,8 @@ const query: QueryBuilderParams = {
 };
 
 const categories = ref<Array<Category>>([]);
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const gradientColor = computed(() => (isDark.value ? "#363636" : "#C9C9C9"));
 const openCategories = ref<Array<string>>([]);
 

--- a/components/content/common/landing-page-v2/HeroSectionV2.vue
+++ b/components/content/common/landing-page-v2/HeroSectionV2.vue
@@ -81,7 +81,10 @@
 </template>
 
 <script setup lang="ts">
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const globeConfig = {
   pointSize: 1,
   globeColor: "#FFF",

--- a/components/content/common/landing-page/FeatureSection.vue
+++ b/components/content/common/landing-page/FeatureSection.vue
@@ -30,7 +30,10 @@
 </template>
 
 <script lang="ts" setup>
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 
 const features = [
   {

--- a/components/content/common/landing-page/HeroSection.vue
+++ b/components/content/common/landing-page/HeroSection.vue
@@ -73,5 +73,8 @@
 </template>
 
 <script setup lang="ts">
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 </script>

--- a/components/content/common/landing-page/Testimonials.vue
+++ b/components/content/common/landing-page/Testimonials.vue
@@ -111,7 +111,10 @@
 </template>
 
 <script setup lang="ts">
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 
 // Reviews data
 const reviews = [

--- a/components/content/inspira/blocks/testimonials/LinearMarqueeTestimonials.vue
+++ b/components/content/inspira/blocks/testimonials/LinearMarqueeTestimonials.vue
@@ -52,7 +52,10 @@
 </template>
 
 <script setup lang="ts">
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 
 // Reviews data
 const reviews = [

--- a/components/content/inspira/blocks/testimonials/SkewedMarqueeTestimonials.vue
+++ b/components/content/inspira/blocks/testimonials/SkewedMarqueeTestimonials.vue
@@ -107,7 +107,10 @@
 </template>
 
 <script setup lang="ts">
-const isDark = computed(() => useColorMode().value == "dark");
+import { useCookieColorMode } from "#imports";
+
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 
 // Reviews data
 const reviews = [

--- a/components/content/inspira/examples/BalanceSliderDemo.vue
+++ b/components/content/inspira/examples/BalanceSliderDemo.vue
@@ -11,9 +11,10 @@
 
 <script lang="ts" setup>
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const rightColor = computed(() => (isDark.value ? "#FFFFFF" : "#000000"));
 const indicatorColor = computed(() => (isDark.value ? "#FFFFFF" : "#000000"));
 </script>

--- a/components/content/inspira/examples/CardSpotlightDemo.vue
+++ b/components/content/inspira/examples/CardSpotlightDemo.vue
@@ -11,7 +11,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 </script>

--- a/components/content/inspira/examples/GradientButtonDemo.vue
+++ b/components/content/inspira/examples/GradientButtonDemo.vue
@@ -6,8 +6,9 @@
 
 <script lang="ts" setup>
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const bgColor = computed(() => (isDark.value ? "#000" : "#fff"));
 </script>

--- a/components/content/inspira/examples/ParticlesBgDemo.vue
+++ b/components/content/inspira/examples/ParticlesBgDemo.vue
@@ -20,7 +20,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 </script>

--- a/components/content/inspira/examples/backgrounds/FallingStarsBgDemo.vue
+++ b/components/content/inspira/examples/backgrounds/FallingStarsBgDemo.vue
@@ -12,7 +12,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 </script>

--- a/components/content/inspira/examples/line-shadow-text/LineShadowTextDemo.vue
+++ b/components/content/inspira/examples/line-shadow-text/LineShadowTextDemo.vue
@@ -14,8 +14,9 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const shadowColor = computed(() => (isDark.value ? "white" : "black"));
 </script>

--- a/components/content/inspira/examples/sparkles/SparklesDemo.vue
+++ b/components/content/inspira/examples/sparkles/SparklesDemo.vue
@@ -38,7 +38,10 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const particlesColor = computed(() => (useColorMode().value === "dark" ? "#FFFFFF" : "#000000"));
+const colorMode = useCookieColorMode();
+const particlesColor = computed(() =>
+  colorMode.value === "dark" ? "#FFFFFF" : "#000000",
+);
 </script>

--- a/components/content/inspira/examples/sparkles/SparklesFullPageDemo.vue
+++ b/components/content/inspira/examples/sparkles/SparklesFullPageDemo.vue
@@ -21,7 +21,10 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { useColorMode } from "@vueuse/core";
+import { useCookieColorMode } from "#imports";
 
-const particlesColor = computed(() => (useColorMode().value === "dark" ? "#FFFFFF" : "#000000"));
+const colorMode = useCookieColorMode();
+const particlesColor = computed(() =>
+  colorMode.value === "dark" ? "#FFFFFF" : "#000000",
+);
 </script>

--- a/components/content/inspira/examples/world-map/WorldMapDemo.vue
+++ b/components/content/inspira/examples/world-map/WorldMapDemo.vue
@@ -32,6 +32,7 @@
 
 <script lang="ts" setup>
 import { Motion } from "motion-v";
+import { useCookieColorMode } from "#imports";
 
 const dots = [
   {
@@ -66,5 +67,6 @@ const dots = [
   },
 ];
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 </script>

--- a/components/content/inspira/ui/scroll-island/ScrollIsland.vue
+++ b/components/content/inspira/ui/scroll-island/ScrollIsland.vue
@@ -61,9 +61,9 @@
 <script lang="ts" setup>
 import { cn } from "@/lib/utils";
 import NumberFlow from "@number-flow/vue";
-import { useColorMode } from "@vueuse/core";
 import { motion, MotionConfig } from "motion-v";
 import { computed, onMounted, onUnmounted, ref, useSlots } from "vue";
+import { useCookieColorMode } from "#imports";
 
 interface Props {
   class?: string;
@@ -82,7 +82,8 @@ const slots = useSlots();
 
 const scrollPercentage = ref(0);
 
-const isDark = computed(() => useColorMode().value == "dark");
+const colorMode = useCookieColorMode();
+const isDark = computed(() => colorMode.value === "dark");
 const isSlotAvailable = computed(() => !!slots.default);
 const borderRadius = computed(() => `${props.height / 2}px`);
 

--- a/components/layout/AppSidebarRight.vue
+++ b/components/layout/AppSidebarRight.vue
@@ -38,6 +38,7 @@
 
 <script setup lang="ts">
 import { computed, defineAsyncComponent, ref, watch } from 'vue'
+import { useCookieColorMode } from '#imports'
 import { useI18n } from 'vue-i18n'
 import { resolveSocialRedirect, type SocialProvider } from '~/lib/auth/social'
 import { useAuthSession } from '~/stores/auth-session'
@@ -81,7 +82,8 @@ const props = withDefaults(
 )
 
 const sticky = computed(() => props.sticky)
-const isDark = computed(() => useColorMode().value === 'dark')
+const colorMode = useCookieColorMode()
+const isDark = computed(() => colorMode.value === 'dark')
 const auth = useAuthSession()
 const isAuthenticated = computed(() => auth.isAuthenticated.value)
 const { t } = useI18n()
@@ -112,9 +114,9 @@ function scheduleParticles() {
     requestIdleCallback?: (callback: () => void) => number
   }
 
-  const enableParticles = () => {
-    shouldRenderParticles.value = true
-  }
+    function enableParticles() {
+      shouldRenderParticles.value = true
+    }
 
   if (typeof idleWindow.requestIdleCallback === 'function') {
     idleWindow.requestIdleCallback(enableParticles)

--- a/composables/useCookieColorMode.ts
+++ b/composables/useCookieColorMode.ts
@@ -1,0 +1,24 @@
+import { useColorMode } from '@vueuse/core'
+import { useCookie } from '#imports'
+
+type ColorModeValue = 'light' | 'dark' | 'auto'
+
+export function useCookieColorMode() {
+  const colorModeCookie = useCookie<ColorModeValue>('color-mode', {
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  return useColorMode<ColorModeValue>({
+    storageKey: 'color-mode',
+    storage: {
+      getItem: () => colorModeCookie.value ?? 'auto',
+      setItem: (_, value) => {
+        colorModeCookie.value = value as ColorModeValue
+      },
+      removeItem: () => {
+        colorModeCookie.value = null
+      },
+    },
+  })
+}

--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -1,7 +1,7 @@
 import { computed, watch } from 'vue'
-import { useColorMode } from '@vueuse/core'
 import type { Theme } from 'shadcn-docs-nuxt/lib/themes'
 import { themes } from 'shadcn-docs-nuxt/lib/themes'
+import { useCookieColorMode } from './useCookieColorMode'
 
 interface ThemeCookieConfig {
   theme: Theme['name']
@@ -90,23 +90,7 @@ export function useThemes() {
     }
   }
 
-  const colorModeCookie = useCookie<'light' | 'dark' | 'auto'>('color-mode', {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-  })
-
-  const colorMode = useColorMode({
-    storageKey: 'color-mode',
-    storage: {
-      getItem: () => colorModeCookie.value ?? 'auto',
-      setItem: (_, value) => {
-        colorModeCookie.value = value as typeof colorModeCookie.value
-      },
-      removeItem: () => {
-        colorModeCookie.value = null
-      },
-    },
-  })
+  const colorMode = useCookieColorMode()
   const isDark = computed(() => colorMode.value === 'dark')
 
   const themeCookie = useCookie<ThemeCookieConfig>('theme', {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -120,6 +120,7 @@
 
 <script setup lang="ts">
 import { watch, computed, ref, defineAsyncComponent } from 'vue'
+import { useCookieColorMode } from '#imports'
 import { useDisplay } from 'vuetify'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 import AppTopBar from '@/components/layout/AppTopBar.vue'
@@ -137,7 +138,8 @@ const AppSidebarRight = defineAsyncComponent({
   suspensible: false,
 })
 
-const isDark = computed(() => useColorMode().value == 'dark')
+const colorMode = useCookieColorMode()
+const isDark = computed(() => colorMode.value === 'dark')
 const route = useRoute()
 const router = useRouter()
 const display = useDisplay()
@@ -227,7 +229,8 @@ function onEditDetails() {}
 function onAddFeatured() {}
 function onViewAllPhotos() {}
 function onViewAllFriends() {}
-function openFriend(f: any) {}
+type Friend = (typeof friends)[number]
+function openFriend(_friend: Friend) {}
 function onViewAllEvents() {}
 function onAddEvent() {}
 

--- a/pages/styleguide.vue
+++ b/pages/styleguide.vue
@@ -240,7 +240,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
-import { useColorMode } from '@vueuse/core'
+import { useCookieColorMode } from '#imports'
 import {
   BaseButton,
   BaseCard,
@@ -256,7 +256,7 @@ import {
   BaseModal,
 } from '~/components/ui'
 
-const colorMode = useColorMode()
+const colorMode = useCookieColorMode()
 const activeColorMode = computed(() => {
   const raw = colorMode.preference ?? (colorMode.value as 'auto' | 'light' | 'dark' | undefined)
   return raw ?? 'auto'


### PR DESCRIPTION
## Summary
- update components that rely on the color mode to reuse a single cookie-backed ref so dark-mode styling updates immediately

## Testing
- pnpm lint *(fails: command hangs on existing lint issues, cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68da735334cc83268ccb74586027bf8e