### PR TITLE
Refresh contact, help, and about page designs

### DIFF
--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,6 +1,9 @@
 <template>
-  <section aria-labelledby="contact-form-heading">
-    <header class="mb-6">
+  <section class="contact-form" aria-labelledby="contact-form-heading">
+    <header
+      v-if="showHeading"
+      class="contact-form__header mb-6"
+    >
       <h2
         id="contact-form-heading"
         class="text-h5 font-weight-bold"
@@ -18,7 +21,7 @@
       role="form"
       @submit.prevent="handleSubmit"
     >
-      <div class="d-flex flex-column gap-4">
+      <div class="contact-form__grid">
         <div>
           <v-text-field
             id="contact-name"
@@ -145,6 +148,7 @@
           color="primary"
           :loading="isSubmitting"
           :disabled="isSubmitting"
+          class="contact-form__submit"
           data-test="submit-button"
         >
           {{ isSubmitting ? t("pages.contact.form.sending") : t("pages.contact.form.submit") }}
@@ -166,9 +170,15 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useNuxtApp } from "#app";
 
 import type { ContactValidationErrors, ContactValidationKey } from "~/lib/contact/validation";
 import { validateContactForm } from "~/lib/contact/validation";
+
+const props = defineProps<{ showHeading?: boolean }>();
+
+const showHeading = computed(() => props.showHeading ?? true);
 
 const { t, locale } = useI18n();
 const { $fetch, $notify } = useNuxtApp();
