### PR TITLE
fix: use Nuxt request event import

### DIFF
--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -1,6 +1,5 @@
-import type { CookieOptions } from 'nuxt/app'
+import { useRequestEvent, type CookieOptions } from 'nuxt/app'
 import type { H3Event } from 'h3'
-import { useRequestEvent } from '#app'
 
 type MaybeEvent = H3Event | null | undefined
 


### PR DESCRIPTION
## Summary
- adjust the cookies helper to import `useRequestEvent` from `nuxt/app` instead of the `#app` alias
- avoid using Vue app aliases in server runtime to prevent plugin impound errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da8289fd54832699c98095df7c8b29