### PR TITLE
Fix source map parser crash in dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,5 +110,10 @@
     "typescript-eslint": "^8.42.0",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971"
+  "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971",
+  "pnpm": {
+    "overrides": {
+      "source-map": "npm:source-map-js@1.2.1"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,8 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(happy-dom@16.8.1)(jiti@2.6.0)(jsdom@25.0.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
+    overrides:
+      source-map: npm:source-map-js@1.2.1
 
 packages:
 
@@ -6649,9 +6651,6 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -13939,7 +13938,7 @@ snapshots:
       semver: 7.7.2
       serve-placeholder: 2.0.2
       serve-static: 2.2.0
-      source-map: 0.7.6
+      source-map-js: 1.2.1
       std-env: 3.9.0
       ufo: 1.6.1
       ultrahtml: 1.6.0
@@ -15150,7 +15149,7 @@ snapshots:
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
-      source-map: 0.7.6
+      source-map-js: 1.2.1
       yargs: 17.7.2
     optionalDependencies:
       rollup: 4.52.2
@@ -15635,7 +15634,6 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- add a pnpm override so dependencies resolve `source-map` to the JS implementation
- update the lockfile to drop the WASM build and point dependants at `source-map-js`

## Testing
- pnpm install --lockfile-only *(fails: registry.npmjs.org returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daac6e57988326b3879e0abbf7daf5