@@ -296,15 +306,24 @@ async function handleSubmit() {
 </script>
 
 <style scoped>
-section {
-  background-color: rgba(var(--v-theme-surface-variant), 0.4);
-  border-radius: 16px;
-  padding: 24px;
+.contact-form__header p {
+  max-width: 420px;
 }
 
-@media (min-width: 960px) {
-  section {
-    padding: 32px;
+.contact-form__grid {
+  display: grid;
+  gap: 18px;
+}
+
+.contact-form__submit {
+  align-self: flex-start;
+  min-width: 160px;
+}
+
+@media (max-width: 600px) {
+  .contact-form__submit {
+    width: 100%;
   }
 }
 </style>
+

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,25 +1,42 @@
 <template>
   <main
-    class="py-12"
+    class="about-page py-12"
     aria-labelledby="about-heading"
   >
-    <v-container>
+    <v-container class="about-container">
       <section
         class="mb-12"
         aria-describedby="about-subtitle"
       >
-        <h1
-          id="about-heading"
-          class="text-h3 font-weight-bold mb-3"
+        <v-sheet
+          class="about-hero"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.about.title") }}
-        </h1>
-        <p
-          id="about-subtitle"
-          class="text-body-1 text-medium-emphasis"
-        >
-          {{ t("pages.about.subtitle") }}
-        </p>
+          <div class="about-hero__badge">
+            <v-icon
+              icon="mdi-rocket-launch-outline"
+              size="22"
+              class="mr-2"
+              aria-hidden="true"
+            />
+            <span class="text-caption font-weight-medium text-uppercase tracking-wide">
+              {{ t("pages.about.missionTitle") }}
+            </span>
+          </div>
+          <h1
+            id="about-heading"
+            class="text-h3 font-weight-bold mb-3"
+          >
+            {{ t("pages.about.title") }}
+          </h1>
+          <p
+            id="about-subtitle"
+            class="text-body-1 text-medium-emphasis mb-0"
+          >
+            {{ t("pages.about.subtitle") }}
+          </p>
+        </v-sheet>
       </section>
 
       <section
@@ -34,43 +51,71 @@
             cols="12"
             md="6"
           >
-            <h2
-              id="mission-title"
-              class="text-h4 font-weight-semibold mb-4"
+            <v-sheet
+              class="about-section"
+              elevation="0"
+              rounded="xl"
             >
-              {{ t("pages.about.missionTitle") }}
-            </h2>
-            <p class="text-body-1 text-medium-emphasis mb-6">
-              {{ t("pages.about.missionBody") }}
-            </p>
+              <h2
+                id="mission-title"
+                class="text-h4 font-weight-semibold mb-4"
+              >
+                {{ t("pages.about.missionTitle") }}
+              </h2>
+              <p class="text-body-1 text-medium-emphasis mb-6">
+                {{ t("pages.about.missionBody") }}
+              </p>
+              <div class="d-flex flex-wrap gap-3">
+                <v-chip
+                  v-for="tech in techStack"
+                  :key="tech.label"
+                  class="about-chip"
+                  color="primary"
+                  variant="tonal"
+                >
+                  {{ tech.label }}
+                </v-chip>
+              </div>
+            </v-sheet>
           </v-col>
           <v-col
             cols="12"
             md="6"
           >
-            <v-card
-              v-for="point in missionPoints"
-              :key="point.title"
-              variant="tonal"
-              class="mb-4 pa-4"
+            <v-sheet
+              class="about-section about-section--cards"
+              elevation="0"
+              rounded="xl"
             >
-              <div class="d-flex align-start">
-                <v-icon
-                  :icon="point.icon"
-                  size="32"
-                  class="mr-4"
-                  aria-hidden="true"
-                />
-                <div>
-                  <h3 class="text-subtitle-1 font-weight-semibold mb-1">
-                    {{ point.title }}
-                  </h3>
-                  <p class="text-body-2 text-medium-emphasis mb-0">
-                    {{ point.body }}
-                  </p>
+              <v-card
+                v-for="point in missionPoints"
+                :key="point.title"
+                class="about-mission-card"
+                elevation="0"
+                rounded="lg"
+              >
+                <div class="d-flex align-start">
+                  <v-avatar
+                    class="about-mission-card__icon mr-4"
+                    size="48"
+                  >
+                    <v-icon
+                      :icon="point.icon"
+                      size="26"
+                      aria-hidden="true"
+                    />
+                  </v-avatar>
+                  <div>
+                    <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                      {{ point.title }}
+                    </h3>
+                    <p class="text-body-2 text-medium-emphasis mb-0">
+                      {{ point.body }}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </v-card>
+              </v-card>
+            </v-sheet>
           </v-col>
         </v-row>
       </section>
@@ -79,144 +124,169 @@
         class="mb-12"
         aria-labelledby="team-title"
       >
-        <h2
-          id="team-title"
-          class="text-h4 font-weight-semibold mb-6"
+        <v-sheet
+          class="about-section"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.about.teamTitle") }}
-        </h2>
-        <p class="text-body-1 text-medium-emphasis mb-6">
-          {{ t("pages.about.teamBody") }}
-        </p>
-        <v-row dense>
-          <v-col
-            v-for="member in teamMembers"
-            :key="member.name"
-            cols="12"
-            sm="6"
-            lg="3"
+          <h2
+            id="team-title"
+            class="text-h4 font-weight-semibold mb-6"
           >
-            <v-card
-              class="pa-4 h-100"
-              elevation="4"
-              rounded="lg"
+            {{ t("pages.about.teamTitle") }}
+          </h2>
+          <p class="text-body-1 text-medium-emphasis mb-6">
+            {{ t("pages.about.teamBody") }}
+          </p>
+          <v-row dense>
+            <v-col
+              v-for="member in teamMembers"
+              :key="member.name"
+              cols="12"
+              sm="6"
+              lg="3"
             >
-              <div class="d-flex align-center mb-4">
-                <v-avatar
-                  color="primary"
-                  size="56"
-                  class="mr-4"
-                >
-                  <span class="text-h6 text-white">{{ member.initials }}</span>
-                </v-avatar>
-                <div>
-                  <h3 class="text-subtitle-1 font-weight-semibold mb-1">
-                    {{ member.name }}
-                  </h3>
-                  <p class="text-body-2 text-medium-emphasis mb-0">
-                    {{ member.role }}
-                  </p>
+              <v-card
+                class="about-team-card"
+                elevation="0"
+                rounded="lg"
+              >
+                <div class="d-flex align-center mb-4">
+                  <v-avatar
+                    class="about-team-card__avatar mr-4"
+                    size="56"
+                  >
+                    <span class="text-h6">{{ member.initials }}</span>
+                  </v-avatar>
+                  <div>
+                    <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                      {{ member.name }}
+                    </h3>
+                    <p class="text-body-2 text-medium-emphasis mb-0">
+                      {{ member.role }}
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <p class="text-body-2 text-medium-emphasis mb-0">
-                {{ member.bio }}
-              </p>
-            </v-card>
-          </v-col>
-        </v-row>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ member.bio }}
+                </p>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-sheet>
       </section>
 
       <section
         class="mb-12"
         aria-labelledby="tech-title"
       >
-        <h2
-          id="tech-title"
-          class="text-h4 font-weight-semibold mb-4"
+        <v-sheet
+          class="about-section"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.about.techTitle") }}
-        </h2>
-        <p class="text-body-1 text-medium-emphasis mb-6">
-          {{ t("pages.about.techBody") }}
-        </p>
-        <div class="d-flex flex-wrap gap-3">
-          <v-chip
-            v-for="tech in techStack"
-            :key="tech.label"
-            color="primary"
-            variant="elevated"
-            class="text-body-2"
+          <h2
+            id="tech-title"
+            class="text-h4 font-weight-semibold mb-4"
           >
-            {{ tech.label }} — {{ tech.description }}
-          </v-chip>
-        </div>
+            {{ t("pages.about.techTitle") }}
+          </h2>
+          <p class="text-body-1 text-medium-emphasis mb-6">
+            {{ t("pages.about.techBody") }}
+          </p>
+          <div class="d-flex flex-wrap gap-3">
+            <v-chip
+              v-for="tech in techStack"
+              :key="tech.label"
+              class="about-chip about-chip--outlined"
+              color="primary"
+              variant="outlined"
+            >
+              {{ tech.label }} — {{ tech.description }}
+            </v-chip>
+          </div>
+        </v-sheet>
       </section>
 
       <section
         class="mb-12"
         aria-labelledby="timeline-title"
       >
-        <h2
-          id="timeline-title"
-          class="text-h4 font-weight-semibold mb-4"
+        <v-sheet
+          class="about-section"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.about.timelineTitle") }}
-        </h2>
-        <v-timeline
-          side="end"
-          density="compact"
-        >
-          <v-timeline-item
-            v-for="item in timeline"
-            :key="item.year"
-            :dot-color="item.color"
-            size="small"
+          <h2
+            id="timeline-title"
+            class="text-h4 font-weight-semibold mb-4"
           >
-            <template #opposite>
-              <span class="font-weight-medium">{{ item.year }}</span>
-            </template>
-            <v-card
-              class="pa-4"
-              elevation="3"
-              rounded="lg"
+            {{ t("pages.about.timelineTitle") }}
+          </h2>
+          <v-timeline
+            class="about-timeline"
+            side="end"
+            density="compact"
+          >
+            <v-timeline-item
+              v-for="item in timeline"
+              :key="item.year"
+              :dot-color="item.color"
+              size="small"
             >
-              <h3 class="text-subtitle-1 font-weight-semibold mb-1">
-                {{ item.title }}
-              </h3>
-              <p class="text-body-2 text-medium-emphasis mb-0">
-                {{ item.description }}
-              </p>
-            </v-card>
-          </v-timeline-item>
-        </v-timeline>
+              <template #opposite>
+                <span class="font-weight-medium">{{ item.year }}</span>
+              </template>
+              <v-card
+                class="about-timeline-card"
+                elevation="0"
+                rounded="lg"
+              >
+                <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                  {{ item.title }}
+                </h3>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ item.description }}
+                </p>
+              </v-card>
+            </v-timeline-item>
+          </v-timeline>
+        </v-sheet>
       </section>
 
       <section aria-labelledby="links-title">
