### PR TITLE
Fix secure cookie detection for non-HTTPS environments

### DIFF
--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -56,7 +56,7 @@ function isEventSecure(event: H3Event): boolean {
     return connection.encrypted
   }
 
-  return process.env.NODE_ENV === 'production'
+  return false
 }
 
 export function shouldUseSecureCookies(event?: MaybeEvent): boolean {
@@ -70,7 +70,7 @@ export function shouldUseSecureCookies(event?: MaybeEvent): boolean {
     return window.location.protocol === 'https:'
   }
 
-  return process.env.NODE_ENV === 'production'
+  return false
 }
 
 export function withSecureCookieOptions<T>(


### PR DESCRIPTION
## Summary
- update the secure-cookie detection helpers to require an actually secure connection
- avoid marking authentication cookies as secure when the app runs over HTTP so sessions persist after reloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da99b834688326aacfbbc4aeb49dcf