### PR TITLE
Improve cookie handling for color mode and auth

### DIFF
--- a/composables/useCookieColorMode.ts
+++ b/composables/useCookieColorMode.ts
@@ -1,14 +1,17 @@
 import { watchEffect } from 'vue'
 import { useColorMode } from '@vueuse/core'
 import { useCookie } from '#imports'
+import { withSecureCookieOptions } from '~/lib/cookies'
 
 type ColorModeValue = 'light' | 'dark' | 'auto'
 
 export function useCookieColorMode() {
-  const colorModeCookie = useCookie<ColorModeValue>('color-mode', {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-  })
+  const colorModeCookie = useCookie<ColorModeValue>(
+    'color-mode',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+    }),
+  )
 
   const colorMode = useColorMode<ColorModeValue>({
     storageKey: 'color-mode',

--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -2,6 +2,7 @@ import { computed, watch } from 'vue'
 import type { Theme } from 'shadcn-docs-nuxt/lib/themes'
 import { themes } from 'shadcn-docs-nuxt/lib/themes'
 import { useCookieColorMode } from './useCookieColorMode'
+import { withSecureCookieOptions } from '~/lib/cookies'
 
 interface ThemeCookieConfig {
   theme: Theme['name']
@@ -93,11 +94,13 @@ export function useThemes() {
   const colorMode = useCookieColorMode()
   const isDark = computed(() => colorMode.value === 'dark')
 
-  const themeCookie = useCookie<ThemeCookieConfig>('theme', {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-    default: resolveThemeDefaults,
-  })
+  const themeCookie = useCookie<ThemeCookieConfig>(
+    'theme',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+      default: resolveThemeDefaults,
+    }),
+  )
 
   const theme = computed<Theme['name']>(() => themeCookie.value?.theme ?? resolveThemeDefaults().theme)
   const radius = computed(() => themeCookie.value?.radius ?? resolveThemeDefaults().radius)
@@ -139,10 +142,12 @@ export function useThemes() {
     return hslToHex(components)
   })
 
-  const themePrimaryCookie = useCookie<string | null>('theme-primary', {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-  })
+  const themePrimaryCookie = useCookie<string | null>(
+    'theme-primary',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+    }),
+  )
 
   if (!themePrimaryCookie.value && themePrimaryHex.value) {
     themePrimaryCookie.value = themePrimaryHex.value

--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -1,0 +1,79 @@
+import type { CookieOptions } from 'nuxt/app'
+import type { H3Event } from 'h3'
+import { useRequestEvent } from '#imports'
+
+type MaybeEvent = H3Event | null | undefined
+
+type MaybeEncryptedSocket = { encrypted?: boolean }
+
+function isEventSecure(event: H3Event): boolean {
+  const forwardedProto = event.node.req.headers['x-forwarded-proto']
+
+  if (typeof forwardedProto === 'string' && forwardedProto.trim()) {
+    const [first] = forwardedProto.split(',')
+
+    if (first) {
+      return first.trim().toLowerCase() === 'https'
+    }
+  }
+
+  const schemeHeader = event.node.req.headers[':scheme']
+
+  if (typeof schemeHeader === 'string' && schemeHeader.trim()) {
+    return schemeHeader.trim().toLowerCase() === 'https'
+  }
+
+  const socket = event.node.req.socket as MaybeEncryptedSocket | undefined
+  const connection = event.node.req.connection as MaybeEncryptedSocket | undefined
+
+  if (socket && typeof socket.encrypted === 'boolean') {
+    return socket.encrypted
+  }
+
+  if (connection && typeof connection.encrypted === 'boolean') {
+    return connection.encrypted
+  }
+
+  return process.env.NODE_ENV === 'production'
+}
+
+export function shouldUseSecureCookies(event?: MaybeEvent): boolean {
+  let targetEvent = event ?? null
+
+  if (!targetEvent && import.meta.server) {
+    try {
+      targetEvent = useRequestEvent()
+    } catch (error) {
+      targetEvent = null
+    }
+  }
+
+  if (targetEvent) {
+    return isEventSecure(targetEvent)
+  }
+
+  if (import.meta.client && typeof window !== 'undefined' && window.location) {
+    return window.location.protocol === 'https:'
+  }
+
+  return process.env.NODE_ENV === 'production'
+}
+
+export function withSecureCookieOptions<T>(
+  options?: CookieOptions<T>,
+  event?: MaybeEvent,
+): CookieOptions<T> {
+  const resolved: CookieOptions<T> = {
+    ...(options ?? {}),
+  }
+
+  if (typeof resolved.secure !== 'boolean') {
+    resolved.secure = shouldUseSecureCookies(event)
+  }
+
+  if (!resolved.path) {
+    resolved.path = '/'
+  }
+
+  return resolved
+}

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -61,20 +61,27 @@ import itLocale from 'date-fns/locale/it'
 import esLocale from 'date-fns/locale/es'
 import ruLocale from 'date-fns/locale/ru'
 import arLocale from 'date-fns/locale/ar-SA'
+import { withSecureCookieOptions } from '~/lib/cookies'
 
 export type DataTableHeaders = VDataTable['$props']['headers']
 
 export default defineNuxtPlugin((nuxtApp) => {
-  const primaryCookie = useCookie<string | null>('theme-primary', {
-    sameSite: 'lax',
-    watch: false,
-  })
+  const primaryCookie = useCookie<string | null>(
+    'theme-primary',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+      watch: false,
+    }),
+  )
   const primary = primaryCookie.value ?? '#E91E63'
 
-  const localeCookie = useCookie<string | null>('i18n_redirected', {
-    sameSite: 'lax',
-    watch: false,
-  })
+  const localeCookie = useCookie<string | null>(
+    'i18n_redirected',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+      watch: false,
+    }),
+  )
   const locale = localeCookie.value ?? 'en'
   const nuxtIconComponent = nuxtApp.vueApp.component('Icon')
 