-        <h2
-          id="links-title"
-          class="text-h5 font-weight-semibold mb-4"
+        <v-sheet
+          class="about-section"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.about.linksTitle") }}
-        </h2>
-        <div class="d-flex flex-wrap gap-4">
-          <v-btn
-            v-for="link in resourceLinks"
-            :key="link.href"
-            :href="link.href"
-            :target="link.target"
-            :rel="link.rel"
-            color="primary"
-            variant="outlined"
-            :aria-label="link.ariaLabel"
+          <h2
+            id="links-title"
+            class="text-h5 font-weight-semibold mb-4"
           >
-            <v-icon
-              :icon="link.icon"
-              class="mr-2"
-              aria-hidden="true"
-            />
-            {{ link.label }}
-          </v-btn>
-        </div>
+            {{ t("pages.about.linksTitle") }}
+          </h2>
+          <div class="d-flex flex-wrap gap-4">
+            <v-btn
+              v-for="link in resourceLinks"
+              :key="link.href"
+              :href="link.href"
+              :target="link.target"
+              :rel="link.rel"
+              color="primary"
+              variant="outlined"
+              class="about-link"
+              :aria-label="link.ariaLabel"
+            >
+              <v-icon
+                :icon="link.icon"
+                class="mr-2"
+                aria-hidden="true"
+              />
+              {{ link.label }}
+            </v-btn>
+          </div>
+        </v-sheet>
       </section>
     </v-container>
   </main>
