### PR TITLE
feat(layout): expose customizable sidebar slots

### DIFF
--- a/docs/custom-sidebars.md
+++ b/docs/custom-sidebars.md
@@ -1,0 +1,36 @@
+# Personnaliser les sidebars du layout par défaut
+
+Le layout par défaut expose désormais des slots nommés permettant aux pages d'injecter leurs propres contenus dans les sidebars gauche et droite tout en bénéficiant de la mise en page standard.
+
+## Exemple
+
+```vue
+<template>
+  <NuxtLayout name="default">
+    <template #left-sidebar="{ items, activeKey, onSelect }">
+      <AppSidebar
+        :items="items"
+        :active-key="activeKey"
+        @select="onSelect"
+      />
+      <v-divider class="my-4" />
+      <MyCustomNavigation />
+    </template>
+
+    <template #right-sidebar="{ weather, leaderboard, rating, user }">
+      <ProfileSidebar
+        :user="user"
+        :friends="[]"
+        :photos="[]"
+        :life-events="[]"
+      />
+      <MyUpcomingEvents />
+      <SidebarWeatherCard v-if="weather" :weather="weather" />
+    </template>
+
+    <MyPageContent />
+  </NuxtLayout>
+</template>
+```
+
+Les slots fournissent les données déjà utilisées par le layout (`items`, `activeKey`, `onSelect`, `weather`, `leaderboard`, `rating`, `user`) afin d'étendre ou remplacer le comportement existant sans dupliquer la logique.

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -31,11 +31,18 @@
       class="app-drawer"
     >
       <div class="pane-scroll py-4">
-        <AppSidebar
+        <slot
+          name="left-sidebar"
           :items="sidebarItems"
           :active-key="activeSidebar"
-          @select="handleSidebarSelect"
-        />
+          :on-select="handleSidebarSelect"
+        >
+          <AppSidebar
+            :items="sidebarItems"
+            :active-key="activeSidebar"
+            @select="handleSidebarSelect"
+          />
+        </slot>
       </div>
     </v-navigation-drawer>
 
@@ -65,37 +72,45 @@
                 :eager="rightDrawer"
                 @select="handleSidebarSelect"
               >
-                <div class="flex flex-col gap-4">
-                  <ProfileSidebar
-                    :user="user"
-                    :photos="photos"
-                    :friends="friends"
-                    :friends-count="1599"
-                    :life-events="events"
-                    @edit-bio="onEditBio"
-                    @edit-details="onEditDetails"
-                    @add-featured="onAddFeatured"
-                    @view-all-photos="onViewAllPhotos"
-                    @view-all-friends="onViewAllFriends"
-                    @open-friend="openFriend"
-                    @view-all-events="onViewAllEvents"
-                    @add-event="onAddEvent"
-                  />
-                  <SidebarWeatherCard
-                    v-if="weather"
-                    :weather="weather"
-                  />
-                  <SidebarLeaderboardCard
-                    v-if="leaderboard"
-                    :title="leaderboard.title"
-                    :live-label="leaderboard.live"
-                    :participants="leaderboard.participants"
-                  />
-                  <SidebarRatingCard
-                    v-if="rating"
-                    :rating="rating"
-                  />
-                </div>
+                <slot
+                  name="right-sidebar"
+                  :weather="weather"
+                  :leaderboard="leaderboard"
+                  :rating="rating"
+                  :user="user"
+                >
+                  <div class="flex flex-col gap-4">
+                    <ProfileSidebar
+                      :user="user"
+                      :photos="photos"
+                      :friends="friends"
+                      :friends-count="1599"
+                      :life-events="events"
+                      @edit-bio="onEditBio"
+                      @edit-details="onEditDetails"
+                      @add-featured="onAddFeatured"
+                      @view-all-photos="onViewAllPhotos"
+                      @view-all-friends="onViewAllFriends"
+                      @open-friend="openFriend"
+                      @view-all-events="onViewAllEvents"
+                      @add-event="onAddEvent"
+                    />
+                    <SidebarWeatherCard
+                      v-if="weather"
+                      :weather="weather"
+                    />
+                    <SidebarLeaderboardCard
+                      v-if="leaderboard"
+                      :title="leaderboard.title"
+                      :live-label="leaderboard.live"
+                      :participants="leaderboard.participants"
+                    />
+                    <SidebarRatingCard
+                      v-if="rating"
+                      :rating="rating"
+                    />
+                  </div>
+                </slot>
               </AppSidebarRight>
             </div>
             <template #fallback>


### PR DESCRIPTION
## Summary
- expose named left and right sidebar slots in the default layout while keeping the existing components as fallbacks
- allow right sidebar content to be overridden with access to weather, leaderboard, rating and user data
- document how pages can provide custom sidebar content via the new slots

## Testing
- `pnpm test:unit` *(fails: existing suite requires Pinia and component registrations in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf8bdd7d483268d933ccb7e47ba6a