--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -7,6 +7,7 @@ import { useCookie, useState } from '#imports'
 import { defineStore } from '~/lib/pinia-shim'
 import type { AuthLoginEnvelope, AuthSessionEnvelope, AuthUser } from '~/types/auth'
 import type { MercureTokenEnvelope, MercureTokenState } from '~/types/mercure'
+import { withSecureCookieOptions } from '~/lib/cookies'
 
 interface LoginCredentials {
   identifier: string
@@ -70,22 +71,25 @@ export const useAuthSession = defineStore('auth-session', () => {
   const runtimeConfig = useRuntimeConfig()
   const sessionTokenCookie = useCookie<string | null>(
     runtimeConfig.auth?.sessionTokenCookieName ?? 'auth_session_token',
-    {
+    withSecureCookieOptions({
       sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
       watch: false,
-    },
+    }),
   )
-  const presenceCookie = useCookie<string | null>(runtimeConfig.auth?.tokenPresenceCookieName ?? 'auth_token_present', {
-    sameSite: 'strict',
-    secure: process.env.NODE_ENV === 'production',
-    watch: false,
-  })
-  const userCookie = useCookie<AuthUser | null>(runtimeConfig.auth?.userCookieName ?? 'auth_user', {
-    sameSite: 'lax',
-    secure: process.env.NODE_ENV === 'production',
-    watch: false,
-  })
+  const presenceCookie = useCookie<string | null>(
+    runtimeConfig.auth?.tokenPresenceCookieName ?? 'auth_token_present',
+    withSecureCookieOptions({
+      sameSite: 'strict',
+      watch: false,
+    }),
+  )
+  const userCookie = useCookie<AuthUser | null>(
+    runtimeConfig.auth?.userCookieName ?? 'auth_user',
+    withSecureCookieOptions({
+      sameSite: 'lax',
+      watch: false,
+    }),
+  )
 
   if (presenceCookie.value === '1') {
     tokenAvailableState.value = true

--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -6,6 +6,10 @@ type StateRef<T> = ReturnType<typeof ref<T>>
 const stateRegistry = new Map<string, StateRef<unknown>>()
 const cookieRegistry = new Map<string, StateRef<unknown>>()
 
+export function useRequestEvent() {
+  return null
+}
+
 export function useState<T>(key: string, init: () => T): StateRef<T> {
   if (!stateRegistry.has(key)) {
     stateRegistry.set(key, ref(init()))


### PR DESCRIPTION
## Summary
- add a shared cookie helper that infers secure defaults from the current request or window context
- switch color mode, theme, auth, and Vuetify cookie usage to the shared helper for consistent options
- update server session cookie writer and Nuxt test mocks to support the new helper

## Testing
- pnpm lint *(fails: existing lint warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68da7e904c108326af1f7997d24da53b