@@ -369,21 +439,132 @@ const resourceLinks = computed(() => [
 </script>
 
 <style scoped>
-main {
+main.about-page {
+  position: relative;
+  overflow: hidden;
   background:
-    radial-gradient(circle at top left, rgba(var(--v-theme-primary), 0.08), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(var(--v-theme-secondary), 0.08), transparent 55%);
+    radial-gradient(circle at top left, rgba(var(--v-theme-primary), 0.14), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(var(--v-theme-secondary), 0.12), transparent 55%),
+    linear-gradient(180deg, rgba(var(--v-theme-surface), 1) 0%, rgba(var(--v-theme-surface-variant), 0.18) 100%);
 }
 
-.v-card.h-100 {
+.about-container {
+  position: relative;
+  z-index: 1;
+}
+
+.about-hero {
+  padding: 48px 40px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-primary), 0.18), transparent 45%),
+    rgba(var(--v-theme-surface), 0.8);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  backdrop-filter: blur(18px);
+}
+
+.about-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-primary), 0.12);
+  color: rgba(var(--v-theme-primary), 0.92);
+  margin-bottom: 20px;
+}
+
+.tracking-wide {
+  letter-spacing: 0.14em;
+}
+
+.about-section {
+  padding: 36px 32px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-surface-variant), 0.14), transparent 55%),
+    rgba(var(--v-theme-surface), 0.82);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  backdrop-filter: blur(16px);
+}
+
+.about-section--cards {
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 16px;
+}
+
+.about-mission-card {
+  padding: 20px 24px;
+  background: rgba(var(--v-theme-surface), 0.88);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.32);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.about-mission-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 36px -22px rgba(var(--v-theme-on-surface), 0.4);
+}
+
+.about-mission-card__icon {
+  background: rgba(var(--v-theme-primary), 0.14);
+  color: rgba(var(--v-theme-primary), 0.96);
+}
+
+.about-team-card {
+  height: 100%;
+  padding: 28px 24px;
+  background: rgba(var(--v-theme-surface), 0.88);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.32);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.about-team-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px -24px rgba(var(--v-theme-on-surface), 0.4);
+}
+
+.about-team-card__avatar {
+  background: rgba(var(--v-theme-secondary), 0.18);
+  color: rgba(var(--v-theme-secondary), 0.95);
+  font-weight: 600;
+}
+
+.about-chip {
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.about-chip--outlined {
+  border-color: rgba(var(--v-theme-primary), 0.35);
+  background: rgba(var(--v-theme-primary), 0.08);
+}
+
+.about-timeline {
+  padding-block: 8px;
+}
+
+.about-timeline-card {
+  padding: 24px 22px;
+  background: rgba(var(--v-theme-surface), 0.88);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.32);
+}
+
+.about-link {
+  border-color: rgba(var(--v-theme-primary), 0.4) !important;
+  background: rgba(var(--v-theme-surface), 0.85);
+}
+
+@media (max-width: 1280px) {
+  .about-section {
+    padding: 28px 24px;
+  }
 }
 
 @media (max-width: 960px) {
-  main {
-    padding-block: 48px;
+  main.about-page {
+    padding-block: 60px;
+  }
+
+  .about-hero {
+    padding: 36px 28px;
   }
 }
 </style>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -1,36 +1,55 @@
 <template>
   <main
-    class="py-12"
+    class="contact-page py-12"
     aria-labelledby="contact-heading"
   >
-    <v-container>
+    <v-container class="contact-container">
       <v-row
-        class="align-stretch"
+        class="align-stretch contact-layout"
         dense
       >
         <v-col
           cols="12"
           md="6"
         >
-          <article
-            class="mb-8"
-            aria-describedby="contact-intro"
+          <v-sheet
+            class="contact-panel contact-panel--primary"
+            elevation="0"
+            rounded="xl"
           >
-            <h1
-              id="contact-heading"
-              class="text-h3 font-weight-bold mb-3"
+            <article
+              class="mb-8"
+              aria-describedby="contact-intro"
             >
-              {{ t("pages.contact.title") }}
-            </h1>
-            <p
-              id="contact-intro"
-              class="text-body-1 text-medium-emphasis mb-6"
-            >
-              {{ t("pages.contact.subtitle") }}
-            </p>
-          </article>
+              <div class="contact-badge">
+                <v-icon
+                  icon="mdi-message-processing-outline"
+                  size="22"
+                  class="mr-2"
+                  aria-hidden="true"
+                />
+                <span class="text-caption font-weight-medium text-uppercase tracking-wide">
+                  {{ t("pages.contact.details.title") }}
+                </span>
+              </div>
+              <h1
+                id="contact-heading"
+                class="text-h3 font-weight-bold mb-3"
+              >
+                {{ t("pages.contact.title") }}
+              </h1>
+              <p
+                id="contact-intro"
+                class="text-body-1 text-medium-emphasis"
+              >
+                {{ t("pages.contact.subtitle") }}
+              </p>
+            </article>
 
-          <ContactForm />
+            <div class="contact-form-wrapper">
+              <ContactForm :show-heading="false" />
+            </div>
+          </v-sheet>
         </v-col>
 
         <v-col
@@ -38,58 +57,70 @@
           md="6"
         >
           <aside aria-labelledby="contact-support">
-            <section class="mb-8">
-              <h2
-                id="contact-support"
-                class="text-h5 font-weight-semibold mb-2"
-              >
-                {{ t("pages.contact.details.title") }}
-              </h2>
-              <p class="text-body-2 text-medium-emphasis">
-                {{ t("pages.contact.details.description") }}
-              </p>
-
-              <div class="d-flex flex-column gap-4 mt-5">
-                <v-card
-                  v-for="channel in supportChannels"
-                  :key="channel.title"
-                  variant="tonal"
-                  class="pa-4"
+            <v-sheet
+              class="contact-panel contact-panel--secondary mb-6"
+              elevation="0"
+              rounded="xl"
+            >
+              <section>
+                <h2
+                  id="contact-support"
+                  class="text-h5 font-weight-semibold mb-2"
                 >
-                  <div class="d-flex align-center mb-2">
-                    <v-icon
-                      :icon="channel.icon"
-                      size="28"
-                      class="mr-3"
-                      aria-hidden="true"
-                    />
-                    <h3 class="text-subtitle-1 font-weight-medium mb-0">
-                      {{ channel.title }}
-                    </h3>
-                  </div>
-                  <p class="text-body-2 text-medium-emphasis mb-4">
-                    {{ channel.description }}
-                  </p>
-                  <v-btn
-                    v-if="channel.href || channel.to"
-                    :href="channel.href"
-                    :to="channel.to"
-                    :target="channel.target"
-                    :rel="channel.rel"
-                    color="primary"
-                    variant="text"
-                    class="justify-start px-0"
-                    :aria-label="channel.ctaLabel"
-                  >
-                    {{ channel.cta }}
-                  </v-btn>
-                </v-card>
-              </div>
-            </section>
+                  {{ t("pages.contact.details.title") }}
+                </h2>
+                <p class="text-body-2 text-medium-emphasis">
+                  {{ t("pages.contact.details.description") }}
+                </p>
 
-            <section
-              class="pa-6 rounded-lg"
-              :class="availabilityClass"
+                <div class="d-flex flex-column gap-4 mt-6">
+                  <v-card
+                    v-for="channel in supportChannels"
+                    :key="channel.title"
+                    class="contact-channel"
+                    elevation="0"
+                    rounded="lg"
+                  >
+                    <div class="d-flex align-center mb-3">
+                      <v-avatar
+                        size="40"
+                        class="mr-3 contact-channel__icon"
+                      >
+                        <v-icon
+                          :icon="channel.icon"
+                          size="24"
+                          aria-hidden="true"
+                        />
+                      </v-avatar>
+                      <h3 class="text-subtitle-1 font-weight-medium mb-0">
+                        {{ channel.title }}
+                      </h3>
+                    </div>
+                    <p class="text-body-2 text-medium-emphasis mb-4">
+                      {{ channel.description }}
+                    </p>
+                    <v-btn
+                      v-if="channel.href || channel.to"
+                      :href="channel.href"
+                      :to="channel.to"
+                      :target="channel.target"
+                      :rel="channel.rel"
+                      color="primary"
+                      variant="text"
+                      class="justify-start px-0"
+                      :aria-label="channel.ctaLabel"
+                    >
+                      {{ channel.cta }}
+                    </v-btn>
+                  </v-card>
+                </div>
+              </section>
+            </v-sheet>
+
+            <v-sheet
+              class="contact-availability"
+              elevation="0"
+              rounded="xl"
               aria-labelledby="availability-title"
             >
               <h2
@@ -101,7 +132,7 @@
               <p class="text-body-2 text-medium-emphasis mb-0">
                 {{ t("pages.contact.availability.body") }}
               </p>
-            </section>
+            </v-sheet>
           </aside>
         </v-col>
       </v-row>
@@ -174,25 +205,108 @@ const supportChannels = computed(() => [
   },
 ]);
 
