### PR TITLE
Fix logout menu item state in AppTopBar

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -148,7 +148,7 @@
                 v-for="item in userMenuItems"
                 :key="item.title"
                 :title="item.title"
-                :disabled="item.action === 'logout' && loggingOut"
+                :disabled="item.action === 'logout' && loggingOut.value"
                 @click="handleUserMenuSelect(item)"
             >
               <template #prepend>


### PR DESCRIPTION
## Summary
- ensure the logout entry in the profile menu correctly reads the logging state
- allow users to trigger the logout action from the AppBar again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa4f5f3c4832694981535834427b6