### PR TITLE
feat: add profile friends, photos, and edit pages

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -610,6 +610,137 @@
         "title": "Quick stats"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "contact": {
       "title": "اتصل بنا",
       "subtitle": "نرد عادة خلال ١–٢ يوم عمل.",
@@ -848,6 +979,18 @@
     "profile": {
       "title": "Profile",
       "description": "View your personal details and account activity."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -608,6 +608,137 @@
         "title": "Schnelle Statistiken"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "contact": {
       "title": "Kontakt",
       "subtitle": "Wir antworten in der Regel innerhalb von 1–2 Werktagen.",
@@ -846,6 +977,18 @@
     "profile": {
       "title": "Profil",
       "description": "Sieh dir deine persönlichen Daten und Kontoaktivitäten an."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -608,6 +608,137 @@
         "title": "Quick stats"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "contact": {
       "title": "Contact",
       "subtitle": "We usually reply within 1–2 business days.",
@@ -846,6 +977,18 @@
     "profile": {
       "title": "Profile",
       "description": "View your personal details and account activity."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -167,6 +167,137 @@
         "title": "Estadísticas rápidas"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",
@@ -672,6 +803,18 @@
     "profile": {
       "title": "Perfil",
       "description": "Consulta los detalles de tu cuenta y actividad."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -608,6 +608,137 @@
         "title": "Statistiques rapides"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "contact": {
       "title": "Contact",
       "subtitle": "Nous répondons généralement sous 1–2 jours ouvrés.",
@@ -846,6 +977,18 @@
     "profile": {
       "title": "Profil",
       "description": "Consultez vos informations personnelles et l’activité du compte."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -167,6 +167,137 @@
         "title": "Statistiche rapide"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",
@@ -672,6 +803,18 @@
     "profile": {
       "title": "Profilo",
       "description": "Consulta i tuoi dati personali e l'attività dell'account."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -167,6 +167,137 @@
         "title": "Краткая статистика"
       }
     },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",
@@ -672,6 +803,18 @@
     "profile": {
       "title": "Профиль",
       "description": "Просматривайте личные данные и активность аккаунта."
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -464,12 +464,155 @@
       "stats": {
         "title": "快速概览"
       }
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "subtitle": "Reconnect with your collaborators, mentors, and communities.",
+      "actions": {
+        "message": "Send message",
+        "schedule": "Schedule call",
+        "viewProfile": "Open profile"
+      },
+      "highlights": {
+        "title": "Featured collaborators",
+        "subtitle": "Handpicked partners you collaborate with the most this quarter."
+      },
+      "filters": {
+        "all": "All",
+        "design": "Design",
+        "product": "Product",
+        "engineering": "Engineering",
+        "marketing": "Marketing"
+      },
+      "stats": {
+        "totalFriends": "Connections",
+        "mutual": "mutual connections",
+        "online": "online now"
+      },
+      "sections": {
+        "suggestions": "Suggested connections",
+        "active": "Active now"
+      },
+      "status": {
+        "online": "Online",
+        "focus": "Focus",
+        "busy": "Busy",
+        "offline": "Offline"
+      },
+      "feedback": {
+        "message": "Drafting a quick hello…",
+        "messageWith": "Drafting a quick hello to {name}…",
+        "schedule": "Opening your scheduling flow…",
+        "scheduleWith": "Opening your scheduling flow for {name}…",
+        "connect": "We'll note that you'd like to connect.",
+        "connectWith": "We'll let {name} know you'd like to connect."
+      },
+      "empty": "No profiles match this filter yet."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "subtitle": "Curate highlights from launches, research trips, and behind-the-scenes moments.",
+      "actions": {
+        "upload": "Upload photos",
+        "createAlbum": "Create album"
+      },
+      "sections": {
+        "pinned": "Pinned collections",
+        "albums": "Album explorer",
+        "timeline": "Creative notes"
+      },
+      "meta": {
+        "updated": "Updated {date}",
+        "photoCount": "photos"
+      },
+      "filters": {
+        "recent": "Recent",
+        "events": "Events",
+        "studio": "Studio",
+        "travel": "Travel"
+      },
+      "cta": {
+        "share": "Share curated sets with your crew or export to presentations."
+      },
+      "stats": {
+        "albums": "curated albums",
+        "tags": "unique story tags"
+      },
+      "timeline": {
+        "title": "Story milestones",
+        "description": "Snapshots from key launches, residencies, and retreats that shaped your year."
+      },
+      "feedback": {
+        "upload": "Opening your media picker…",
+        "createAlbum": "Let's craft a new album.",
+        "shareCollection": "Sharing options are ready.",
+        "generic": "Action started."
+      },
+      "empty": "No photos match this filter yet."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "subtitle": "Refresh your details so collaborators always have the latest context.",
+      "sections": {
+        "profile": "Profile",
+        "contact": "Contact",
+        "about": "About",
+        "social": "Social links"
+      },
+      "labels": {
+        "firstName": "First name",
+        "lastName": "Last name",
+        "headline": "Headline",
+        "pronouns": "Pronouns",
+        "language": "Preferred language",
+        "timezone": "Time zone",
+        "email": "Email",
+        "phone": "Phone",
+        "location": "Location",
+        "website": "Website",
+        "bio": "Bio",
+        "skills": "Key skills",
+        "interests": "Focus areas",
+        "linkedin": "LinkedIn",
+        "twitter": "Twitter / X",
+        "dribbble": "Dribbble",
+        "behance": "Behance"
+      },
+      "actions": {
+        "cancel": "Reset",
+        "save": "Save changes"
+      },
+      "helpers": {
+        "bio": "Share your mission, how you collaborate, or recent wins (280 characters).",
+        "skills": "Type to add custom skills or pick from the suggestions.",
+        "summary": "This quick card updates automatically as you edit your details."
+      },
+      "feedback": {
+        "successMessage": "Profile details saved successfully.",
+        "errorMessage": "Please review the highlighted fields."
+      },
+      "validation": {
+        "required": "This field is required.",
+        "bioLimit": "Your bio must be 280 characters or fewer."
+      }
     }
   },
   "seo": {
     "profile": {
       "title": "个人资料",
       "description": "查看您的个人信息和账号活动。"
+    },
+    "profileFriends": {
+      "title": "Connections",
+      "description": "Browse your collaborators, suggested contacts, and real-time activity."
+    },
+    "profilePhotos": {
+      "title": "Photo library",
+      "description": "Organise launch highlights, studio shoots, and research archives."
+    },
+    "profileEdit": {
+      "title": "Edit profile",
+      "description": "Update your contact information, skills, and social links."
     }
   },
   "admin": {

--- a/pages/profile-edit.vue
+++ b/pages/profile-edit.vue
@@ -1,0 +1,527 @@
+<template>
+  <main
+    class="py-8"
+    aria-labelledby="profile-edit-title"
+  >
+    <v-container>
+      <header
+        class="mb-8"
+        aria-describedby="profile-edit-subtitle"
+      >
+        <v-card
+          class="pa-6"
+          rounded="xl"
+          elevation="8"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div>
+              <h1
+                id="profile-edit-title"
+                class="text-h4 font-weight-bold mb-2"
+              >
+                {{ t("pages.profileEdit.title") }}
+              </h1>
+              <p
+                id="profile-edit-subtitle"
+                class="text-body-1 text-medium-emphasis mb-0"
+              >
+                {{ t("pages.profileEdit.subtitle") }}
+              </p>
+            </div>
+            <div class="d-flex gap-3">
+              <v-btn
+                variant="outlined"
+                color="primary"
+                @click="resetForm"
+              >
+                {{ t("pages.profileEdit.actions.cancel") }}
+              </v-btn>
+              <v-btn
+                color="primary"
+                :loading="isSaving"
+                @click="submitForm"
+              >
+                {{ t("pages.profileEdit.actions.save") }}
+              </v-btn>
+            </div>
+          </div>
+        </v-card>
+      </header>
+
+      <v-alert
+        v-if="formErrors.length"
+        type="error"
+        variant="tonal"
+        class="mb-6"
+        border="start"
+        border-color="error"
+      >
+        <ul class="pl-6 mb-0 d-flex flex-column gap-2">
+          <li
+            v-for="error in formErrors"
+            :key="error"
+          >
+            {{ error }}
+          </li>
+        </ul>
+      </v-alert>
+
+      <v-row
+        dense
+        align="stretch"
+      >
+        <v-col
+          cols="12"
+          xl="8"
+        >
+          <section
+            class="mb-8"
+            aria-labelledby="profile-core-section"
+          >
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              elevation="6"
+            >
+              <h2
+                id="profile-core-section"
+                class="text-h5 font-weight-semibold mb-4"
+              >
+                {{ t("pages.profileEdit.sections.profile") }}
+              </h2>
+              <div class="d-flex flex-column gap-4">
+                <div class="d-flex flex-column flex-sm-row gap-4">
+                  <v-text-field
+                    v-model="form.firstName"
+                    :label="t('pages.profileEdit.labels.firstName')"
+                    :error-messages="fieldError('firstName')"
+                    variant="outlined"
+                    density="comfortable"
+                    required
+                  />
+                  <v-text-field
+                    v-model="form.lastName"
+                    :label="t('pages.profileEdit.labels.lastName')"
+                    :error-messages="fieldError('lastName')"
+                    variant="outlined"
+                    density="comfortable"
+                    required
+                  />
+                </div>
+                <v-text-field
+                  v-model="form.headline"
+                  :label="t('pages.profileEdit.labels.headline')"
+                  variant="outlined"
+                  density="comfortable"
+                  :error-messages="fieldError('headline')"
+                />
+                <div class="d-flex flex-column flex-sm-row gap-4">
+                  <v-select
+                    v-model="form.pronouns"
+                    :items="pronounOptions"
+                    :label="t('pages.profileEdit.labels.pronouns')"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                  <v-select
+                    v-model="form.language"
+                    :items="languageOptions"
+                    :label="t('pages.profileEdit.labels.language')"
+                    variant="outlined"
+                    density="comfortable"
+                    required
+                    :error-messages="fieldError('language')"
+                  />
+                  <v-select
+                    v-model="form.timezone"
+                    :items="timezoneOptions"
+                    :label="t('pages.profileEdit.labels.timezone')"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                </div>
+              </div>
+            </v-card>
+          </section>
+
+          <section
+            class="mb-8"
+            aria-labelledby="profile-contact-section"
+          >
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              elevation="6"
+            >
+              <h2
+                id="profile-contact-section"
+                class="text-h5 font-weight-semibold mb-4"
+              >
+                {{ t("pages.profileEdit.sections.contact") }}
+              </h2>
+              <div class="d-flex flex-column gap-4">
+                <div class="d-flex flex-column flex-sm-row gap-4">
+                  <v-text-field
+                    v-model="form.email"
+                    :label="t('pages.profileEdit.labels.email')"
+                    variant="outlined"
+                    density="comfortable"
+                    required
+                    :error-messages="fieldError('email')"
+                  />
+                  <v-text-field
+                    v-model="form.phone"
+                    :label="t('pages.profileEdit.labels.phone')"
+                    variant="outlined"
+                    density="comfortable"
+                    :error-messages="fieldError('phone')"
+                  />
+                </div>
+                <div class="d-flex flex-column flex-sm-row gap-4">
+                  <v-text-field
+                    v-model="form.location"
+                    :label="t('pages.profileEdit.labels.location')"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                  <v-text-field
+                    v-model="form.website"
+                    :label="t('pages.profileEdit.labels.website')"
+                    variant="outlined"
+                    density="comfortable"
+                  />
+                </div>
+              </div>
+            </v-card>
+          </section>
+
+          <section aria-labelledby="profile-about-section">
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              elevation="6"
+            >
+              <h2
+                id="profile-about-section"
+                class="text-h5 font-weight-semibold mb-4"
+              >
+                {{ t("pages.profileEdit.sections.about") }}
+              </h2>
+              <div class="d-flex flex-column gap-4">
+                <v-textarea
+                  v-model="form.bio"
+                  :label="t('pages.profileEdit.labels.bio')"
+                  :hint="t('pages.profileEdit.helpers.bio')"
+                  persistent-hint
+                  rows="5"
+                  variant="outlined"
+                  density="comfortable"
+                  :counter="280"
+                  :error-messages="fieldError('bio')"
+                />
+                <v-combobox
+                  v-model="form.skills"
+                  :items="skillOptions"
+                  :label="t('pages.profileEdit.labels.skills')"
+                  :hint="t('pages.profileEdit.helpers.skills')"
+                  multiple
+                  chips
+                  closable-chips
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-select
+                  v-model="form.interests"
+                  :items="interestOptions"
+                  :label="t('pages.profileEdit.labels.interests')"
+                  multiple
+                  chips
+                  closable-chips
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </div>
+            </v-card>
+          </section>
+        </v-col>
+        <v-col
+          cols="12"
+          xl="4"
+        >
+          <aside>
+            <v-card
+              class="pa-6 mb-6"
+              rounded="xl"
+              elevation="4"
+            >
+              <h2 class="text-h6 font-weight-semibold mb-4">
+                {{ t("pages.profileEdit.sections.social") }}
+              </h2>
+              <div class="d-flex flex-column gap-4">
+                <v-text-field
+                  v-model="form.social.linkedin"
+                  prepend-inner-icon="mdi-linkedin"
+                  :label="t('pages.profileEdit.labels.linkedin')"
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-text-field
+                  v-model="form.social.twitter"
+                  prepend-inner-icon="mdi-twitter"
+                  :label="t('pages.profileEdit.labels.twitter')"
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-text-field
+                  v-model="form.social.dribbble"
+                  prepend-inner-icon="mdi-basketball"
+                  :label="t('pages.profileEdit.labels.dribbble')"
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-text-field
+                  v-model="form.social.behance"
+                  prepend-inner-icon="mdi-briefcase-outline"
+                  :label="t('pages.profileEdit.labels.behance')"
+                  variant="outlined"
+                  density="comfortable"
+                />
+              </div>
+            </v-card>
+
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              variant="tonal"
+            >
+              <h2 class="text-h6 font-weight-semibold mb-3">
+                {{ t("pages.profileEdit.sections.contact") }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-4">
+                {{ t("pages.profileEdit.helpers.summary") }}
+              </p>
+              <div class="d-flex flex-column gap-3">
+                <div class="d-flex align-center gap-3">
+                  <v-avatar
+                    size="40"
+                    color="primary"
+                    variant="tonal"
+                  >
+                    <span class="text-body-2 font-weight-semibold">{{ initials }}</span>
+                  </v-avatar>
+                  <div>
+                    <div class="text-subtitle-2 font-weight-semibold">{{ fullName }}</div>
+                    <div class="text-caption text-medium-emphasis">{{ form.headline }}</div>
+                  </div>
+                </div>
+                <div class="text-body-2 text-medium-emphasis">
+                  <div>{{ form.email }}</div>
+                  <div v-if="form.phone">{{ form.phone }}</div>
+                  <div v-if="form.location">{{ form.location }}</div>
+                </div>
+              </div>
+            </v-card>
+          </aside>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <v-snackbar
+      v-model="showSnackbar"
+      :color="snackbarColor"
+      timeout="3000"
+      variant="flat"
+    >
+      {{ snackbarMessage }}
+    </v-snackbar>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from "vue";
+
+definePageMeta({
+  middleware: "auth",
+  title: "profile-edit",
+});
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.profileEdit.title");
+  const description = t("seo.profileEdit.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+interface ProfileForm {
+  firstName: string;
+  lastName: string;
+  headline: string;
+  pronouns: string | null;
+  language: string;
+  timezone: string | null;
+  email: string;
+  phone: string;
+  location: string;
+  website: string;
+  bio: string;
+  skills: string[];
+  interests: string[];
+  social: {
+    linkedin: string;
+    twitter: string;
+    dribbble: string;
+    behance: string;
+  };
+}
+
+const initialForm: ProfileForm = {
+  firstName: "Amina",
+  lastName: "Rahman",
+  headline: "Lead Product Designer · Flowbase",
+  pronouns: "she/her",
+  language: "en",
+  timezone: "Africa/Casablanca",
+  email: "amina.rahman@broworld.space",
+  phone: "+212 620-555-012",
+  location: "Casablanca, Morocco",
+  website: "https://flowbase.design",
+  bio: "I design inclusive collaboration tools and coach design teams on systems thinking.",
+  skills: ["Design systems", "Workshop facilitation", "Product discovery"],
+  interests: ["Community leadership", "Accessibility", "Storytelling"],
+  social: {
+    linkedin: "https://www.linkedin.com/in/amina-rahman",
+    twitter: "https://x.com/amina-rahman",
+    dribbble: "https://dribbble.com/amina",
+    behance: "https://www.behance.net/aminarahman",
+  },
+};
+
+const form = reactive<ProfileForm>({ ...initialForm });
+
+const pronounOptions = ["she/her", "he/him", "they/them", "xe/xem"];
+const languageOptions = [
+  { title: "English", value: "en" },
+  { title: "Français", value: "fr" },
+  { title: "العربية", value: "ar" },
+  { title: "Deutsch", value: "de" },
+];
+const timezoneOptions = [
+  "Africa/Casablanca",
+  "Europe/Paris",
+  "America/New_York",
+  "Asia/Dubai",
+  "Asia/Singapore",
+];
+const skillOptions = [
+  "Design systems",
+  "Product discovery",
+  "Workshop facilitation",
+  "Narrative design",
+  "Accessibility",
+  "Leadership coaching",
+];
+const interestOptions = [
+  "Community leadership",
+  "Accessibility",
+  "Storytelling",
+  "Research ops",
+  "Content strategy",
+];
+
+const errors = reactive<Record<keyof ProfileForm | string, string>>({});
+const showSnackbar = ref(false);
+const snackbarMessage = ref("");
+const snackbarColor = ref("primary");
+const isSaving = ref(false);
+
+const fullName = computed(() => `${form.firstName} ${form.lastName}`.trim());
+const initials = computed(() => {
+  const first = form.firstName?.charAt(0) ?? "";
+  const last = form.lastName?.charAt(0) ?? "";
+  const combined = `${first}${last}`.trim();
+
+  if (combined) {
+    return combined.toUpperCase();
+  }
+
+  const fallback = t("pages.profileEdit.labels.firstName");
+  return fallback.charAt(0).toUpperCase();
+});
+
+const formErrors = computed(() => Object.values(errors).filter(Boolean));
+
+function fieldError(field: keyof ProfileForm | string) {
+  return errors[field] ? [errors[field]] : [];
+}
+
+function validate() {
+  errors.firstName = form.firstName ? "" : t("pages.profileEdit.validation.required");
+  errors.lastName = form.lastName ? "" : t("pages.profileEdit.validation.required");
+  errors.language = form.language ? "" : t("pages.profileEdit.validation.required");
+  errors.email = form.email ? "" : t("pages.profileEdit.validation.required");
+  errors.bio = form.bio.length <= 280 ? "" : t("pages.profileEdit.validation.bioLimit");
+
+  return Object.values(errors).every((value) => !value);
+}
+
+function resetForm() {
+  Object.assign(form, initialForm);
+  Object.keys(errors).forEach((key) => {
+    errors[key] = "";
+  });
+}
+
+async function submitForm() {
+  if (isSaving.value) {
+    return;
+  }
+
+  const isValid = validate();
+
+  if (!isValid) {
+    snackbarMessage.value = t("pages.profileEdit.feedback.errorMessage");
+    snackbarColor.value = "error";
+    showSnackbar.value = true;
+    return;
+  }
+
+  try {
+    isSaving.value = true;
+    await new Promise((resolve) => setTimeout(resolve, 900));
+    snackbarMessage.value = t("pages.profileEdit.feedback.successMessage");
+    snackbarColor.value = "success";
+    showSnackbar.value = true;
+  }
+  catch (error) {
+    snackbarMessage.value = t("pages.profileEdit.feedback.errorMessage");
+    snackbarColor.value = "error";
+    showSnackbar.value = true;
+  }
+  finally {
+    isSaving.value = false;
+  }
+}
+</script>

--- a/pages/profile-friends.vue
+++ b/pages/profile-friends.vue
@@ -1,0 +1,642 @@
+<template>
+  <main
+    class="py-8"
+    aria-labelledby="profile-friends-title"
+  >
+    <v-container>
+      <header
+        class="mb-10"
+        aria-describedby="profile-friends-subtitle"
+      >
+        <v-card
+          class="pa-6"
+          rounded="xl"
+          elevation="8"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div class="flex-grow-1">
+              <h1
+                id="profile-friends-title"
+                class="text-h4 font-weight-bold mb-2"
+              >
+                {{ t("pages.profileFriends.title") }}
+              </h1>
+              <p
+                id="profile-friends-subtitle"
+                class="text-body-1 text-medium-emphasis mb-4"
+              >
+                {{ t("pages.profileFriends.subtitle") }}
+              </p>
+              <div class="d-flex flex-wrap gap-4">
+                <div
+                  v-for="stat in heroStats"
+                  :key="stat.id"
+                  class="d-flex flex-column"
+                >
+                  <span class="text-h5 font-weight-semibold">{{ stat.value }}</span>
+                  <span class="text-body-2 text-medium-emphasis">{{ stat.label }}</span>
+                </div>
+              </div>
+            </div>
+            <div class="d-flex flex-column flex-sm-row align-stretch gap-3">
+              <v-btn
+                color="primary"
+                size="large"
+                class="flex-grow-1"
+                @click="triggerAction('message')"
+              >
+                {{ t("pages.profileFriends.actions.message") }}
+              </v-btn>
+              <v-btn
+                variant="tonal"
+                color="primary"
+                size="large"
+                class="flex-grow-1"
+                @click="triggerAction('schedule')"
+              >
+                {{ t("pages.profileFriends.actions.schedule") }}
+              </v-btn>
+            </div>
+          </div>
+        </v-card>
+      </header>
+
+      <section
+        class="mb-10"
+        aria-labelledby="friends-filter-title"
+      >
+        <div class="d-flex flex-column flex-sm-row justify-space-between align-sm-center mb-4 gap-4">
+          <div>
+            <h2
+              id="friends-filter-title"
+              class="text-h5 font-weight-semibold mb-1"
+            >
+              {{ t("pages.profileFriends.highlights.title") }}
+            </h2>
+            <p class="text-body-2 text-medium-emphasis mb-0">
+              {{ t("pages.profileFriends.highlights.subtitle") }}
+            </p>
+          </div>
+          <v-chip-group
+            v-model="activeFilter"
+            selected-class="bg-primary text-primary-on-surface"
+            class="flex-wrap"
+          >
+            <v-chip
+              v-for="option in filterOptions"
+              :key="option.id"
+              :value="option.id"
+              variant="outlined"
+              size="small"
+              class="text-body-2"
+            >
+              {{ option.label }}
+            </v-chip>
+          </v-chip-group>
+        </div>
+
+        <v-row
+          dense
+          align="stretch"
+        >
+          <v-col
+            v-for="friend in filteredFriends"
+            :key="friend.id"
+            cols="12"
+            sm="6"
+            xl="4"
+          >
+            <v-card
+              class="pa-5 h-100"
+              rounded="xl"
+              elevation="6"
+            >
+              <div class="d-flex align-start gap-4 mb-4">
+                <v-avatar size="64">
+                  <v-img
+                    :src="friend.avatar"
+                    :alt="friend.name"
+                    cover
+                  />
+                </v-avatar>
+                <div class="flex-grow-1">
+                  <div class="d-flex align-center justify-space-between gap-2 mb-1">
+                    <h3 class="text-subtitle-1 font-weight-semibold mb-0">{{ friend.name }}</h3>
+                    <v-chip
+                      v-if="friend.status"
+                      :color="statusColor(friend.status)"
+                      size="small"
+                      class="text-caption font-weight-medium"
+                    >
+                      {{ statusLabel(friend.status) }}
+                    </v-chip>
+                  </div>
+                  <p class="text-body-2 text-medium-emphasis mb-2">{{ friend.headline }}</p>
+                  <div class="d-flex flex-wrap gap-2 mb-3">
+                    <v-chip
+                      v-for="tag in friend.tags"
+                      :key="tag"
+                      size="small"
+                      variant="tonal"
+                    >
+                      {{ tag }}
+                    </v-chip>
+                  </div>
+                </div>
+              </div>
+
+              <div class="d-flex flex-wrap align-center justify-space-between text-medium-emphasis text-body-2 mb-4 gap-2">
+                <div class="d-flex align-center gap-2">
+                  <v-icon icon="mdi-map-marker-outline" size="18" />
+                  <span>{{ friend.location }}</span>
+                </div>
+                <div class="d-flex align-center gap-2">
+                  <v-icon icon="mdi-account-multiple-outline" size="18" />
+                  <span>{{ friend.mutualCount }} {{ t("pages.profileFriends.stats.mutual") }}</span>
+                </div>
+              </div>
+
+              <div class="d-flex flex-wrap gap-3">
+                <v-btn
+                  color="primary"
+                  variant="outlined"
+                  size="small"
+                  @click="openProfile(friend)"
+                >
+                  {{ t("pages.profileFriends.actions.viewProfile") }}
+                </v-btn>
+                <v-btn
+                  color="primary"
+                  variant="text"
+                  size="small"
+                  @click="triggerAction('message', friend)"
+                >
+                  {{ t("pages.profileFriends.actions.message") }}
+                </v-btn>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+
+        <div
+          v-if="filteredFriends.length === 0"
+          class="text-body-1 text-medium-emphasis text-center py-8"
+        >
+          {{ t("pages.profileFriends.empty") }}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="friend-suggestions-title"
+      >
+        <v-row dense>
+          <v-col
+            cols="12"
+            lg="8"
+          >
+            <v-card
+              class="pa-6 h-100"
+              rounded="xl"
+              elevation="4"
+            >
+              <h2
+                id="friend-suggestions-title"
+                class="text-h5 font-weight-semibold mb-4"
+              >
+                {{ t("pages.profileFriends.sections.suggestions") }}
+              </h2>
+              <v-list
+                lines="three"
+                density="comfortable"
+              >
+                <v-list-item
+                  v-for="suggestion in suggestions"
+                  :key="suggestion.id"
+                >
+                  <template #prepend>
+                    <v-avatar size="48">
+                      <v-img
+                        :src="suggestion.avatar"
+                        :alt="suggestion.name"
+                        cover
+                      />
+                    </v-avatar>
+                  </template>
+                  <v-list-item-title class="font-weight-semibold">{{ suggestion.name }}</v-list-item-title>
+                  <v-list-item-subtitle>{{ suggestion.headline }}</v-list-item-subtitle>
+                  <template #append>
+                    <div class="d-flex flex-column align-end gap-2">
+                      <v-chip
+                        size="small"
+                        variant="tonal"
+                      >
+                        {{ suggestion.mutualCount }} {{ t("pages.profileFriends.stats.mutual") }}
+                      </v-chip>
+                      <v-btn
+                        color="primary"
+                        variant="text"
+                        size="small"
+                        @click="triggerAction('connect', suggestion)"
+                      >
+                        {{ t("pages.profileFriends.actions.message") }}
+                      </v-btn>
+                    </div>
+                  </template>
+                </v-list-item>
+              </v-list>
+            </v-card>
+          </v-col>
+          <v-col
+            cols="12"
+            lg="4"
+          >
+            <v-card
+              class="pa-6 h-100"
+              rounded="xl"
+              variant="tonal"
+            >
+              <div class="d-flex flex-column gap-3">
+                <h2 class="text-h6 font-weight-semibold mb-1">
+                  {{ t("pages.profileFriends.sections.active") }}
+                </h2>
+                <div class="d-flex flex-column gap-2">
+                  <div
+                    v-for="friend in activeNow"
+                    :key="friend.id"
+                    class="d-flex align-center justify-space-between"
+                  >
+                    <div class="d-flex align-center gap-3">
+                      <v-avatar size="40">
+                        <v-img
+                          :src="friend.avatar"
+                          :alt="friend.name"
+                          cover
+                        />
+                      </v-avatar>
+                      <div>
+                        <div class="text-subtitle-2 font-weight-medium">{{ friend.name }}</div>
+                        <div class="text-caption text-medium-emphasis">{{ friend.lastActive }}</div>
+                      </div>
+                    </div>
+                    <v-chip
+                      :color="statusColor(friend.status)"
+                      size="x-small"
+                      class="font-weight-medium"
+                    >
+                      {{ statusLabel(friend.status) }}
+                    </v-chip>
+                  </div>
+                </div>
+              </div>
+            </v-card>
+          </v-col>
+        </v-row>
+      </section>
+    </v-container>
+
+    <v-dialog
+      v-model="showProfileDialog"
+      max-width="520"
+    >
+      <v-card v-if="selectedFriend">
+        <v-card-title class="d-flex align-center gap-3">
+          <v-avatar size="56">
+            <v-img
+              :src="selectedFriend.avatar"
+              :alt="selectedFriend.name"
+              cover
+            />
+          </v-avatar>
+          <div>
+            <div class="text-subtitle-1 font-weight-semibold">{{ selectedFriend.name }}</div>
+            <div class="text-body-2 text-medium-emphasis">{{ selectedFriend.headline }}</div>
+          </div>
+        </v-card-title>
+        <v-card-text>
+          <div class="d-flex flex-wrap gap-2 mb-4">
+            <v-chip
+              v-for="tag in selectedFriend.tags"
+              :key="tag"
+              size="small"
+              variant="tonal"
+            >
+              {{ tag }}
+            </v-chip>
+          </div>
+          <p class="text-body-2 text-medium-emphasis mb-4">
+            {{ selectedFriend.bio }}
+          </p>
+          <div class="d-flex align-center gap-2 text-body-2 text-medium-emphasis">
+            <v-icon icon="mdi-map-marker-outline" size="18" />
+            <span>{{ selectedFriend.location }}</span>
+          </div>
+        </v-card-text>
+        <v-card-actions class="justify-space-between">
+          <v-btn
+            variant="text"
+            color="primary"
+            @click="showProfileDialog = false"
+          >
+            {{ t("common.close") }}
+          </v-btn>
+          <div class="d-flex gap-2">
+            <v-btn
+              variant="outlined"
+              color="primary"
+              @click="triggerAction('schedule', selectedFriend)"
+            >
+              {{ t("pages.profileFriends.actions.schedule") }}
+            </v-btn>
+            <v-btn
+              color="primary"
+              @click="triggerAction('message', selectedFriend)"
+            >
+              {{ t("pages.profileFriends.actions.message") }}
+            </v-btn>
+          </div>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <v-snackbar
+      v-model="showActionSnackbar"
+      timeout="3000"
+      color="primary"
+      variant="flat"
+    >
+      {{ snackbarMessage }}
+    </v-snackbar>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+definePageMeta({
+  middleware: "auth",
+  title: "profile-friends",
+});
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.profileFriends.title");
+  const description = t("seo.profileFriends.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+interface FriendCard {
+  id: string;
+  name: string;
+  headline: string;
+  avatar: string;
+  location: string;
+  mutualCount: number;
+  status: "online" | "offline" | "busy" | "focus";
+  tags: string[];
+  segments: ("design" | "product" | "engineering" | "marketing")[];
+  lastActive: string;
+  bio: string;
+}
+
+const allFriends = ref<FriendCard[]>([
+  {
+    id: "amina-rahman",
+    name: "Amina Rahman",
+    headline: "Lead Product Designer · Flowbase",
+    avatar: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Casablanca, Morocco",
+    mutualCount: 12,
+    status: "online",
+    tags: ["Design systems", "Accessibility"],
+    segments: ["design", "product"],
+    lastActive: "5 min",
+    bio: "Exploring inclusive design for large platforms and mentoring early-career designers.",
+  },
+  {
+    id: "leo-martinez",
+    name: "Leo Martínez",
+    headline: "Senior Frontend Engineer · Alloy",
+    avatar: "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Madrid, Spain",
+    mutualCount: 18,
+    status: "focus",
+    tags: ["Nuxt", "Design systems"],
+    segments: ["engineering", "product"],
+    lastActive: "Just now",
+    bio: "Leading the design system implementation and coaching cross-functional squads.",
+  },
+  {
+    id: "noor-hassan",
+    name: "Noor Hassan",
+    headline: "Community Strategist · Orbit",
+    avatar: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Dubai, UAE",
+    mutualCount: 9,
+    status: "online",
+    tags: ["Community", "Storytelling"],
+    segments: ["marketing", "product"],
+    lastActive: "12 min",
+    bio: "Scaling partnerships through curated learning circles and thoughtful rituals.",
+  },
+  {
+    id: "sasha-ivanov",
+    name: "Sasha Ivanov",
+    headline: "Staff Software Engineer · Vertex",
+    avatar: "https://images.unsplash.com/photo-1463453091185-61582044d556?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Berlin, Germany",
+    mutualCount: 7,
+    status: "busy",
+    tags: ["Performance", "TypeScript"],
+    segments: ["engineering"],
+    lastActive: "25 min",
+    bio: "Improving performance budgets and tooling for globally distributed teams.",
+  },
+  {
+    id: "harper-lee",
+    name: "Harper Lee",
+    headline: "Growth Marketing Lead · Sail",
+    avatar: "https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Toronto, Canada",
+    mutualCount: 14,
+    status: "online",
+    tags: ["Lifecycle", "Analytics"],
+    segments: ["marketing"],
+    lastActive: "2 min",
+    bio: "Designing lifecycle journeys and community programs for product-led growth.",
+  },
+  {
+    id: "meera-kapoor",
+    name: "Meera Kapoor",
+    headline: "Principal Product Manager · Aurora",
+    avatar: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Bengaluru, India",
+    mutualCount: 21,
+    status: "focus",
+    tags: ["Roadmaps", "Discovery"],
+    segments: ["product"],
+    lastActive: "8 min",
+    bio: "Championing discovery frameworks and inclusive roadmap rituals across teams.",
+  },
+  {
+    id: "julien-morel",
+    name: "Julien Morel",
+    headline: "Design Operations Manager · Lumen",
+    avatar: "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Paris, France",
+    mutualCount: 10,
+    status: "offline",
+    tags: ["Ops", "Workshops"],
+    segments: ["design", "product"],
+    lastActive: "2 h",
+    bio: "Connecting research, content, and design practices through workshops and rituals.",
+  },
+  {
+    id: "ayesha-rahim",
+    name: "Ayesha Rahim",
+    headline: "Solutions Engineer · Stripe",
+    avatar: "https://images.unsplash.com/photo-1529665253569-6d01c0eaf7b6?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Singapore",
+    mutualCount: 11,
+    status: "online",
+    tags: ["Integrations", "Workflows"],
+    segments: ["engineering", "product"],
+    lastActive: "3 min",
+    bio: "Bridging product discovery with implementation for enterprise customers.",
+  },
+  {
+    id: "daniel-cho",
+    name: "Daniel Cho",
+    headline: "Brand Strategist · Northwind",
+    avatar: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=facearea&w=160&h=160&q=80",
+    location: "Seoul, South Korea",
+    mutualCount: 6,
+    status: "offline",
+    tags: ["Narrative", "Workshops"],
+    segments: ["marketing", "design"],
+    lastActive: "5 h",
+    bio: "Building narrative frameworks and brand playbooks for community-led launches.",
+  },
+]);
+
+const featuredIds = new Set(["amina-rahman", "leo-martinez", "meera-kapoor"]);
+
+const heroStats = computed(() => {
+  const total = allFriends.value.length;
+  const mutual = allFriends.value.reduce((sum, friend) => sum + friend.mutualCount, 0);
+  const online = allFriends.value.filter((friend) => friend.status === "online").length;
+  const formatter = new Intl.NumberFormat(locale.value || "en-US");
+
+  return [
+    { id: "total", label: t("pages.profileFriends.stats.totalFriends"), value: formatter.format(total) },
+    { id: "mutual", label: t("pages.profileFriends.stats.mutual"), value: formatter.format(mutual) },
+    { id: "online", label: t("pages.profileFriends.stats.online"), value: formatter.format(online) },
+  ];
+});
+
+const filterOptions = computed(() => [
+  { id: "all", label: t("pages.profileFriends.filters.all") },
+  { id: "design", label: t("pages.profileFriends.filters.design") },
+  { id: "product", label: t("pages.profileFriends.filters.product") },
+  { id: "engineering", label: t("pages.profileFriends.filters.engineering") },
+  { id: "marketing", label: t("pages.profileFriends.filters.marketing") },
+]);
+
+const activeFilter = ref<string>("all");
+
+const filteredFriends = computed(() => {
+  if (activeFilter.value === "all") {
+    return allFriends.value.filter((friend) => featuredIds.has(friend.id));
+  }
+
+  return allFriends.value.filter(
+    (friend) => featuredIds.has(friend.id) && friend.segments.includes(activeFilter.value as FriendCard["segments"][number]),
+  );
+});
+
+const suggestions = computed(() => allFriends.value.filter((friend) => !featuredIds.has(friend.id)));
+
+const activeNow = computed(() =>
+  allFriends.value.filter((friend) => friend.status === "online" || friend.status === "focus").slice(0, 4),
+);
+
+const showProfileDialog = ref(false);
+const selectedFriend = ref<FriendCard | null>(null);
+const showActionSnackbar = ref(false);
+const snackbarMessage = ref("");
+
+function statusColor(status: FriendCard["status"]) {
+  switch (status) {
+    case "online":
+      return "success";
+    case "focus":
+      return "primary";
+    case "busy":
+      return "warning";
+    default:
+      return "grey";
+  }
+}
+
+function statusLabel(status: FriendCard["status"]) {
+  switch (status) {
+    case "online":
+      return t("pages.profileFriends.status.online");
+    case "focus":
+      return t("pages.profileFriends.status.focus");
+    case "busy":
+      return t("pages.profileFriends.status.busy");
+    default:
+      return t("pages.profileFriends.status.offline");
+  }
+}
+
+function openProfile(friend: FriendCard) {
+  selectedFriend.value = friend;
+  showProfileDialog.value = true;
+}
+
+function triggerAction(action: "message" | "schedule" | "connect", friend?: FriendCard) {
+  const name = friend?.name;
+
+  if (action === "message") {
+    snackbarMessage.value = name
+      ? t("pages.profileFriends.feedback.messageWith", { name })
+      : t("pages.profileFriends.feedback.message");
+  }
+  else if (action === "schedule") {
+    snackbarMessage.value = name
+      ? t("pages.profileFriends.feedback.scheduleWith", { name })
+      : t("pages.profileFriends.feedback.schedule");
+  }
+  else {
+    snackbarMessage.value = name
+      ? t("pages.profileFriends.feedback.connectWith", { name })
+      : t("pages.profileFriends.feedback.connect");
+  }
+
+  showActionSnackbar.value = true;
+}
+</script>

--- a/pages/profile-photos.vue
+++ b/pages/profile-photos.vue
@@ -1,0 +1,616 @@
+<template>
+  <main
+    class="py-8"
+    aria-labelledby="profile-photos-title"
+  >
+    <v-container>
+      <header
+        class="mb-10"
+        aria-describedby="profile-photos-subtitle"
+      >
+        <v-card
+          class="pa-6"
+          rounded="xl"
+          elevation="8"
+        >
+          <div class="d-flex flex-column flex-lg-row align-lg-center justify-space-between gap-6">
+            <div class="flex-grow-1">
+              <h1
+                id="profile-photos-title"
+                class="text-h4 font-weight-bold mb-2"
+              >
+                {{ t("pages.profilePhotos.title") }}
+              </h1>
+              <p
+                id="profile-photos-subtitle"
+                class="text-body-1 text-medium-emphasis mb-4"
+              >
+                {{ t("pages.profilePhotos.subtitle") }}
+              </p>
+              <div class="d-flex flex-wrap gap-4">
+                <div
+                  v-for="stat in collectionStats"
+                  :key="stat.id"
+                  class="d-flex flex-column"
+                >
+                  <span class="text-h5 font-weight-semibold">{{ stat.value }}</span>
+                  <span class="text-body-2 text-medium-emphasis">{{ stat.label }}</span>
+                </div>
+              </div>
+            </div>
+            <div class="d-flex flex-column flex-sm-row align-stretch gap-3">
+              <v-btn
+                color="primary"
+                size="large"
+                class="flex-grow-1"
+                @click="triggerAction('upload')"
+              >
+                {{ t("pages.profilePhotos.actions.upload") }}
+              </v-btn>
+              <v-btn
+                variant="tonal"
+                color="primary"
+                size="large"
+                class="flex-grow-1"
+                @click="triggerAction('create-album')"
+              >
+                {{ t("pages.profilePhotos.actions.createAlbum") }}
+              </v-btn>
+            </div>
+          </div>
+        </v-card>
+      </header>
+
+      <v-row dense>
+        <v-col
+          cols="12"
+          xl="8"
+        >
+          <section
+            class="mb-8"
+            aria-labelledby="pinned-albums-title"
+          >
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              elevation="6"
+            >
+              <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-4 mb-6">
+                <div>
+                  <h2
+                    id="pinned-albums-title"
+                    class="text-h5 font-weight-semibold mb-1"
+                  >
+                    {{ t("pages.profilePhotos.sections.pinned") }}
+                  </h2>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ t("pages.profilePhotos.meta.updated", { date: highlightedAlbum.updated }) }}
+                  </p>
+                </div>
+                <v-chip-group
+                  v-model="activeFilter"
+                  selected-class="bg-primary text-primary-on-surface"
+                  class="flex-wrap"
+                >
+                  <v-chip
+                    v-for="filter in filters"
+                    :key="filter.id"
+                    :value="filter.id"
+                    variant="outlined"
+                    size="small"
+                    class="text-body-2"
+                  >
+                    {{ filter.label }}
+                  </v-chip>
+                </v-chip-group>
+              </div>
+
+              <v-row
+                dense
+                align="stretch"
+              >
+                <v-col
+                  cols="12"
+                  md="6"
+                >
+                  <v-card
+                    class="pa-4 h-100"
+                    rounded="xl"
+                    elevation="4"
+                  >
+                    <div class="rounded-xl overflow-hidden mb-4">
+                      <v-img
+                        :src="highlightedAlbum.cover"
+                        :alt="highlightedAlbum.title"
+                        aspect-ratio="4/3"
+                        cover
+                      />
+                    </div>
+                    <h3 class="text-subtitle-1 font-weight-semibold mb-1">{{ highlightedAlbum.title }}</h3>
+                    <p class="text-body-2 text-medium-emphasis mb-4">
+                      {{ highlightedAlbum.description }}
+                    </p>
+                    <div class="d-flex flex-wrap gap-2 text-body-2 text-medium-emphasis">
+                      <span>{{ highlightedAlbum.count }} {{ t("pages.profilePhotos.meta.photoCount") }}</span>
+                      <span>•</span>
+                      <span>{{ highlightedAlbum.location }}</span>
+                    </div>
+                  </v-card>
+                </v-col>
+                <v-col
+                  cols="12"
+                  md="6"
+                >
+                  <div class="d-flex flex-column gap-3">
+                    <v-card
+                      v-for="album in secondaryAlbums"
+                      :key="album.id"
+                      class="pa-4"
+                      rounded="xl"
+                      variant="tonal"
+                    >
+                      <div class="d-flex gap-4">
+                        <v-img
+                          :src="album.cover"
+                          :alt="album.title"
+                          class="rounded-lg"
+                          aspect-ratio="1"
+                          width="96"
+                          cover
+                        />
+                        <div class="flex-grow-1">
+                          <div class="d-flex align-center justify-space-between mb-1">
+                            <h3 class="text-subtitle-1 font-weight-semibold mb-0">{{ album.title }}</h3>
+                            <v-chip
+                              size="small"
+                              variant="tonal"
+                            >
+                              {{ album.count }}
+                            </v-chip>
+                          </div>
+                          <p class="text-body-2 text-medium-emphasis mb-2">{{ album.description }}</p>
+                          <div class="text-caption text-medium-emphasis">{{ album.updated }}</div>
+                        </div>
+                      </div>
+                    </v-card>
+                  </div>
+                </v-col>
+              </v-row>
+            </v-card>
+          </section>
+
+          <section aria-labelledby="photo-gallery-title">
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              elevation="4"
+            >
+              <div class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-4 mb-4">
+                <div>
+                  <h2
+                    id="photo-gallery-title"
+                    class="text-h5 font-weight-semibold mb-1"
+                  >
+                    {{ t("pages.profilePhotos.sections.albums") }}
+                  </h2>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ t("pages.profilePhotos.cta.share") }}
+                  </p>
+                </div>
+                <v-btn
+                  variant="outlined"
+                  color="primary"
+                  size="small"
+                  @click="triggerAction('share-collection')"
+                >
+                  {{ t("pages.profilePhotos.actions.createAlbum") }}
+                </v-btn>
+              </div>
+
+              <div class="masonry-grid">
+                <div
+                  v-for="photo in displayedPhotos"
+                  :key="photo.id"
+                  class="masonry-item"
+                >
+                  <v-img
+                    :src="photo.src"
+                    :alt="photo.alt"
+                    class="rounded-xl"
+                    aspect-ratio="photo.ratio"
+                    cover
+                  />
+                  <div class="mt-2 d-flex flex-column gap-1">
+                    <div class="d-flex align-center justify-space-between">
+                      <span class="text-subtitle-2 font-weight-medium">{{ photo.title }}</span>
+                      <v-chip
+                        size="x-small"
+                        variant="tonal"
+                      >
+                        {{ photo.category }}
+                      </v-chip>
+                    </div>
+                    <span class="text-caption text-medium-emphasis">{{ photo.takenAt }}</span>
+                  </div>
+                </div>
+              </div>
+
+              <div
+                v-if="displayedPhotos.length === 0"
+                class="text-body-1 text-medium-emphasis text-center py-8"
+              >
+                {{ t("pages.profilePhotos.empty") }}
+              </div>
+            </v-card>
+          </section>
+        </v-col>
+        <v-col
+          cols="12"
+          xl="4"
+        >
+          <aside>
+            <v-card
+              class="pa-6 mb-6"
+              rounded="xl"
+              elevation="4"
+            >
+              <h2 class="text-h6 font-weight-semibold mb-4">
+                {{ t("pages.profilePhotos.timeline.title") }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-6">
+                {{ t("pages.profilePhotos.timeline.description") }}
+              </p>
+              <v-expansion-panels
+                multiple
+                variant="accordion"
+              >
+                <v-expansion-panel
+                  v-for="item in timeline"
+                  :key="item.id"
+                >
+                  <v-expansion-panel-title>
+                    <div class="d-flex flex-column">
+                      <span class="text-subtitle-2 font-weight-semibold">{{ item.title }}</span>
+                      <span class="text-caption text-medium-emphasis">{{ item.date }}</span>
+                    </div>
+                  </v-expansion-panel-title>
+                  <v-expansion-panel-text>
+                    <p class="text-body-2 text-medium-emphasis mb-3">{{ item.description }}</p>
+                    <div class="d-flex flex-wrap gap-2">
+                      <v-chip
+                        v-for="tag in item.tags"
+                        :key="tag"
+                        size="x-small"
+                        variant="tonal"
+                      >
+                        {{ tag }}
+                      </v-chip>
+                    </div>
+                  </v-expansion-panel-text>
+                </v-expansion-panel>
+              </v-expansion-panels>
+            </v-card>
+
+            <v-card
+              class="pa-6"
+              rounded="xl"
+              variant="tonal"
+            >
+              <h2 class="text-h6 font-weight-semibold mb-3">
+                {{ t("pages.profilePhotos.sections.timeline") }}
+              </h2>
+              <div class="d-flex flex-column gap-3">
+                <div
+                  v-for="note in quickNotes"
+                  :key="note.id"
+                  class="d-flex gap-3"
+                >
+                  <v-avatar
+                    size="36"
+                    color="primary"
+                    variant="tonal"
+                  >
+                    <span class="text-body-2 font-weight-semibold">{{ note.initials }}</span>
+                  </v-avatar>
+                  <div>
+                    <div class="text-subtitle-2 font-weight-semibold">{{ note.title }}</div>
+                    <div class="text-caption text-medium-emphasis">{{ note.subtitle }}</div>
+                  </div>
+                </div>
+              </div>
+            </v-card>
+          </aside>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <v-snackbar
+      v-model="showSnackbar"
+      timeout="3000"
+      color="primary"
+      variant="flat"
+    >
+      {{ snackbarMessage }}
+    </v-snackbar>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from "vue";
+
+definePageMeta({
+  middleware: "auth",
+  title: "profile-photos",
+});
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.profilePhotos.title");
+  const description = t("seo.profilePhotos.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+interface PhotoItem {
+  id: string;
+  src: string;
+  alt: string;
+  title: string;
+  category: string;
+  takenAt: string;
+  ratio: number;
+  filter: string;
+}
+
+interface AlbumSummary {
+  id: string;
+  title: string;
+  description: string;
+  cover: string;
+  count: number;
+  location: string;
+  updated: string;
+}
+
+const highlightedAlbum = reactive<AlbumSummary>({
+  id: "field-research",
+  title: "Field research week",
+  description: "Immersive research sessions with the Flowbase design team across artisanal workshops.",
+  cover: "https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=960&q=80",
+  count: 42,
+  location: "Lisbon, Portugal",
+  updated: "2 days ago",
+});
+
+const secondaryAlbums = reactive<AlbumSummary[]>([
+  {
+    id: "studio",
+    title: "Studio portraits",
+    description: "Editorial portraits for the latest community profile series.",
+    cover: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=640&q=80",
+    count: 18,
+    location: "",
+    updated: "4 days ago",
+  },
+  {
+    id: "product-launch",
+    title: "Product launch night",
+    description: "Highlights from the BroWorld 2.0 launch gathering.",
+    cover: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=640&q=80",
+    count: 27,
+    location: "",
+    updated: "1 week ago",
+  },
+  {
+    id: "retreat",
+    title: "Team retreat",
+    description: "Moments from the annual leadership retreat in the mountains.",
+    cover: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=640&q=80",
+    count: 33,
+    location: "",
+    updated: "3 weeks ago",
+  },
+]);
+
+const filters = computed(() => [
+  { id: "recent", label: t("pages.profilePhotos.filters.recent") },
+  { id: "events", label: t("pages.profilePhotos.filters.events") },
+  { id: "studio", label: t("pages.profilePhotos.filters.studio") },
+  { id: "travel", label: t("pages.profilePhotos.filters.travel") },
+]);
+
+const activeFilter = ref<string>("recent");
+
+const photoLibrary = reactive<PhotoItem[]>([
+  {
+    id: "photo-1",
+    src: "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80",
+    alt: "Team celebrating product launch",
+    title: "Launch toast",
+    category: "Events",
+    takenAt: "May 2024",
+    ratio: 4 / 5,
+    filter: "events",
+  },
+  {
+    id: "photo-2",
+    src: "https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=800&q=80",
+    alt: "Research interviews",
+    title: "Field notes",
+    category: "Research",
+    takenAt: "April 2024",
+    ratio: 3 / 4,
+    filter: "recent",
+  },
+  {
+    id: "photo-3",
+    src: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=800&q=80",
+    alt: "Portrait studio setup",
+    title: "Studio light tests",
+    category: "Studio",
+    takenAt: "March 2024",
+    ratio: 4 / 5,
+    filter: "studio",
+  },
+  {
+    id: "photo-4",
+    src: "https://images.unsplash.com/photo-1463453091185-61582044d556?auto=format&fit=crop&w=800&q=80",
+    alt: "Mountain retreat",
+    title: "Retreat sunrise",
+    category: "Travel",
+    takenAt: "February 2024",
+    ratio: 16 / 9,
+    filter: "travel",
+  },
+  {
+    id: "photo-5",
+    src: "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80",
+    alt: "Portrait backdrop",
+    title: "Portrait session",
+    category: "Studio",
+    takenAt: "January 2024",
+    ratio: 1,
+    filter: "studio",
+  },
+  {
+    id: "photo-6",
+    src: "https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=800&q=80",
+    alt: "Workshop collaboration",
+    title: "Workshop board",
+    category: "Events",
+    takenAt: "December 2023",
+    ratio: 3 / 4,
+    filter: "events",
+  },
+  {
+    id: "photo-7",
+    src: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=800&q=80",
+    alt: "Urban exploration",
+    title: "City stroll",
+    category: "Travel",
+    takenAt: "October 2023",
+    ratio: 3 / 2,
+    filter: "travel",
+  },
+  {
+    id: "photo-8",
+    src: "https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=800&q=80",
+    alt: "Notebook close-up",
+    title: "Interview notes",
+    category: "Research",
+    takenAt: "September 2023",
+    ratio: 4 / 3,
+    filter: "recent",
+  },
+]);
+
+const collectionStats = computed(() => {
+  const formatter = new Intl.NumberFormat(locale.value || "en-US");
+  const totalPhotos = photoLibrary.length + highlightedAlbum.count + secondaryAlbums.reduce((sum, album) => sum + album.count, 0);
+  const curatedAlbums = 1 + secondaryAlbums.length;
+  const curatedTags = new Set(photoLibrary.map((photo) => photo.category)).size;
+
+  return [
+    { id: "photos", label: t("pages.profilePhotos.meta.photoCount"), value: formatter.format(totalPhotos) },
+    { id: "albums", label: t("pages.profilePhotos.stats.albums"), value: formatter.format(curatedAlbums) },
+    { id: "tags", label: t("pages.profilePhotos.stats.tags"), value: formatter.format(curatedTags) },
+  ];
+});
+
+const displayedPhotos = computed(() => {
+  if (activeFilter.value === "recent") {
+    return photoLibrary;
+  }
+
+  return photoLibrary.filter((photo) => photo.filter === activeFilter.value);
+});
+
+const timeline = reactive(
+  [
+    {
+      id: "2024-q2",
+      title: "Research residency",
+      date: "Q2 2024",
+      description: "A week-long residency documenting artisan workshops to inspire new community formats.",
+      tags: ["Research", "Community"],
+    },
+    {
+      id: "2024-launch",
+      title: "BroWorld 2.0 launch",
+      date: "May 2024",
+      description: "Captured stories from partners, beta customers, and the team during launch week.",
+      tags: ["Events", "Product"],
+    },
+    {
+      id: "2023-retreat",
+      title: "Leadership retreat",
+      date: "November 2023",
+      description: "Photo journal from the annual strategy retreat in the mountains.",
+      tags: ["Retreat", "Team"],
+    },
+  ] satisfies Array<{ id: string; title: string; date: string; description: string; tags: string[] }>,
+);
+
+const quickNotes = reactive(
+  [
+    { id: "note-1", initials: "AR", title: "Shot list updated", subtitle: "Amina added 3 new prompts" },
+    { id: "note-2", initials: "LM", title: "Color grading", subtitle: "Leo shared LUT presets" },
+    { id: "note-3", initials: "NH", title: "Story ideas", subtitle: "Noor drafted interview angles" },
+  ] satisfies Array<{ id: string; initials: string; title: string; subtitle: string }>,
+);
+
+const showSnackbar = ref(false);
+const snackbarMessage = ref("");
+
+function triggerAction(action: "upload" | "create-album" | "share-collection") {
+  const mapping: Record<"upload" | "create-album" | "share-collection", string> = {
+    upload: "upload",
+    "create-album": "createAlbum",
+    "share-collection": "shareCollection",
+  };
+
+  const key = mapping[action] ?? "generic";
+  snackbarMessage.value = t(`pages.profilePhotos.feedback.${key}`);
+  showSnackbar.value = true;
+}
+</script>
+
+<style scoped>
+.masonry-grid {
+  column-count: 2;
+  column-gap: 1.5rem;
+}
+
+.masonry-item {
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
+}
+
+@media (min-width: 1280px) {
+  .masonry-grid {
+    column-count: 3;
+  }
+}
+</style>

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -8,6 +8,9 @@
           :friends="sidebarFriends"
           :friends-count="friendsCount"
           :life-events="sidebarEvents"
+          @view-all-friends="goToFriendsPage"
+          @view-all-photos="goToPhotosPage"
+          @edit-details="goToEditPage"
         />
       </div>
     </template>
@@ -301,6 +304,7 @@ definePageMeta({
 const auth = useAuthSession();
 const { t, locale, localeProperties } = useI18n();
 const route = useRoute();
+const router = useRouter();
 const runtimeConfig = useRuntimeConfig();
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
@@ -632,6 +636,18 @@ const sidebarFriends = computed<SidebarFriend[]>(() => {
 });
 
 const sidebarEvents = computed(() => [] as { title: string; date?: string; description?: string }[]);
+
+function goToFriendsPage() {
+  router.push({ name: "profile-friends" });
+}
+
+function goToPhotosPage() {
+  router.push({ name: "profile-photos" });
+}
+
+function goToEditPage() {
+  router.push({ name: "profile-edit" });
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- add dedicated profile friends, photos, and edit pages with responsive layouts, mock data, and SEO metadata
- wire profile sidebar actions to navigate to the new experiences
- seed translation strings for the new profile pages across available locales

## Testing
- pnpm lint *(fails: existing folder naming and lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2fe5634c8326aadda8a95b4185f3