-const availabilityClass = computed(() => ["bg-surface-container-low", "elevation-1"]);
 </script>
 
 <style scoped>
-main {
-  background: linear-gradient(
-    180deg,
-    rgba(var(--v-theme-surface), 1) 0%,
-    rgba(var(--v-theme-surface-variant), 0.25) 100%
-  );
+main.contact-page {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(var(--v-theme-primary), 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(var(--v-theme-secondary), 0.1), transparent 60%),
+    linear-gradient(180deg, rgba(var(--v-theme-surface), 1) 0%, rgba(var(--v-theme-surface-variant), 0.2) 100%);
 }
 
-.bg-surface-container-low {
-  background-color: rgba(var(--v-theme-surface-container-low), 0.8);
+.contact-container {
+  position: relative;
+  z-index: 1;
+}
+
+.contact-layout {
+  row-gap: 32px;
+}
+
+.contact-panel {
+  height: 100%;
+  padding: 32px;
+  background: rgba(var(--v-theme-surface), 0.72);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.4);
+  backdrop-filter: blur(16px);
+  transition: box-shadow 200ms ease, transform 200ms ease;
+}
+
+.contact-panel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px -24px rgba(var(--v-theme-on-surface), 0.4);
+}
+
+.contact-panel--primary {
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-primary), 0.12), transparent 35%),
+    rgba(var(--v-theme-surface), 0.82);
+}
+
+.contact-panel--secondary {
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-secondary), 0.12), transparent 45%),
+    rgba(var(--v-theme-surface), 0.78);
+}
+
+.contact-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-primary), 0.12);
+  color: rgba(var(--v-theme-primary), 0.9);
+  margin-bottom: 20px;
+}
+
+.tracking-wide {
+  letter-spacing: 0.14em;
+}
+
+.contact-form-wrapper {
+  padding: 24px;
+  border-radius: 24px;
+  background: rgba(var(--v-theme-surface-container-high), 0.65);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+}
+
+.contact-channel {
+  padding: 24px;
+  background: rgba(var(--v-theme-surface), 0.8);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.contact-channel:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 32px -18px rgba(var(--v-theme-on-surface), 0.35);
+}
+
+.contact-channel__icon {
+  background: rgba(var(--v-theme-primary), 0.12);
+  color: rgba(var(--v-theme-primary), 0.95);
+}
+
+.contact-availability {
+  padding: 28px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-tertiary), 0.16), transparent 55%),
+    rgba(var(--v-theme-surface), 0.86);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.4);
 }
 
 @media (max-width: 960px) {
-  aside {
-    margin-top: 32px;
+  main.contact-page {
+    padding-block: 64px;
+  }
+
+  .contact-panel,
+  .contact-form-wrapper,
+  .contact-availability {
+    padding: 24px;
   }
 }
 </style>

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -1,162 +1,219 @@
 <template>
   <main
-    class="py-12"
+    class="help-page py-12"
     aria-labelledby="help-heading"
   >
-    <v-container>
+    <v-container class="help-container">
       <section
-        class="mb-8"
+        class="help-hero mb-10"
         aria-describedby="help-subtitle"
       >
-        <h1
-          id="help-heading"
-          class="text-h3 font-weight-bold mb-3"
+        <v-sheet
+          class="help-hero__surface"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.help.title") }}
-        </h1>
-        <p
-          id="help-subtitle"
-          class="text-body-1 text-medium-emphasis mb-6"
-        >
-          {{ t("pages.help.subtitle") }}
-        </p>
-        <v-text-field
-          v-model="query"
-          :label="t('pages.help.searchPlaceholder')"
-          prepend-inner-icon="mdi-magnify"
-          variant="outlined"
-          density="comfortable"
-          clearable
-          data-test="faq-search"
-          aria-describedby="help-faq"
-        />
+          <div class="help-hero__header">
+            <div class="help-hero__badge">
+              <v-icon
+                icon="mdi-lifebuoy"
+                size="22"
+                class="mr-2"
+                aria-hidden="true"
+              />
+              <span class="text-caption font-weight-medium text-uppercase tracking-wide">
+                {{ t("pages.help.quickLinksTitle") }}
+              </span>
+            </div>
+            <h1
+              id="help-heading"
+              class="text-h3 font-weight-bold mb-3"
+            >
+              {{ t("pages.help.title") }}
+            </h1>
+            <p
+              id="help-subtitle"
+              class="text-body-1 text-medium-emphasis"
+            >
+              {{ t("pages.help.subtitle") }}
+            </p>
+          </div>
+
+          <div class="help-hero__search">
+            <v-text-field
+              v-model="query"
+              :label="t('pages.help.searchPlaceholder')"
+              prepend-inner-icon="mdi-magnify"
+              variant="outlined"
+              density="comfortable"
+              clearable
+              data-test="faq-search"
+              aria-describedby="help-faq"
+            />
+            <v-chip
+              class="help-hero__count"
+              color="primary"
+              variant="tonal"
+              size="small"
+            >
+              {{ filteredFaq.length }}
+              {{
+                filteredFaq.length === 1
+                  ? t("pages.help.faqCountSingular")
+                  : t("pages.help.faqCountPlural")
+              }}
+            </v-chip>
+          </div>
+        </v-sheet>
       </section>
 
       <section
         class="mb-10"
         aria-labelledby="quick-actions"
       >
-        <h2
-          id="quick-actions"
-          class="text-h5 font-weight-semibold mb-4"
+        <v-sheet
+          class="help-actions"
+          elevation="0"
+          rounded="xl"
         >
-          {{ t("pages.help.quickLinksTitle") }}
-        </h2>
-        <v-row dense>
-          <v-col
-            v-for="action in actions"
-            :key="action.label"
-            cols="12"
-            md="4"
-          >
-            <v-card
-              class="pa-5 h-100"
-              elevation="4"
-              rounded="lg"
-            >
-              <div class="d-flex align-start mb-4">
-                <v-avatar
-                  color="primary"
-                  size="40"
-                  class="mr-3"
-                >
-                  <v-icon
-                    :icon="action.icon"
-                    aria-hidden="true"
-                  />
-                </v-avatar>
-                <div>
-                  <h3 class="text-subtitle-1 font-weight-semibold mb-1">
-                    {{ action.label }}
-                  </h3>
-                  <p class="text-body-2 text-medium-emphasis mb-0">
-                    {{ action.description }}
-                  </p>
-                </div>
-              </div>
-              <v-btn
-                :href="action.href"
-                :to="action.to"
-                :target="action.target"
-                :rel="action.rel"
-                color="primary"
-                variant="text"
-                class="justify-start px-0"
-                :aria-label="action.ariaLabel"
+          <div class="d-flex align-center justify-space-between flex-wrap gap-4 mb-6">
+            <div>
+              <h2
+                id="quick-actions"
+                class="text-h5 font-weight-semibold mb-1"
               >
-                {{ action.cta }}
-              </v-btn>
-            </v-card>
-          </v-col>
-        </v-row>
+                {{ t("pages.help.quickLinksTitle") }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-0">
+                {{ t("pages.help.subtitle") }}
+              </p>
+            </div>
+          </div>
+          <v-row
+            class="help-actions__row"
+            dense
+          >
+            <v-col
+              v-for="action in actions"
+              :key="action.label"
+              cols="12"
+              md="4"
+            >
+              <v-card
+                class="help-actions__card"
+                elevation="0"
+                rounded="lg"
+              >
+                <div class="d-flex align-start mb-4">
+                  <v-avatar
+                    class="help-actions__icon mr-3"
+                    size="42"
+                  >
+                    <v-icon
+                      :icon="action.icon"
+                      aria-hidden="true"
+                    />
+                  </v-avatar>
+                  <div>
+                    <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                      {{ action.label }}
+                    </h3>
+                    <p class="text-body-2 text-medium-emphasis mb-0">
+                      {{ action.description }}
+                    </p>
+                  </div>
+                </div>
+                <v-btn
+                  :href="action.href"
+                  :to="action.to"
+                  :target="action.target"
+                  :rel="action.rel"
+                  color="primary"
+                  variant="text"
+                  class="justify-start px-0"
+                  :aria-label="action.ariaLabel"
+                >
+                  {{ action.cta }}
+                </v-btn>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-sheet>
       </section>
 
       <section aria-labelledby="help-faq">
-        <div class="d-flex align-center justify-space-between mb-4">
-          <h2
-            id="help-faq"
-            class="text-h5 font-weight-semibold mb-0"
-          >
-            {{ t("pages.help.faqTitle") }}
-          </h2>
-          <span class="text-caption text-medium-emphasis">
-            {{ filteredFaq.length }}
-            {{
-              filteredFaq.length === 1
-                ? t("pages.help.faqCountSingular")
-                : t("pages.help.faqCountPlural")
-            }}
-          </span>
-        </div>
-
-        <v-expansion-panels
-          multiple
-          variant="accordion"
-          data-test="faq-panels"
+        <v-sheet
+          class="help-faq"
+          elevation="0"
+          rounded="xl"
         >
-          <template v-if="filteredFaq.length">
+          <div class="d-flex align-center justify-space-between flex-wrap gap-3 mb-4">
+            <h2
+              id="help-faq"
+              class="text-h5 font-weight-semibold mb-0"
+            >
+              {{ t("pages.help.faqTitle") }}
+            </h2>
+            <span class="text-caption text-medium-emphasis">
+              {{ filteredFaq.length }}
+              {{
+                filteredFaq.length === 1
+                  ? t("pages.help.faqCountSingular")
+                  : t("pages.help.faqCountPlural")
+              }}
+            </span>
+          </div>
+
+          <v-expansion-panels
+            class="help-faq__panels"
+            multiple
+            variant="accordion"
+            data-test="faq-panels"
+          >
+            <template v-if="filteredFaq.length">
+              <v-expansion-panel
+                v-for="item in filteredFaq"
+                :key="item.question"
+              >
+                <v-expansion-panel-title>
+                  <span class="font-weight-medium">{{ item.question }}</span>
+                </v-expansion-panel-title>
+                <v-expansion-panel-text>
+                  <p class="text-body-2 text-medium-emphasis mb-2">
+                    {{ item.answer }}
+                  </p>
+                  <ul
+                    v-if="item.links?.length"
+                    class="pl-4"
+                  >
+                    <li
+                      v-for="link in item.links"
+                      :key="link.href"
+                      class="text-body-2"
+                    >
+                      <a
+                        :href="link.href"
+                        :target="link.target"
+                        :rel="link.rel"
+                        class="text-primary"
+                      >
+                        {{ link.label }}
+                      </a>
+                    </li>
+                  </ul>
+                </v-expansion-panel-text>
+              </v-expansion-panel>
+            </template>
             <v-expansion-panel
-              v-for="item in filteredFaq"
-              :key="item.question"
+              v-else
+              disabled
             >
               <v-expansion-panel-title>
-                <span class="font-weight-medium">{{ item.question }}</span>
+                {{ t("pages.help.faqEmpty") }}
               </v-expansion-panel-title>
-              <v-expansion-panel-text>
-                <p class="text-body-2 text-medium-emphasis mb-2">
-                  {{ item.answer }}
-                </p>
-                <ul
-                  v-if="item.links?.length"
-                  class="pl-4"
-                >
-                  <li
-                    v-for="link in item.links"
-                    :key="link.href"
-                    class="text-body-2"
-                  >
-                    <a
-                      :href="link.href"
-                      :target="link.target"
-                      :rel="link.rel"
-                      class="text-primary"
-                    >
-                      {{ link.label }}
-                    </a>
-                  </li>
-                </ul>
-              </v-expansion-panel-text>
             </v-expansion-panel>
-          </template>
-          <v-expansion-panel
-            v-else
-            disabled
-          >
-            <v-expansion-panel-title>
-              {{ t("pages.help.faqEmpty") }}
-            </v-expansion-panel-title>
-          </v-expansion-panel>
-        </v-expansion-panels>
+          </v-expansion-panels>
+        </v-sheet>
       </section>
     </v-container>
   </main>
@@ -287,17 +344,137 @@ const filteredFaq = computed(() => {
 </script>
 
 <style scoped>
-main {
-  background: linear-gradient(
-    180deg,
-    rgba(var(--v-theme-surface), 1) 0%,
-    rgba(var(--v-theme-surface-variant), 0.2) 100%
-  );
+main.help-page {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top right, rgba(var(--v-theme-primary), 0.14), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(var(--v-theme-secondary), 0.12), transparent 60%),
+    linear-gradient(180deg, rgba(var(--v-theme-surface), 1) 0%, rgba(var(--v-theme-surface-variant), 0.18) 100%);
 }
 
-.v-card.h-100 {
+.help-container {
+  position: relative;
+  z-index: 1;
+}
+
+.help-hero__surface {
+  padding: 40px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-primary), 0.16), transparent 45%),
+    rgba(var(--v-theme-surface), 0.78);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  backdrop-filter: blur(16px);
+}
+
+.help-hero__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(var(--v-theme-primary), 0.12);
+  color: rgba(var(--v-theme-primary), 0.9);
+  margin-bottom: 20px;
+}
+
+.tracking-wide {
+  letter-spacing: 0.14em;
+}
+
+.help-hero__search {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-top: 24px;
+}
+
+.help-hero__search :deep(.v-field) {
+  background-color: rgba(var(--v-theme-surface), 0.85);
+}
+
+.help-hero__count {
+  font-weight: 600;
+}
+
+.help-actions {
+  padding: 36px 32px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-secondary), 0.16), transparent 45%),
+    rgba(var(--v-theme-surface), 0.82);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  backdrop-filter: blur(14px);
+}
+
+.help-actions__row {
+  row-gap: 24px;
+}
+
+.help-actions__card {
+  height: 100%;
+  padding: 28px 24px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  background: rgba(var(--v-theme-surface), 0.85);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.help-actions__card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 40px -22px rgba(var(--v-theme-on-surface), 0.4);
+}
+
+.help-actions__icon {
+  background: rgba(var(--v-theme-primary), 0.12);
+  color: rgba(var(--v-theme-primary), 0.95);
+}
+
+.help-faq {
+  padding: 36px 32px;
+  background:
+    linear-gradient(135deg, rgba(var(--v-theme-tertiary), 0.15), transparent 55%),
+    rgba(var(--v-theme-surface), 0.84);
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.35);
+  backdrop-filter: blur(14px);
+}
+
+.help-faq__panels {
+  background: transparent;
+}
+
+.help-faq__panels :deep(.v-expansion-panel) {
+  border-radius: 18px;
+  margin-bottom: 12px;
+  border: 1px solid rgba(var(--v-theme-outline-variant), 0.28);
+  background: rgba(var(--v-theme-surface), 0.92);
+}
+
+.help-faq__panels :deep(.v-expansion-panel-title) {
+  padding: 18px 24px;
+}
+
+.help-faq__panels :deep(.v-expansion-panel-text__wrapper) {
+  padding: 0 24px 20px;
+}
+
+@media (max-width: 1024px) {
+  .help-hero__surface,
+  .help-actions,
+  .help-faq {
+    padding: 28px 24px;
+  }
+}
+
+@media (max-width: 600px) {
+  main.help-page {
+    padding-block: 60px;
+  }
+
+  .help-hero__search {
+    flex-direction: column;
+    align-items: stretch;
+  }
 }
 </style>

