### PR TITLE
fix: import useRequestEvent from #app

### DIFF
--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -1,6 +1,6 @@
 import type { CookieOptions } from 'nuxt/app'
 import type { H3Event } from 'h3'
-import { useRequestEvent } from '#imports'
+import { useRequestEvent } from '#app'
 
 type MaybeEvent = H3Event | null | undefined
 


### PR DESCRIPTION
## Summary
- fix the cookies helper to import useRequestEvent from the canonical #app entrypoint so unimport can resolve it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da81973c1c8326ad7b9edf79761a68