### PR TITLE
Fix pnpm lockfile overrides placement

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  source-map: npm:source-map-js@1.2.1
+
 importers:
 
   .:
@@ -270,9 +273,6 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(happy-dom@16.8.1)(jiti@2.6.0)(jsdom@25.0.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
-    overrides:
-      source-map: npm:source-map-js@1.2.1
-
 packages:
 
   '@ai-sdk/gateway@1.0.30':


### PR DESCRIPTION
## Summary
- move the source-map override metadata to the top-level of the pnpm lockfile so it matches pnpm 10 expectations

## Testing
- `pnpm install --frozen-lockfile`


------
https://chatgpt.com/codex/tasks/task_e_68dab06e760483269cf92de2fe74eb0e