--- a/tests/e2e/ContactForm.spec.ts
+++ b/tests/e2e/ContactForm.spec.ts
@@ -5,16 +5,13 @@ import { createI18n } from "vue-i18n";
 import ContactForm from "~/components/contact/ContactForm.vue";
 import en from "~/i18n/locales/en.json";
 
-const toastMock = vi.fn();
+const notifyMock = vi.fn();
 const fetchMock = vi.fn();
-
-vi.mock("~/components/content/common/toast", () => ({
-  toast: (...args: unknown[]) => toastMock(...args),
-}));
 
 vi.mock("#app", () => ({
   useNuxtApp: () => ({
     $fetch: (...args: unknown[]) => fetchMock(...args),
+    $notify: (...args: unknown[]) => notifyMock(...args),
   }),
 }));
 
@@ -33,7 +30,7 @@ const i18n = createI18n({
 
 describe("ContactForm", () => {
   beforeEach(() => {
-    toastMock.mockClear();
+    notifyMock.mockClear();
     fetchMock.mockReset();
   });
 
@@ -66,9 +63,10 @@ describe("ContactForm", () => {
       },
       method: "POST",
     });
-    expect(toastMock).toHaveBeenCalledWith({
-      description: en.pages.contact.form.success,
+    expect(notifyMock).toHaveBeenCalledWith({
+      message: en.pages.contact.form.success,
       title: en.pages.contact.title,
+      type: "success",
     });
 
     expect((wrapper.find('[data-test="name-field"] input').element as HTMLInputElement).value).toBe(


### PR DESCRIPTION
## Summary
- redesign the contact page with hero styling, glass panels, and updated support cards
- refresh the help page search hero, quick actions, and FAQ panels for a cohesive look
- restyle the about page sections with gradient surfaces, timeline cards, and enhanced resource links
- add an option to hide the contact form heading and align the test suite with the $notify toast helper

## Testing
- pnpm vitest run tests/e2e/ContactForm.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc7be134ec8326be14914afa92f48f