### PR TITLE
fix: import defineNitroPlugin explicitly in llms plugin

### DIFF
--- a/server/plugins/llms.ts
+++ b/server/plugins/llms.ts
@@ -3,6 +3,7 @@
 import { resolve, relative, join } from "pathe";
 import { readdirSync, statSync, readFileSync, existsSync } from "fs";
 import yaml from "yaml";
+import { defineNitroPlugin } from "nitropack";
 import type { NitroApp } from "nitropack";
 
 /**


### PR DESCRIPTION
## Summary
- import defineNitroPlugin from nitropack in the server LLMs plugin so the runtime no longer relies on Vue-only aliases

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68da8b60d1d48326890b99b77bd29f9e