### PR TITLE
Fix auth session reinitialization after reload

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -293,8 +293,12 @@ export const useAuthSession = defineStore('auth-session', () => {
   }
 
   async function initialize() {
-    if (readyState.value && import.meta.client) {
-      return isAuthenticated.value
+    // During client hydration we may have an authenticated session cookie without a
+    // hydrated user state (for example if the session cookies were set by the
+    // server). In that case we should refresh the session even if the store was
+    // previously marked as ready so we can recover the current user information.
+    if (import.meta.client && readyState.value && isAuthenticated.value) {
+      return true
     }
 
     return refreshSession()


### PR DESCRIPTION
## Summary
- refresh the auth session on the client when the store is ready but lacks authenticated state to restore the user after reloads
- document why the additional refresh is required during hydration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daa162b68c83269b1ed5995667eea6