### PR TITLE
Fix dark mode background application

### DIFF
--- a/composables/useCookieColorMode.ts
+++ b/composables/useCookieColorMode.ts
@@ -1,3 +1,4 @@
+import { watchEffect } from 'vue'
 import { useColorMode } from '@vueuse/core'
 import { useCookie } from '#imports'
 
@@ -9,7 +10,7 @@ export function useCookieColorMode() {
     secure: process.env.NODE_ENV === 'production',
   })
 
-  return useColorMode<ColorModeValue>({
+  const colorMode = useColorMode<ColorModeValue>({
     storageKey: 'color-mode',
     storage: {
       getItem: () => colorModeCookie.value ?? 'auto',
@@ -21,4 +22,18 @@ export function useCookieColorMode() {
       },
     },
   })
+
+  if (import.meta.client) {
+    watchEffect(() => {
+      const resolvedMode =
+        colorMode.value === 'auto' ? colorMode.system.value : colorMode.value
+      const isDark = resolvedMode === 'dark'
+      const classList = document.documentElement.classList
+
+      classList.toggle('dark', isDark)
+      classList.toggle('theme--dark', isDark)
+    })
+  }
+
+  return colorMode
 }


### PR DESCRIPTION
## Summary
- ensure the cookie-based color mode composable synchronizes the `dark` and `theme--dark` classes on the document
- resolve the effective mode in auto mode so dark styling is applied when appropriate

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da7b5a0ca083268f6093b03d66ba45