### PR TITLE
feat: rendre dynamique la barre latérale droite du profil

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -81,21 +81,6 @@
                   :user="user"
                 >
                   <div class="flex flex-col gap-4">
-                    <ProfileSidebar
-                      :user="user"
-                      :photos="photos"
-                      :friends="friends"
-                      :friends-count="1599"
-                      :life-events="events"
-                      @edit-bio="onEditBio"
-                      @edit-details="onEditDetails"
-                      @add-featured="onAddFeatured"
-                      @view-all-photos="onViewAllPhotos"
-                      @view-all-friends="onViewAllFriends"
-                      @open-friend="openFriend"
-                      @view-all-events="onViewAllEvents"
-                      @add-event="onAddEvent"
-                    />
                     <SidebarWeatherCard
                       v-if="weather"
                       :weather="weather"
@@ -177,7 +162,6 @@ import { useAuthSession } from "~/stores/auth-session";
 import SidebarWeatherCard from "~/components/layout/SidebarWeatherCard.vue";
 import SidebarLeaderboardCard from "~/components/layout/SidebarLeaderboardCard.vue";
 import SidebarRatingCard from "~/components/layout/SidebarRatingCard.vue";
-import ProfileSidebar from "~/components/layout/ProfileSidebar.vue";
 
 const AppSidebarRight = defineAsyncComponent({
   loader: () => import("~/components/layout/AppSidebarRight.vue"),
@@ -235,46 +219,7 @@ const sidebarItems = computed<LayoutSidebarItem[]>(() => buildSidebarItems(canAc
 const activeSidebar = ref("apps");
 
 /** Données de démonstration pour ProfileSidebar */
-const user = {
-  name: "Rami Aouinti",
-  bio: "عامل الناس بأخلاقك لا بأخلاقهم",
-  livesIn: "Köln",
-  from: "Tunis",
-  schools: [
-    "Hat hier studiert: INSAT",
-    "Ist hier zur Schule gegangen: Lycée el Menazah 6",
-    "Hat hier studiert: Hochschulenzentrum - Beuth Hochschule für Technik Berlin",
-  ],
-};
-
-const photos = Array.from({ length: 12 }).map((_, i) => ({
-  src: `https://picsum.photos/seed/p${i}/300/300`,
-  alt: `photo ${i}`,
-}));
-
-const friends = [
-  { name: "Nihal Rmili", avatar: "https://i.pravatar.cc/150?img=5" },
-  { name: "Ahlam Chermiti", avatar: "https://i.pravatar.cc/150?img=6" },
-  { name: "Oussama Bacha", avatar: "https://i.pravatar.cc/150?img=7" },
-  { name: "Wafâ Mahdaoui", avatar: "https://i.pravatar.cc/150?img=8" },
-  { name: "Hiba Souab", avatar: "https://i.pravatar.cc/150?img=9" },
-  { name: "Nedra K.", avatar: "https://i.pravatar.cc/150?img=10" },
-  { name: "Mongi Souab", avatar: "https://i.pravatar.cc/150?img=11" },
-  { name: "Sana Boualima", avatar: "https://i.pravatar.cc/150?img=12" },
-  { name: "Friend 9", avatar: "https://i.pravatar.cc/150?img=13" },
-];
-
-const events = [{ title: "Studium abgeschlossen: INSAT", date: "Dezember 2015", description: "" }];
-
-function onEditBio() {}
-function onEditDetails() {}
-function onAddFeatured() {}
-function onViewAllPhotos() {}
-function onViewAllFriends() {}
-type Friend = (typeof friends)[number];
-function openFriend(_friend: Friend) {}
-function onViewAllEvents() {}
-function onAddEvent() {}
+const user = computed(() => auth.currentUser.value ?? null);
 
 /** ✅ Règle d’affichage du contenu: gauche ouverte ET (droite ouverte si demandée) */
 const areSidebarsVisible = computed(() => {

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1,216 +1,239 @@
 <template>
-  <main
-    class="py-10"
-    aria-labelledby="profile-title"
-  >
-    <v-container>
-      <header
-        class="mb-8"
-        aria-describedby="profile-subtitle"
-      >
-        <v-card
-          class="pa-6"
-          rounded="xl"
-          elevation="10"
+  <NuxtLayout name="default">
+    <template #right-sidebar>
+      <div class="flex flex-col gap-4">
+        <ProfileSidebar
+          :user="sidebarUser"
+          :photos="sidebarPhotos"
+          :friends="sidebarFriends"
+          :friends-count="friendsCount"
+          :life-events="sidebarEvents"
+        />
+      </div>
+    </template>
+
+    <main
+      class="py-10"
+      aria-labelledby="profile-title"
+    >
+      <v-container>
+        <header
+          class="mb-8"
+          aria-describedby="profile-subtitle"
         >
-          <div class="d-flex flex-column flex-sm-row align-sm-center gap-4">
-            <v-avatar
-              size="96"
-              class="flex-shrink-0"
-              color="primary"
-              variant="tonal"
-            >
-              <v-img
-                :src="avatarSrc"
-                :alt="avatarAlt"
-                cover
-              />
-            </v-avatar>
-            <div class="flex-grow-1 w-100">
-              <div
-                class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-3"
+          <v-card
+            class="pa-6"
+            rounded="xl"
+            elevation="10"
+          >
+            <div class="d-flex flex-column flex-sm-row align-sm-center gap-4">
+              <v-avatar
+                size="96"
+                class="flex-shrink-0"
+                color="primary"
+                variant="tonal"
               >
-                <div>
-                  <h1
-                    id="profile-title"
-                    class="text-h4 font-weight-bold mb-1"
-                  >
-                    {{ displayName }}
-                  </h1>
-                  <p class="text-body-2 text-medium-emphasis mb-0">
-                    {{ usernameLabel }}
-                  </p>
-                </div>
+                <v-img
+                  :src="avatarSrc"
+                  :alt="avatarAlt"
+                  cover
+                />
+              </v-avatar>
+              <div class="flex-grow-1 w-100">
                 <div
-                  class="d-flex flex-wrap align-center gap-2"
-                  :aria-label="t('pages.profile.labels.roles')"
-                  role="list"
+                  class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-3"
                 >
-                  <template v-if="hasRoles">
-                    <v-chip
-                      v-for="role in roles"
-                      :key="role"
-                      color="primary"
-                      variant="tonal"
-                      size="small"
-                      role="listitem"
+                  <div>
+                    <h1
+                      id="profile-title"
+                      class="text-h4 font-weight-bold mb-1"
                     >
-                      {{ role }}
-                    </v-chip>
-                  </template>
-                  <span
-                    v-else
-                    class="text-body-2 text-medium-emphasis"
-                    >{{ placeholderValue }}</span
+                      {{ displayName }}
+                    </h1>
+                    <p class="text-body-2 text-medium-emphasis mb-0">
+                      {{ usernameLabel }}
+                    </p>
+                  </div>
+                  <div
+                    class="d-flex flex-wrap align-center gap-2"
+                    :aria-label="t('pages.profile.labels.roles')"
+                    role="list"
                   >
+                    <template v-if="hasRoles">
+                      <v-chip
+                        v-for="role in roles"
+                        :key="role"
+                        color="primary"
+                        variant="tonal"
+                        size="small"
+                        role="listitem"
+                      >
+                        {{ role }}
+                      </v-chip>
+                    </template>
+                    <span
+                      v-else
+                      class="text-body-2 text-medium-emphasis"
+                      >{{ placeholderValue }}</span
+                    >
+                  </div>
                 </div>
+                <p
+                  id="profile-subtitle"
+                  class="text-body-1 text-medium-emphasis mt-4 mb-0"
+                >
+                  {{ t("pages.profile.subtitle") }}
+                </p>
               </div>
-              <p
-                id="profile-subtitle"
-                class="text-body-1 text-medium-emphasis mt-4 mb-0"
-              >
-                {{ t("pages.profile.subtitle") }}
-              </p>
             </div>
-          </div>
-        </v-card>
-      </header>
+          </v-card>
+        </header>
 
-      <v-row
-        dense
-        align="stretch"
-      >
-        <v-col
-          cols="12"
-          md="4"
+        <v-row
+          dense
+          align="stretch"
         >
-          <section
-            aria-labelledby="contact-section-title"
-            class="h-100"
+          <v-col
+            cols="12"
           >
-            <v-card
-              class="pa-6 h-100"
-              rounded="lg"
-              variant="tonal"
+            <v-row
+              dense
+              align="stretch"
             >
-              <h2
-                id="contact-section-title"
-                class="text-h5 font-weight-semibold mb-4"
+              <v-col
+                cols="12"
+                md="6"
               >
-                {{ t("pages.profile.sections.contact") }}
-              </h2>
-              <dl class="d-flex flex-column gap-4">
-                <div
-                  v-for="item in contactItems"
-                  :key="item.id"
+                <section
+                  aria-labelledby="contact-section-title"
+                  class="h-100"
                 >
-                  <dt class="text-body-2 text-medium-emphasis mb-1">{{ item.label }}</dt>
-                  <dd class="text-body-1 font-weight-medium mb-0">
-                    <a
-                      v-if="item.href && item.value !== placeholderValue"
-                      :href="item.href"
-                      class="text-primary text-decoration-none"
+                  <v-card
+                    class="pa-6 h-100"
+                    rounded="lg"
+                    variant="tonal"
+                  >
+                    <h2
+                      id="contact-section-title"
+                      class="text-h5 font-weight-semibold mb-4"
                     >
-                      {{ item.value }}
-                    </a>
-                    <span v-else>{{ item.value }}</span>
-                  </dd>
-                </div>
-              </dl>
-            </v-card>
-          </section>
-        </v-col>
+                      {{ t("pages.profile.sections.contact") }}
+                    </h2>
+                    <dl class="d-flex flex-column gap-4">
+                      <div
+                        v-for="item in contactItems"
+                        :key="item.id"
+                      >
+                        <dt class="text-body-2 text-medium-emphasis mb-1">{{ item.label }}</dt>
+                        <dd class="text-body-1 font-weight-medium mb-0">
+                          <a
+                            v-if="item.href && item.value !== placeholderValue"
+                            :href="item.href"
+                            class="text-primary text-decoration-none"
+                          >
+                            {{ item.value }}
+                          </a>
+                          <span v-else>{{ item.value }}</span>
+                        </dd>
+                      </div>
+                    </dl>
+                  </v-card>
+                </section>
+              </v-col>
 
-        <v-col
-          cols="12"
-          md="4"
-        >
-          <section
-            aria-labelledby="profile-section-title"
-            class="h-100"
-          >
-            <v-card
-              class="pa-6 h-100"
-              rounded="lg"
-              variant="tonal"
-            >
-              <h2
-                id="profile-section-title"
-                class="text-h5 font-weight-semibold mb-4"
+              <v-col
+                cols="12"
+                md="6"
               >
-                {{ t("pages.profile.sections.profile") }}
-              </h2>
-              <dl class="d-flex flex-column gap-4">
-                <div
-                  v-for="item in profileItems"
-                  :key="item.id"
+                <section
+                  aria-labelledby="profile-section-title"
+                  class="h-100"
                 >
-                  <dt class="text-body-2 text-medium-emphasis mb-1">{{ item.label }}</dt>
-                  <dd class="text-body-1 font-weight-medium mb-0">{{ item.value }}</dd>
-                </div>
-              </dl>
-            </v-card>
-          </section>
-        </v-col>
-
-        <v-col
-          cols="12"
-          md="4"
-        >
-          <section
-            aria-labelledby="social-section-title"
-            class="h-100"
-          >
-            <v-card
-              class="pa-6 h-100"
-              rounded="lg"
-              variant="tonal"
-            >
-              <h2
-                id="social-section-title"
-                class="text-h5 font-weight-semibold mb-4"
-              >
-                {{ t("pages.profile.sections.social") }}
-              </h2>
-              <dl
-                class="d-flex flex-column gap-4"
-                :aria-label="t('pages.profile.stats.title')"
-              >
-                <div>
-                  <dt class="text-body-2 text-medium-emphasis mb-1">
-                    {{ t("pages.profile.labels.friends") }}
-                  </dt>
-                  <dd class="text-body-1 font-weight-medium mb-0">{{ formattedFriendsCount }}</dd>
-                </div>
-                <div>
-                  <dt class="text-body-2 text-medium-emphasis mb-1">
-                    {{ t("pages.profile.labels.stories") }}
-                  </dt>
-                  <dd class="text-body-1 font-weight-medium mb-0">{{ formattedStoriesCount }}</dd>
-                </div>
-                <div>
-                  <dt class="text-body-2 text-medium-emphasis mb-1">
-                    {{ t("pages.profile.labels.accountStatus") }}
-                  </dt>
-                  <dd class="text-body-1 font-weight-medium mb-0">
-                    <v-chip
-                      v-if="accountStatus"
-                      :color="accountStatus.color"
-                      size="small"
-                      variant="flat"
+                  <v-card
+                    class="pa-6 h-100"
+                    rounded="lg"
+                    variant="tonal"
+                  >
+                    <h2
+                      id="profile-section-title"
+                      class="text-h5 font-weight-semibold mb-4"
                     >
-                      {{ accountStatus.label }}
-                    </v-chip>
-                    <span v-else>{{ placeholderValue }}</span>
-                  </dd>
-                </div>
-              </dl>
-            </v-card>
-          </section>
-        </v-col>
-      </v-row>
-    </v-container>
-  </main>
+                      {{ t("pages.profile.sections.profile") }}
+                    </h2>
+                    <dl class="d-flex flex-column gap-4">
+                      <div
+                        v-for="item in profileItems"
+                        :key="item.id"
+                      >
+                        <dt class="text-body-2 text-medium-emphasis mb-1">{{ item.label }}</dt>
+                        <dd class="text-body-1 font-weight-medium mb-0">{{ item.value }}</dd>
+                      </div>
+                    </dl>
+                  </v-card>
+                </section>
+              </v-col>
+
+              <v-col
+                cols="12"
+              >
+                <section
+                  aria-labelledby="social-section-title"
+                  class="h-100"
+                >
+                  <v-card
+                    class="pa-6 h-100"
+                    rounded="lg"
+                    variant="tonal"
+                  >
+                    <h2
+                      id="social-section-title"
+                      class="text-h5 font-weight-semibold mb-4"
+                    >
+                      {{ t("pages.profile.sections.social") }}
+                    </h2>
+                    <dl
+                      class="d-flex flex-column gap-4"
+                      :aria-label="t('pages.profile.stats.title')"
+                    >
+                      <div>
+                        <dt class="text-body-2 text-medium-emphasis mb-1">
+                          {{ t("pages.profile.labels.friends") }}
+                        </dt>
+                        <dd class="text-body-1 font-weight-medium mb-0">{{ formattedFriendsCount }}</dd>
+                      </div>
+                      <div>
+                        <dt class="text-body-2 text-medium-emphasis mb-1">
+                          {{ t("pages.profile.labels.stories") }}
+                        </dt>
+                        <dd class="text-body-1 font-weight-medium mb-0">{{ formattedStoriesCount }}</dd>
+                      </div>
+                      <div>
+                        <dt class="text-body-2 text-medium-emphasis mb-1">
+                          {{ t("pages.profile.labels.accountStatus") }}
+                        </dt>
+                        <dd class="text-body-1 font-weight-medium mb-0">
+                          <v-chip
+                            v-if="accountStatus"
+                            :color="accountStatus.color"
+                            size="small"
+                            variant="flat"
+                          >
+                            {{ accountStatus.label }}
+                          </v-chip>
+                          <span v-else>{{ placeholderValue }}</span>
+                        </dd>
+                      </div>
+                    </dl>
+                  </v-card>
+                </section>
+              </v-col>
+            </v-row>
+          </v-col>
+
+        </v-row>
+      </v-container>
+    </main>
+  </NuxtLayout>
 </template>
 
 <script setup lang="ts">
@@ -218,6 +241,7 @@ import { computed } from "vue";
 
 import { useAuthSession } from "~/stores/auth-session";
 import type { AuthUser } from "~/types/auth";
+import ProfileSidebar from "~/components/layout/ProfileSidebar.vue";
 
 interface ProfileDetails {
   id?: string;
@@ -228,6 +252,8 @@ interface ProfileDetails {
   photo?: string | null;
   description?: string | null;
   address?: string | null;
+  hometown?: string | null;
+  schools?: string[] | null;
 }
 
 interface FriendEntry {
@@ -245,6 +271,7 @@ interface ProfileUser extends AuthUser {
 definePageMeta({
   middleware: "auth",
   title: "profile",
+  layout: false,
 });
 
 const auth = useAuthSession();
@@ -362,6 +389,7 @@ const address = computed(() => asString(profileDetails.value?.address));
 const titleValue = computed(() => asString(profileDetails.value?.title));
 const gender = computed(() => asString(profileDetails.value?.gender));
 const description = computed(() => asString(profileDetails.value?.description));
+const hometown = computed(() => asString(profileDetails.value?.hometown));
 const birthdayFormatted = computed(() => {
   const raw = asString(profileDetails.value?.birthday);
 
@@ -488,6 +516,52 @@ const profileItems = computed(() => {
     },
   ];
 });
+
+const sidebarUser = computed(() => {
+  const placeholder = placeholderValue.value;
+
+  const sanitizedBio = description.value ?? undefined;
+  const sanitizedLivesIn = address.value ?? undefined;
+  const sanitizedFrom = hometown.value ?? undefined;
+  const schools = Array.isArray(profileDetails.value?.schools)
+    ? (profileDetails.value!.schools.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      ) as string[])
+    : [];
+
+  return {
+    name: displayName.value || placeholder,
+    bio: sanitizedBio,
+    livesIn: sanitizedLivesIn,
+    from: sanitizedFrom,
+    schools,
+  };
+});
+
+const sidebarPhotos = computed(() => {
+  const photo = avatarSrc.value;
+  const alt = avatarAlt.value;
+
+  if (!photo) {
+    return [] as { src: string; alt?: string }[];
+  }
+
+  return [{ src: photo, alt }];
+});
+
+const sidebarFriends = computed(() => {
+  const placeholder = placeholderValue.value;
+
+  return friendEntries.value.map((entry) => ({
+    name:
+      asString((entry as { name?: string | null; user?: string | null })?.name) ??
+      asString(entry?.user) ??
+      placeholder,
+    avatar: defaultAvatar,
+  }));
+});
+
+const sidebarEvents = computed(() => [] as { title: string; date?: string; description?: string }[]);
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- retire la dépendance au `ProfileSidebar` de base dans le layout et conserve seulement les widgets génériques par défaut
- encapsule la page profil dans `NuxtLayout` pour injecter `ProfileSidebar` via le slot `right-sidebar`
- expose la mise en page du profil en plein largeur tandis que la barre latérale vit dans le layout commun

## Testing
- pnpm lint *(interrompu manuellement : la commande ne terminait pas)*

------
https://chatgpt.com/codex/tasks/task_e_68dc1654fe80832698d5ee8a515f0fdf