### PR TITLE
Fix server aliases to avoid Vue runtime resolution error

### DIFF
--- a/server/api/auth/login.post.ts
+++ b/server/api/auth/login.post.ts
@@ -1,8 +1,8 @@
 import { createError, readBody } from 'h3'
 import type { FetchError } from 'ofetch'
 import { joinURL } from 'ufo'
-import type { AuthLoginResponse, AuthUser } from '~/types/auth'
-import { clearAuthSession, setSession } from '~/server/utils/auth/session'
+import type { AuthLoginResponse, AuthUser } from '../../../types/auth'
+import { clearAuthSession, setSession } from '../../utils/auth/session'
 
 interface LoginRequestBody {
   identifier?: string

--- a/server/api/auth/logout.post.ts
+++ b/server/api/auth/logout.post.ts
@@ -1,4 +1,4 @@
-import { clearAuthSession } from '~/server/utils/auth/session'
+import { clearAuthSession } from '../../utils/auth/session'
 
 export default defineEventHandler(async (event) => {
   clearAuthSession(event)

--- a/server/api/auth/session.get.ts
+++ b/server/api/auth/session.get.ts
@@ -1,5 +1,5 @@
-import { clearAuthSession, getSessionToken, getSessionUser } from '~/server/utils/auth/session'
-import type { AuthSessionEnvelope } from '~/types/auth'
+import { clearAuthSession, getSessionToken, getSessionUser } from '../../utils/auth/session'
+import type { AuthSessionEnvelope } from '../../../types/auth'
 
 export default defineEventHandler(async (event) => {
   const token = getSessionToken(event)

--- a/server/api/mercure/token.get.ts
+++ b/server/api/mercure/token.get.ts
@@ -1,8 +1,8 @@
 import { createError } from 'h3'
 import type { FetchError } from 'ofetch'
 import { joinURL } from 'ufo'
-import type { MercureTokenEnvelope } from '~/types/mercure'
-import { withAuthHeaders } from '~/server/utils/auth/session'
+import type { MercureTokenEnvelope } from '../../../types/mercure'
+import { withAuthHeaders } from '../../utils/auth/session'
 
 function sanitizeBaseEndpoint(raw: string): string {
   return raw.replace(/\/$/, '')

--- a/server/api/users/[id].delete.ts
+++ b/server/api/users/[id].delete.ts
@@ -1,5 +1,5 @@
 import { createError } from "h3";
-import { removeUser } from "~/server/utils/users/storage";
+import { removeUser } from "../../utils/users/storage";
 
 export default defineEventHandler(async (event) => {
   const id = event.context.params?.id;

--- a/server/api/users/[id].put.ts
+++ b/server/api/users/[id].put.ts
@@ -1,6 +1,6 @@
 import { createError, readBody } from "h3";
-import type { AuthUser } from "~/types/auth";
-import { updateUser } from "~/server/utils/users/storage";
+import type { AuthUser } from "../../../types/auth";
+import { updateUser } from "../../utils/users/storage";
 
 export default defineEventHandler(async (event) => {
   const id = event.context.params?.id;

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,5 +1,5 @@
 import { createError } from "h3";
-import { listUsers } from "~/server/utils/users/storage";
+import { listUsers } from "../../utils/users/storage";
 
 export default defineEventHandler(async () => {
   try {

--- a/server/api/users/index.post.ts
+++ b/server/api/users/index.post.ts
@@ -1,6 +1,6 @@
 import { createError, readBody } from "h3";
-import type { AuthUser } from "~/types/auth";
-import { createUser } from "~/server/utils/users/storage";
+import type { AuthUser } from "../../../types/auth";
+import { createUser } from "../../utils/users/storage";
 
 export default defineEventHandler(async (event) => {
   const body = await readBody<Partial<AuthUser>>(event);

--- a/server/api/v1/posts/[id].delete.ts
+++ b/server/api/v1/posts/[id].delete.ts
@@ -1,6 +1,6 @@
 import { createError } from "h3";
-import { invalidatePostAndLists } from "~/server/utils/cache/posts";
-import { deletePostAtSource } from "~/server/utils/posts/api";
+import { invalidatePostAndLists } from "../../../utils/cache/posts";
+import { deletePostAtSource } from "../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params ?? {};

--- a/server/api/v1/posts/[id].get.ts
+++ b/server/api/v1/posts/[id].get.ts
@@ -1,12 +1,12 @@
 import { createError } from "h3";
-import type { PostItemEnvelope } from "~/server/utils/posts/types";
+import type { PostItemEnvelope } from "../../../utils/posts/types";
 import {
   cachePostById,
   getCachedPostById,
   getPostItemCacheKey,
   queueRevalidation,
-} from "~/server/utils/cache/posts";
-import { fetchPostByIdFromSource } from "~/server/utils/posts/api";
+} from "../../../utils/cache/posts";
+import { fetchPostByIdFromSource } from "../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params ?? {};

--- a/server/api/v1/posts/[id].patch.ts
+++ b/server/api/v1/posts/[id].patch.ts
@@ -1,11 +1,11 @@
 import { createError, readBody } from "h3";
-import type { PostItemEnvelope } from "~/server/utils/posts/types";
+import type { PostItemEnvelope } from "../../../utils/posts/types";
 import {
   cachePostById,
   invalidatePostAndLists,
-} from "~/server/utils/cache/posts";
-import { fetchPostByIdFromSource, updatePostAtSource } from "~/server/utils/posts/api";
-import type { BlogApiResponse, BlogPost } from "~/lib/mock/blog";
+} from "../../../utils/cache/posts";
+import { fetchPostByIdFromSource, updatePostAtSource } from "../../../utils/posts/api";
+import type { BlogApiResponse, BlogPost } from "../../../lib/mock/blog";
 
 function normalizePostResponse(response: unknown): BlogPost | null {
   if (!response || typeof response !== "object") {

--- a/server/api/v1/posts/[id]/comments/[commentId]/reactions/index.post.ts
+++ b/server/api/v1/posts/[id]/comments/[commentId]/reactions/index.post.ts
@@ -1,6 +1,6 @@
 import { createError, readBody } from "h3";
-import { invalidatePostAndLists } from "~/server/utils/cache/posts";
-import { reactToCommentAtSource } from "~/server/utils/posts/api";
+import { invalidatePostAndLists } from "../../../../../../../utils/cache/posts";
+import { reactToCommentAtSource } from "../../../../../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id, commentId } = event.context.params ?? {};

--- a/server/api/v1/posts/[id]/comments/index.get.ts
+++ b/server/api/v1/posts/[id]/comments/index.get.ts
@@ -1,5 +1,5 @@
 import { createError } from "h3";
-import { fetchPostCommentsFromSource } from "~/server/utils/posts/api";
+import { fetchPostCommentsFromSource } from "../../../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params ?? {};

--- a/server/api/v1/posts/[id]/comments/index.post.ts
+++ b/server/api/v1/posts/[id]/comments/index.post.ts
@@ -1,6 +1,6 @@
 import { createError, readBody } from "h3";
-import { invalidatePostAndLists } from "~/server/utils/cache/posts";
-import { addCommentAtSource } from "~/server/utils/posts/api";
+import { invalidatePostAndLists } from "../../../../../utils/cache/posts";
+import { addCommentAtSource } from "../../../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params ?? {};

--- a/server/api/v1/posts/[id]/reactions/index.post.ts
+++ b/server/api/v1/posts/[id]/reactions/index.post.ts
@@ -1,6 +1,6 @@
 import { createError, readBody } from "h3";
-import { invalidatePostAndLists } from "~/server/utils/cache/posts";
-import { postReactionAtSource } from "~/server/utils/posts/api";
+import { invalidatePostAndLists } from "../../../../../utils/cache/posts";
+import { postReactionAtSource } from "../../../../../utils/posts/api";
 
 export default defineEventHandler(async (event) => {
   const { id } = event.context.params ?? {};

--- a/server/api/v1/posts/index.get.ts
+++ b/server/api/v1/posts/index.get.ts
@@ -1,5 +1,5 @@
 import { createError, getQuery } from "h3";
-import type { PostsListEnvelope } from "~/server/utils/posts/types";
+import type { PostsListEnvelope } from "../../../utils/posts/types";
 import {
   cachePostById,
   cachePostsList,
@@ -7,9 +7,9 @@ import {
   getPostsListCacheKey,
   normalizeListQuery,
   queueRevalidation,
-} from "~/server/utils/cache/posts";
-import { fetchPostsListFromSource } from "~/server/utils/posts/api";
-import { getSessionToken } from "~/server/utils/auth/session";
+} from "../../../utils/cache/posts";
+import { fetchPostsListFromSource } from "../../../utils/posts/api";
+import { getSessionToken } from "../../../utils/auth/session";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);

--- a/server/api/v1/posts/index.post.ts
+++ b/server/api/v1/posts/index.post.ts
@@ -1,8 +1,8 @@
 import { createError, readBody } from "h3";
-import type { PostItemEnvelope } from "~/server/utils/posts/types";
-import { cachePostById, invalidatePostsList } from "~/server/utils/cache/posts";
-import { createPostAtSource } from "~/server/utils/posts/api";
-import type { BlogApiResponse, BlogPost } from "~/lib/mock/blog";
+import type { PostItemEnvelope } from "../../../utils/posts/types";
+import { cachePostById, invalidatePostsList } from "../../../utils/cache/posts";
+import { createPostAtSource } from "../../../utils/posts/api";
+import type { BlogApiResponse, BlogPost } from "../../../lib/mock/blog";
 
 function normalizeCreatedPost(response: unknown): BlogPost | null {
   if (!response || typeof response !== "object") {

--- a/server/utils/auth/session.ts
+++ b/server/utils/auth/session.ts
@@ -1,7 +1,7 @@
 import { deleteCookie, getCookie, setCookie } from 'h3'
 import type { H3Event } from 'h3'
-import type { AuthUser } from '~/types/auth'
-import { shouldUseSecureCookies, withSecureCookieOptions } from '~/lib/cookies'
+import type { AuthUser } from '../../../types/auth'
+import { shouldUseSecureCookies, withSecureCookieOptions } from '../../../lib/cookies'
 
 interface SessionCookiesConfig {
   tokenCookieName: string

--- a/server/utils/cache/posts.ts
+++ b/server/utils/cache/posts.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import Redis from "ioredis";
 import type { H3Event } from "h3";
-import type { BlogApiResponse, BlogPost } from "~/lib/mock/blog";
-import type { NormalizedPostsListQuery } from "~/server/utils/posts/types";
+import type { BlogApiResponse, BlogPost } from "../../../lib/mock/blog";
+import type { NormalizedPostsListQuery } from "../posts/types";
 
 type PostsVisibility = "public" | "private";
 

--- a/server/utils/posts/api.ts
+++ b/server/utils/posts/api.ts
@@ -8,9 +8,9 @@ import type {
   NormalizedPostsListQuery,
   ReactionPayload,
   UpdatePostPayload,
-} from "~/server/utils/posts/types";
-import type { BlogApiResponse, BlogCommentWithReplies, BlogPost } from "~/lib/mock/blog";
-import { clearAuthSession, getSessionToken, withAuthHeaders } from "~/server/utils/auth/session";
+} from "./types";
+import type { BlogApiResponse, BlogCommentWithReplies, BlogPost } from "../../../lib/mock/blog";
+import { clearAuthSession, getSessionToken, withAuthHeaders } from "../auth/session";
 
 type PostsVisibility = "public" | "private";
 

--- a/server/utils/posts/types.ts
+++ b/server/utils/posts/types.ts
@@ -1,4 +1,4 @@
-import type { BlogApiResponse, BlogPost } from "~/lib/mock/blog";
+import type { BlogApiResponse, BlogPost } from "../../../lib/mock/blog";
 
 export interface NormalizedPostsListQuery {
   page: number;

--- a/server/utils/users/storage.ts
+++ b/server/utils/users/storage.ts
@@ -1,7 +1,7 @@
 import { createError } from "h3";
 import { useStorage } from "nitropack/runtime";
-import type { AuthUser } from "~/types/auth";
-import { normalizeUserPayload } from "~/lib/users/normalizers";
+import type { AuthUser } from "../../../types/auth";
+import { normalizeUserPayload } from "../../../lib/users/normalizers";
 
 export interface StoredUser extends AuthUser {
   createdAt: string;


### PR DESCRIPTION
## Summary
- replace `~/` imports in server API routes and utilities with relative module paths
- ensure server runtime avoids Vue app aliases that impound forbids

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68da85dea70083268181b237f203aa1c