### PR TITLE
feat: show relative publish times in blog UI

### DIFF
--- a/components/blog/BlogPostCard.vue
+++ b/components/blog/BlogPostCard.vue
@@ -96,6 +96,7 @@ import BlogPostReactCard from "~/components/blog/BlogPostReactCard.vue";
 import CommentThread, { type CommentNode } from "~/components/blog/CommentThread.vue";
 import BlogPostContent from "~/components/blog/BlogPostContent.vue";
 import CommentSortMenu from "~/components/blog/CommentSortMenu.vue";
+import { useRelativeTime } from "~/composables/useRelativeTime";
 
 interface FeedbackState {
   type: "success" | "error";
@@ -109,7 +110,7 @@ const props = defineProps<{
   reactionLabels: Record<ReactionType, string>;
 }>();
 
-const { locale, t } = useI18n();
+const { t } = useI18n();
 const { $notify } = useNuxtApp();
 const { reactToPost, addComment, reactToComment, getComments } = usePostsStore();
 const {
@@ -133,13 +134,7 @@ const activeCommentsRequest = shallowRef<Promise<void> | null>(null);
 const commentsSectionRef = ref<HTMLElement | null>(null);
 const isCommentsSectionVisible = useElementVisibility(commentsSectionRef);
 const commentsActivated = ref(false);
-
-function formatDateTime(value: string) {
-  return new Intl.DateTimeFormat(locale.value ?? "fr-FR", {
-    dateStyle: "long",
-    timeStyle: "short",
-  }).format(new Date(value));
-}
+const { formatRelativeTime } = useRelativeTime();
 type Comment = {
   id: string;
   author: string;
@@ -168,9 +163,7 @@ const sorted = computed(() => {
 
   return arr;
 });
-const publishedLabel = computed(() =>
-  t("blog.reactions.posts.publishedOn", { date: formatDateTime(post.value.publishedAt) }),
-);
+const publishedLabel = computed(() => formatRelativeTime(post.value.publishedAt));
 
 const isAuthenticated = computed(() => isAuthenticatedComputed.value);
 const isAuthor = computed(

--- a/components/blog/CommentThread.vue
+++ b/components/blog/CommentThread.vue
@@ -138,6 +138,7 @@ import CommentComposer from "~/components/blog/CommentComposer.vue";
 import ReactionPicker from "~/components/blog/ReactionPicker.vue";
 import type { Reaction as PickerReaction } from "~/components/blog/ReactionPicker.vue";
 import { useAuthSession } from "~/stores/auth-session";
+import { useRelativeTime } from "~/composables/useRelativeTime";
 
 type Reaction = PickerReaction;
 const auth = useAuthSession();
@@ -168,7 +169,8 @@ const emit = defineEmits<{
   (e: "react", payload: { id: string; type: Reaction }): void;
 }>();
 
-const { locale, t } = useI18n();
+const { t } = useI18n();
+const { formatRelativeTime } = useRelativeTime();
 
 const depth = computed(() => props.depth ?? 0);
 const bubbleOrder: Reaction[] = ["like", "sad", "angry"];
@@ -183,14 +185,6 @@ const topReactions = computed(() =>
 const expanded = reactive<Record<string, boolean>>({});
 const replying = reactive<Record<string, boolean>>({});
 const replyText = reactive<Record<string, string>>({});
-
-const relativeTimeFormatter = computed(
-  () => new Intl.RelativeTimeFormat(locale.value ?? "fr-FR", { numeric: "auto" }),
-);
-const dateFormatter = computed(
-  () =>
-    new Intl.DateTimeFormat(locale.value ?? "fr-FR", { dateStyle: "medium", timeStyle: "short" }),
-);
 
 const commentPlaceholder = computed(() => {
   const firstName = props.currentUser?.firstName ?? "";
@@ -210,28 +204,8 @@ function toggleExpand(id: string) {
 function toggleReply(id: string) {
   replying[id] = !replying[id];
 }
-function formatTime(d: Date | string | number) {
-  const date = new Date(d);
-  const diffSeconds = (date.getTime() - Date.now()) / 1000;
-  const absDiff = Math.abs(diffSeconds);
-
-  if (absDiff < 60) {
-    return relativeTimeFormatter.value.format(Math.round(diffSeconds), "second");
-  }
-
-  if (absDiff < 3600) {
-    return relativeTimeFormatter.value.format(Math.round(diffSeconds / 60), "minute");
-  }
-
-  if (absDiff < 86400) {
-    return relativeTimeFormatter.value.format(Math.round(diffSeconds / 3600), "hour");
-  }
-
-  if (absDiff < 604800) {
-    return relativeTimeFormatter.value.format(Math.round(diffSeconds / 86400), "day");
-  }
-
-  return dateFormatter.value.format(date);
+function formatTime(value: Date | string | number) {
+  return formatRelativeTime(value);
 }
 
 function getReactionTotal(node: CommentNode) {

--- a/composables/useRelativeTime.ts
+++ b/composables/useRelativeTime.ts
@@ -1,0 +1,123 @@
+import { computed } from "vue";
+import { useI18n } from "#imports";
+
+type RelativeUnit = Intl.RelativeTimeFormatUnit;
+
+type RelativeTimeStyle = NonNullable<Intl.RelativeTimeFormatOptions["style"]>;
+
+type RelativeNumeric = NonNullable<Intl.RelativeTimeFormatOptions["numeric"]>;
+
+export interface UseRelativeTimeOptions {
+  /**
+   * Number of days after which the formatter should fall back to an absolute date.
+   * Set to `null` or `undefined` to always return a relative value.
+   */
+  fallbackToDateAfterDays?: number | null;
+  /**
+   * Style passed to `Intl.RelativeTimeFormat` (defaults to `short`).
+   */
+  style?: RelativeTimeStyle;
+  /**
+   * Numeric option passed to `Intl.RelativeTimeFormat` (defaults to `auto`).
+   */
+  numeric?: RelativeNumeric;
+}
+
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+const MONTH = 30.44 * DAY;
+const YEAR = 365.25 * DAY;
+
+const THRESHOLDS: Array<{ limit: number; divisor: number; unit: RelativeUnit }> = [
+  { limit: MINUTE, divisor: SECOND, unit: "second" },
+  { limit: HOUR, divisor: MINUTE, unit: "minute" },
+  { limit: DAY, divisor: HOUR, unit: "hour" },
+  { limit: WEEK, divisor: DAY, unit: "day" },
+  { limit: MONTH, divisor: WEEK, unit: "week" },
+  { limit: YEAR, divisor: MONTH, unit: "month" },
+  { limit: Number.POSITIVE_INFINITY, divisor: YEAR, unit: "year" },
+];
+
+function toDate(value: Date | string | number): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+
+  return Number.isNaN(date.valueOf()) ? null : date;
+}
+
+export function useRelativeTime(options?: UseRelativeTimeOptions) {
+  const { locale } = useI18n();
+
+  const resolvedLocale = computed(() => locale.value || "en-US");
+
+  const relativeFormatter = computed(
+    () =>
+      new Intl.RelativeTimeFormat(resolvedLocale.value, {
+        numeric: options?.numeric ?? "auto",
+        style: options?.style ?? "short",
+      }),
+  );
+
+  const dateFormatter = computed(
+    () =>
+      new Intl.DateTimeFormat(resolvedLocale.value, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+  );
+
+  function formatRelative(value: Date | string | number): string {
+    const date = toDate(value);
+
+    if (!date) {
+      return "";
+    }
+
+    const diffSeconds = (date.getTime() - Date.now()) / 1000;
+    const absSeconds = Math.abs(diffSeconds);
+
+    for (const { limit, divisor, unit } of THRESHOLDS) {
+      if (absSeconds < limit) {
+        const relativeValue = Math.round(diffSeconds / divisor) || 0;
+
+        return relativeFormatter.value.format(relativeValue, unit);
+      }
+    }
+
+    return relativeFormatter.value.format(Math.round(diffSeconds / YEAR) || 0, "year");
+  }
+
+  function format(value: Date | string | number): string {
+    const date = toDate(value);
+
+    if (!date) {
+      return "";
+    }
+
+    if (
+      typeof options?.fallbackToDateAfterDays === "number" &&
+      options.fallbackToDateAfterDays >= 0
+    ) {
+      const diffDays = Math.abs((date.getTime() - Date.now()) / (DAY * 1000));
+
+      if (diffDays > options.fallbackToDateAfterDays) {
+        return dateFormatter.value.format(date);
+      }
+    }
+
+    return formatRelative(date);
+  }
+
+  function formatAbsolute(value: Date | string | number): string {
+    const date = toDate(value);
+
+    return date ? dateFormatter.value.format(date) : "";
+  }
+
+  return {
+    formatRelativeTime: format,
+    formatAbsoluteTime: formatAbsolute,
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `useRelativeTime` composable to provide localized relative timestamps
- switch blog post metadata to display relative publish times using the new helper
- reuse the relative timestamp helper for comment timestamps for consistent formatting

## Testing
- pnpm vitest run tests/unit/BlogPostCard.spec.ts *(fails: [pinia-shim] Pinia instance is not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0a4178308326b846ab9304aa7bfd