### PR TITLE
feat: add industry landing pages

### DIFF
--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -44,7 +44,10 @@
         "adminBlog": "المدونة",
         "help": "المساعدة",
         "about": "حول",
-        "contact": "اتصال"
+        "contact": "اتصال",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -1013,6 +1016,238 @@
           "formFieldsDescription": "Composable wrapper showing labels, hints, errors, and nested controls."
         }
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "seo": {
@@ -1047,6 +1282,22 @@
     "profileSecurity": {
       "title": "Password & security",
       "description": "Manage sign-in credentials, two-factor authentication, and trusted devices."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1213,25 +1464,41 @@
           "content": {
             "title": "إدارة المحتوى",
             "description": "خطط للمقالات والفعاليات والموارد التعليمية وانشرها أو أرشفها.",
-            "tags": ["سير عمل تحريري", "مراجعة", "جدولة"],
+            "tags": [
+              "سير عمل تحريري",
+              "مراجعة",
+              "جدولة"
+            ],
             "status": "هناك 12 عنصراً بحاجة إلى مراجعة تحريرية."
           },
           "community": {
             "title": "المجتمع والإشراف",
             "description": "اضبط قواعد الإشراف وتابع البلاغات والعقوبات.",
-            "tags": ["بلاغات", "عقوبات", "رسائل خاصة"],
+            "tags": [
+              "بلاغات",
+              "عقوبات",
+              "رسائل خاصة"
+            ],
             "status": "متوسط وقت الاستجابة: ساعة و42 دقيقة."
           },
           "commerce": {
             "title": "الربحية والعروض",
             "description": "أدر الاشتراكات والرموز الترويجية والشراكات التجارية.",
-            "tags": ["اشتراكات", "فوترة", "قسائم"],
+            "tags": [
+              "اشتراكات",
+              "فوترة",
+              "قسائم"
+            ],
             "status": "ارتفع معدل التحويل بنسبة 3.4٪ هذا الأسبوع."
           },
           "governance": {
             "title": "الحوكمة والامتثال",
             "description": "دقق صلاحيات الوصول، أدر الأدوار الحساسة وجهّز تقارير الامتثال.",
-            "tags": ["تدقيق", "أدوار", "تتبع"],
+            "tags": [
+              "تدقيق",
+              "أدوار",
+              "تتبع"
+            ],
             "status": "آخر تدقيق شامل تم قبل 5 أيام."
           }
         }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -44,7 +44,10 @@
         "adminBlog": "Blog",
         "help": "Hilfe",
         "about": "Über uns",
-        "contact": "Kontakt"
+        "contact": "Kontakt",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -1011,6 +1014,238 @@
           "formFieldsDescription": "Composable wrapper showing labels, hints, errors, and nested controls."
         }
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "seo": {
@@ -1045,6 +1280,22 @@
     "profileSecurity": {
       "title": "Passwort & Sicherheit",
       "description": "Verwalte Anmeldedaten, Zwei-Faktor-Authentifizierung und vertrauenswürdige Geräte."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1211,25 +1462,41 @@
           "content": {
             "title": "Content-Management",
             "description": "Planen, veröffentlichen und archivieren Sie Artikel, Events und Lernressourcen.",
-            "tags": ["Redaktions-Workflow", "Freigabe", "Terminplanung"],
+            "tags": [
+              "Redaktions-Workflow",
+              "Freigabe",
+              "Terminplanung"
+            ],
             "status": "12 Inhalte erfordern eine redaktionelle Prüfung."
           },
           "community": {
             "title": "Community & Moderation",
             "description": "Konfigurieren Sie Moderationsregeln, verwalten Sie Meldungen und Sanktionen.",
-            "tags": ["Meldungen", "Sanktionen", "Private Nachrichten"],
+            "tags": [
+              "Meldungen",
+              "Sanktionen",
+              "Private Nachrichten"
+            ],
             "status": "Durchschnittliche Reaktionszeit: 1 h 42."
           },
           "commerce": {
             "title": "Monetarisierung & Angebote",
             "description": "Verwalten Sie Abonnements, Promo-Codes und Geschäftspartnerschaften.",
-            "tags": ["Abonnements", "Abrechnung", "Gutscheine"],
+            "tags": [
+              "Abonnements",
+              "Abrechnung",
+              "Gutscheine"
+            ],
             "status": "Konversionsrate diese Woche um 3,4 % gestiegen."
           },
           "governance": {
             "title": "Governance & Compliance",
             "description": "Prüfen Sie Zugriffe, verwalten Sie privilegierte Rollen und erstellen Sie Compliance-Berichte.",
-            "tags": ["Audit", "Rollen", "Nachverfolgbarkeit"],
+            "tags": [
+              "Audit",
+              "Rollen",
+              "Nachverfolgbarkeit"
+            ],
             "status": "Letztes vollständiges Audit vor 5 Tagen abgeschlossen."
           }
         }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -32,6 +32,9 @@
         "calendar": "Calendar",
         "cv": "CV",
         "jobs": "Jobs",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education",
         "profile": "Profile",
         "profileOverview": "Overview",
         "profileSettings": "Account settings",
@@ -526,6 +529,238 @@
         "githubAria": "Open the GitHub repository in a new tab",
         "docsAria": "Read the documentation in a new tab",
         "communityAria": "Join the community forum in a new tab"
+      }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
       }
     },
     "help": {
@@ -1045,6 +1280,22 @@
     "profileSecurity": {
       "title": "Password & security",
       "description": "Manage sign-in credentials, two-factor authentication, and trusted devices."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1211,25 +1462,41 @@
           "content": {
             "title": "Content management",
             "description": "Plan, publish, and archive articles, events, and learning resources.",
-            "tags": ["Editorial workflow", "Review", "Scheduling"],
+            "tags": [
+              "Editorial workflow",
+              "Review",
+              "Scheduling"
+            ],
             "status": "12 items require editorial review."
           },
           "community": {
             "title": "Community & moderation",
             "description": "Configure moderation rules, manage reports, and handle sanctions.",
-            "tags": ["Reports", "Sanctions", "Private messages"],
+            "tags": [
+              "Reports",
+              "Sanctions",
+              "Private messages"
+            ],
             "status": "Average response time: 1h42."
           },
           "commerce": {
             "title": "Monetization & offers",
             "description": "Manage subscriptions, promo codes, and commercial partnerships.",
-            "tags": ["Subscriptions", "Billing", "Coupons"],
+            "tags": [
+              "Subscriptions",
+              "Billing",
+              "Coupons"
+            ],
             "status": "Conversion rate up by 3.4% this week."
           },
           "governance": {
             "title": "Governance & compliance",
             "description": "Audit access, manage privileged roles, and prepare compliance reports.",
-            "tags": ["Audit", "Roles", "Traceability"],
+            "tags": [
+              "Audit",
+              "Roles",
+              "Traceability"
+            ],
             "status": "Last full audit completed 5 days ago."
           }
         }

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -44,7 +44,10 @@
         "adminBlog": "Blog",
         "help": "Ayuda",
         "about": "Acerca de",
-        "contact": "Contacto"
+        "contact": "Contacto",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -531,6 +534,238 @@
           "formFieldsDescription": "Composable wrapper showing labels, hints, errors, and nested controls."
         }
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "auth": {
@@ -871,6 +1106,22 @@
     "profileSecurity": {
       "title": "Contraseña y seguridad",
       "description": "Administra credenciales de acceso, verificación en dos pasos y dispositivos de confianza."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1037,25 +1288,41 @@
           "content": {
             "title": "Gestión de contenido",
             "description": "Planifica, publica y archiva artículos, eventos y recursos formativos.",
-            "tags": ["Flujo editorial", "Validación", "Programación"],
+            "tags": [
+              "Flujo editorial",
+              "Validación",
+              "Programación"
+            ],
             "status": "12 contenidos requieren revisión editorial."
           },
           "community": {
             "title": "Comunidad y moderación",
             "description": "Configura las reglas de moderación, gestiona reportes y sanciones.",
-            "tags": ["Reportes", "Sanciones", "Mensajes privados"],
+            "tags": [
+              "Reportes",
+              "Sanciones",
+              "Mensajes privados"
+            ],
             "status": "Tiempo medio de respuesta: 1 h 42."
           },
           "commerce": {
             "title": "Monetización y ofertas",
             "description": "Administra suscripciones, códigos promocionales y alianzas comerciales.",
-            "tags": ["Suscripciones", "Facturación", "Cupones"],
+            "tags": [
+              "Suscripciones",
+              "Facturación",
+              "Cupones"
+            ],
             "status": "La tasa de conversión subió un 3,4% esta semana."
           },
           "governance": {
             "title": "Gobernanza y cumplimiento",
             "description": "Audita accesos, gestiona roles privilegiados y prepara informes de cumplimiento.",
-            "tags": ["Auditoría", "Roles", "Trazabilidad"],
+            "tags": [
+              "Auditoría",
+              "Roles",
+              "Trazabilidad"
+            ],
             "status": "Última auditoría completa realizada hace 5 días."
           }
         }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -32,6 +32,9 @@
         "calendar": "Calendrier",
         "cv": "CV",
         "jobs": "Emplois",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Éducation",
         "profile": "Profil",
         "profileOverview": "Vue d'ensemble",
         "profileSettings": "Paramètres du compte",
@@ -830,6 +833,238 @@
         "body": "Notre équipe distribuée surveille les demandes du lundi au vendredi et assure une rotation le week-end pour les urgences."
       }
     },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
+    },
     "playground": {
       "ui": {
         "title": "UI Component Playground",
@@ -1045,6 +1280,22 @@
     "profileSecurity": {
       "title": "Mot de passe et sécurité",
       "description": "Gérez vos identifiants de connexion, l'authentification à deux facteurs et les appareils de confiance."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Éducation",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1211,25 +1462,41 @@
           "content": {
             "title": "Gestion du contenu",
             "description": "Planifiez, publiez et archivez les articles, événements et ressources pédagogiques.",
-            "tags": ["Workflow éditorial", "Validation", "Programmation"],
+            "tags": [
+              "Workflow éditorial",
+              "Validation",
+              "Programmation"
+            ],
             "status": "12 contenus nécessitent une revue éditoriale."
           },
           "community": {
             "title": "Communauté & modération",
             "description": "Paramétrez les règles de modération, gérez les signalements et les sanctions.",
-            "tags": ["Signalements", "Sanctions", "Messages privés"],
+            "tags": [
+              "Signalements",
+              "Sanctions",
+              "Messages privés"
+            ],
             "status": "Temps moyen de réponse : 1 h 42."
           },
           "commerce": {
             "title": "Monétisation & offres",
             "description": "Administrez les abonnements, codes promotionnels et partenariats commerciaux.",
-            "tags": ["Abonnements", "Facturation", "Coupons"],
+            "tags": [
+              "Abonnements",
+              "Facturation",
+              "Coupons"
+            ],
             "status": "Taux de conversion en hausse de 3,4 % cette semaine."
           },
           "governance": {
             "title": "Gouvernance & conformité",
             "description": "Auditez les accès, gérez les rôles sensibles et préparez les rapports de conformité.",
-            "tags": ["Audit", "Rôles", "Traçabilité"],
+            "tags": [
+              "Audit",
+              "Rôles",
+              "Traçabilité"
+            ],
             "status": "Dernier audit complet réalisé il y a 5 jours."
           }
         }

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -44,7 +44,10 @@
         "adminBlog": "Blog",
         "help": "Aiuto",
         "about": "Informazioni",
-        "contact": "Contatti"
+        "contact": "Contatti",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -531,6 +534,238 @@
           "formFieldsDescription": "Composable wrapper showing labels, hints, errors, and nested controls."
         }
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "auth": {
@@ -871,6 +1106,22 @@
     "profileSecurity": {
       "title": "Password & security",
       "description": "Manage sign-in credentials, two-factor authentication, and trusted devices."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1037,25 +1288,41 @@
           "content": {
             "title": "Gestione dei contenuti",
             "description": "Pianifica, pubblica e archivia articoli, eventi e risorse formative.",
-            "tags": ["Workflow editoriale", "Validazione", "Programmazione"],
+            "tags": [
+              "Workflow editoriale",
+              "Validazione",
+              "Programmazione"
+            ],
             "status": "12 contenuti richiedono una revisione editoriale."
           },
           "community": {
             "title": "Community e moderazione",
             "description": "Configura le regole di moderazione, gestisci segnalazioni e sanzioni.",
-            "tags": ["Segnalazioni", "Sanzioni", "Messaggi privati"],
+            "tags": [
+              "Segnalazioni",
+              "Sanzioni",
+              "Messaggi privati"
+            ],
             "status": "Tempo medio di risposta: 1 h 42."
           },
           "commerce": {
             "title": "Monetizzazione e offerte",
             "description": "Gestisci abbonamenti, codici promozionali e partnership commerciali.",
-            "tags": ["Abbonamenti", "Fatturazione", "Coupon"],
+            "tags": [
+              "Abbonamenti",
+              "Fatturazione",
+              "Coupon"
+            ],
             "status": "Tasso di conversione in aumento del 3,4% questa settimana."
           },
           "governance": {
             "title": "Governance e conformità",
             "description": "Verifica gli accessi, gestisci i ruoli sensibili e prepara i report di conformità.",
-            "tags": ["Audit", "Ruoli", "Tracciabilità"],
+            "tags": [
+              "Audit",
+              "Ruoli",
+              "Tracciabilità"
+            ],
             "status": "Ultimo audit completo effettuato 5 giorni fa."
           }
         }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -44,7 +44,10 @@
         "adminBlog": "Блог",
         "help": "Помощь",
         "about": "О нас",
-        "contact": "Контакты"
+        "contact": "Контакты",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -531,6 +534,238 @@
           "formFieldsDescription": "Composable wrapper showing labels, hints, errors, and nested controls."
         }
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "auth": {
@@ -871,6 +1106,22 @@
     "profileSecurity": {
       "title": "Password & security",
       "description": "Manage sign-in credentials, two-factor authentication, and trusted devices."
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -1037,25 +1288,41 @@
           "content": {
             "title": "Управление контентом",
             "description": "Планируйте, публикуйте и архивируйте статьи, события и обучающие материалы.",
-            "tags": ["Редакционный процесс", "Проверка", "Планирование"],
+            "tags": [
+              "Редакционный процесс",
+              "Проверка",
+              "Планирование"
+            ],
             "status": "12 материалов требуют редакционной проверки."
           },
           "community": {
             "title": "Сообщество и модерация",
             "description": "Настраивайте правила модерации, управляйте жалобами и санкциями.",
-            "tags": ["Жалобы", "Санкции", "Личные сообщения"],
+            "tags": [
+              "Жалобы",
+              "Санкции",
+              "Личные сообщения"
+            ],
             "status": "Среднее время ответа: 1 ч 42."
           },
           "commerce": {
             "title": "Монетизация и предложения",
             "description": "Управляйте подписками, промокодами и коммерческими партнёрствами.",
-            "tags": ["Подписки", "Выставление счетов", "Купоны"],
+            "tags": [
+              "Подписки",
+              "Выставление счетов",
+              "Купоны"
+            ],
             "status": "Конверсия выросла на 3,4% за эту неделю."
           },
           "governance": {
             "title": "Говернанс и соответствие",
             "description": "Проводите аудит доступа, управляйте привилегированными ролями и готовьте отчёты по соответствию.",
-            "tags": ["Аудит", "Роли", "Трассируемость"],
+            "tags": [
+              "Аудит",
+              "Роли",
+              "Трассируемость"
+            ],
             "status": "Последний полный аудит выполнен 5 дней назад."
           }
         }

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -44,7 +44,10 @@
         "adminBlog": "博客",
         "help": "帮助",
         "about": "关于",
-        "contact": "联系"
+        "contact": "联系",
+        "game": "Gaming",
+        "ecommerce": "E-commerce",
+        "education": "Education"
       }
     },
     "widgets": {
@@ -647,6 +650,238 @@
       "recoveryCodes": {
         "title": "Store these one-time recovery codes"
       }
+    },
+    "job": {
+      "title": "Jobs",
+      "subtitle": "Centralise every step of your recruiting funnel to move from sourcing to signing with clarity.",
+      "featuresTitle": "Build a confident hiring pipeline",
+      "features": {
+        "matching": {
+          "title": "Spot the right talent faster",
+          "description": "Aggregate sourcing activity and prioritise applicants automatically.",
+          "points": [
+            "Sync job boards, referrals, and internal mobility into one view.",
+            "Score applications with configurable criteria and bias safeguards.",
+            "Highlight talent pools ready for nurture or re-engagement."
+          ]
+        },
+        "automation": {
+          "title": "Automate team coordination",
+          "description": "Give recruiters, interviewers, and hiring managers a shared command centre.",
+          "points": [
+            "Trigger interview kits and reminders in the right timezone.",
+            "Share structured feedback templates that surface signal over noise.",
+            "Notify stakeholders the moment a candidate advances or stalls."
+          ]
+        },
+        "insights": {
+          "title": "Measure hiring impact",
+          "description": "Understand conversion, velocity, and quality without exporting spreadsheets.",
+          "points": [
+            "Track time-to-fill, diversity ratios, and offer acceptance in real time.",
+            "Visualise bottlenecks across regions or job families instantly.",
+            "Share live dashboards with leadership and partners securely."
+          ]
+        }
+      },
+      "workflowTitle": "Your hiring rhythm, visualised",
+      "workflow": {
+        "steps": {
+          "publish": {
+            "title": "Publish with confidence",
+            "description": "Launch branded job pages and syndicated listings with reusable templates."
+          },
+          "review": {
+            "title": "Review together",
+            "description": "Collaborate on feedback, calibrate scorecards, and keep the loop accountable."
+          },
+          "hire": {
+            "title": "Hire and onboard",
+            "description": "Secure approvals, generate offers, and pass context to onboarding seamlessly."
+          }
+        }
+      },
+      "stepLabel": "Step {number}",
+      "cta": {
+        "title": "Design a hiring experience candidates love",
+        "description": "Let our team help you tailor BroWorld to your recruitment stack, processes, and compliance needs.",
+        "button": "Talk to us",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "game": {
+      "title": "Gaming",
+      "subtitle": "Launch vibrant player communities, live events, and monetisation loops without extra engineering time.",
+      "featuresTitle": "Level up every player journey",
+      "features": {
+        "community": {
+          "title": "Build communities that stay",
+          "description": "Host news, patch notes, and discussions with built-in moderation controls.",
+          "points": [
+            "Curate seasonal hubs that adapt to each franchise or guild.",
+            "Reward loyal fans with badges, drops, and cross-game progression.",
+            "Localise experiences with one click for global launches."
+          ]
+        },
+        "monetization": {
+          "title": "Unlock sustainable revenue",
+          "description": "Experiment with stores, battle passes, and bundles in a safe sandbox.",
+          "points": [
+            "Configure limited-time offers and track conversion instantly.",
+            "Integrate multiple payment providers and entitlement systems.",
+            "Balance in-game economies with configurable guardrails."
+          ]
+        },
+        "events": {
+          "title": "Orchestrate unforgettable events",
+          "description": "Coordinate tournaments, live ops, and creator collaborations effortlessly.",
+          "points": [
+            "Schedule announcements, streams, and drops in a unified timeline.",
+            "Share production checklists and asset packs with internal teams.",
+            "Track sentiment and uptime to react before the hype dips."
+          ]
+        }
+      },
+      "workflowTitle": "Plan, launch, and grow",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype your experience, test with closed groups, and ship with guardrails."
+          },
+          "engage": {
+            "title": "Engage",
+            "description": "Deliver live updates, challenges, and quests that feel fresh every session."
+          },
+          "grow": {
+            "title": "Grow",
+            "description": "Analyse cohorts, expand to new platforms, and activate creators responsibly."
+          }
+        }
+      },
+      "stepLabel": "Stage {number}",
+      "cta": {
+        "title": "Ship the next fan-favourite season",
+        "description": "We partner with studios of every size to streamline community, monetisation, and live ops management.",
+        "button": "Plan a demo",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "subtitle": "Craft immersive storefronts, orchestrate fulfilment, and personalise campaigns across every channel.",
+      "featuresTitle": "Modern retail, one toolkit",
+      "features": {
+        "catalog": {
+          "title": "Unify your catalogue",
+          "description": "Manage product variants, rich storytelling, and merchandising in one workspace.",
+          "points": [
+            "Support digital, physical, and subscription products side by side.",
+            "Optimise imagery, copy, and translations with collaborative reviews.",
+            "Launch curated collections with scheduling and inventory safeguards."
+          ]
+        },
+        "checkout": {
+          "title": "Delight at checkout",
+          "description": "Reduce friction with fast, accessible, and trusted purchase flows.",
+          "points": [
+            "Offer local payments, wallets, and instalments without custom code.",
+            "Embed fraud checks, taxes, and duties that scale globally.",
+            "Give support teams live context to resolve orders instantly."
+          ]
+        },
+        "marketing": {
+          "title": "Personalise every campaign",
+          "description": "Coordinate lifecycle messaging, loyalty, and analytics together.",
+          "points": [
+            "Segment audiences with zero-party and behavioural data respectfully.",
+            "Trigger automations tied to launches, restocks, and VIP moments.",
+            "Attribute revenue accurately with multi-touch insights."
+          ]
+        }
+      },
+      "workflowTitle": "From concept to scale",
+      "workflow": {
+        "steps": {
+          "launch": {
+            "title": "Launch",
+            "description": "Prototype storefronts, test merchandising, and go live confidently."
+          },
+          "optimize": {
+            "title": "Optimise",
+            "description": "Iterate on conversion, retention, and operations with actionable insights."
+          },
+          "scale": {
+            "title": "Scale",
+            "description": "Expand to new regions, channels, and partnerships with built-in governance."
+          }
+        }
+      },
+      "stepLabel": "Phase {number}",
+      "cta": {
+        "title": "Transform your retail roadmap",
+        "description": "Explore how BroWorld adapts to your commerce stack, fulfilment partners, and customer promises.",
+        "button": "Connect with sales",
+        "buttonAria": "Open the contact page"
+      }
+    },
+    "education": {
+      "title": "Education",
+      "subtitle": "Empower instructors, learners, and administrators with collaborative, data-informed experiences.",
+      "featuresTitle": "Create learning journeys that stick",
+      "features": {
+        "curriculum": {
+          "title": "Design inclusive curriculum",
+          "description": "Author courses, micro-learning paths, and certification programmes with ease.",
+          "points": [
+            "Reuse templates that balance synchronous and asynchronous learning.",
+            "Embed multimedia, assessments, and accessibility standards by default.",
+            "Localise content for cohorts across campuses or regions."
+          ]
+        },
+        "collaboration": {
+          "title": "Champion collaboration",
+          "description": "Connect faculty, mentors, and peers inside a secure digital campus.",
+          "points": [
+            "Coordinate mentorship, office hours, and cohort forums effortlessly.",
+            "Offer real-time feedback loops on assignments and projects.",
+            "Celebrate progress with badges, spotlights, and alumni pathways."
+          ]
+        },
+        "analytics": {
+          "title": "Act on meaningful analytics",
+          "description": "Surface insights that support retention, wellbeing, and accreditation goals.",
+          "points": [
+            "Monitor engagement signals to intervene before learners drift.",
+            "Share programme dashboards with leadership and accreditation boards.",
+            "Respect privacy with transparent controls and governance."
+          ]
+        }
+      },
+      "workflowTitle": "Guide every cohort",
+      "workflow": {
+        "steps": {
+          "design": {
+            "title": "Design",
+            "description": "Map learning outcomes, content, and assessment moments collaboratively."
+          },
+          "deliver": {
+            "title": "Deliver",
+            "description": "Host live and on-demand sessions, track attendance, and adapt in real time."
+          },
+          "reflect": {
+            "title": "Reflect",
+            "description": "Review impact, gather feedback, and iterate for the next intake."
+          }
+        }
+      },
+      "stepLabel": "Milestone {number}",
+      "cta": {
+        "title": "Elevate your learning ecosystem",
+        "description": "Partner with us to modernise programmes, student services, and alumni experiences.",
+        "button": "Schedule a consultation",
+        "buttonAria": "Open the contact page"
+      }
     }
   },
   "seo": {
@@ -669,6 +904,22 @@
     "profileSecurity": {
       "title": "密码与安全",
       "description": "管理登录凭据、双重验证以及受信任的设备。"
+    },
+    "job": {
+      "title": "Jobs",
+      "description": "Plan, track, and optimise hiring programmes."
+    },
+    "game": {
+      "title": "Gaming",
+      "description": "Deliver live game experiences, communities, and monetisation."
+    },
+    "ecommerce": {
+      "title": "E-commerce",
+      "description": "Launch and scale modern retail journeys."
+    },
+    "education": {
+      "title": "Education",
+      "description": "Design collaborative, data-informed learning experiences."
     }
   },
   "admin": {
@@ -835,25 +1086,41 @@
           "content": {
             "title": "内容管理",
             "description": "规划、发布与归档文章、活动以及学习资源。",
-            "tags": ["内容流程", "审核", "排期"],
+            "tags": [
+              "内容流程",
+              "审核",
+              "排期"
+            ],
             "status": "有12条内容等待编辑审核。"
           },
           "community": {
             "title": "社区与审核",
             "description": "配置审核规则，管理举报与处罚。",
-            "tags": ["举报", "处罚", "私信"],
+            "tags": [
+              "举报",
+              "处罚",
+              "私信"
+            ],
             "status": "平均响应时间：1小时42分。"
           },
           "commerce": {
             "title": "变现与优惠",
             "description": "管理订阅、优惠码和商业合作。",
-            "tags": ["订阅", "计费", "优惠券"],
+            "tags": [
+              "订阅",
+              "计费",
+              "优惠券"
+            ],
             "status": "本周转化率提升3.4%。"
           },
           "governance": {
             "title": "治理与合规",
             "description": "审计访问权限，管理敏感角色并准备合规报告。",
-            "tags": ["审计", "角色", "可追溯性"],
+            "tags": [
+              "审计",
+              "角色",
+              "可追溯性"
+            ],
             "status": "最近一次完整审计在5天前完成。"
           }
         }

--- a/lib/navigation/sidebar.ts
+++ b/lib/navigation/sidebar.ts
@@ -17,7 +17,10 @@ export function buildSidebarItems(canAccessAdmin: boolean): LayoutSidebarItem[] 
       to: "/",
     },
     { key: "cv", label: "layout.sidebar.items.cv", icon: "mdi-file-account", to: "/" },
-    { key: "jobs", label: "layout.sidebar.items.jobs", icon: "mdi-briefcase-search", to: "/" },
+    { key: "jobs", label: "layout.sidebar.items.jobs", icon: "mdi-briefcase-search", to: "/job" },
+    { key: "game", label: "layout.sidebar.items.game", icon: "mdi-gamepad-variant-outline", to: "/game" },
+    { key: "ecommerce", label: "layout.sidebar.items.ecommerce", icon: "mdi-shopping-outline", to: "/ecommerce" },
+    { key: "education", label: "layout.sidebar.items.education", icon: "mdi-school-outline", to: "/education" },
   ];
 
   items.push(

--- a/pages/ecommerce.vue
+++ b/pages/ecommerce.vue
@@ -1,0 +1,241 @@
+<template>
+  <main
+    class="py-12"
+    aria-labelledby="ecommerce-heading"
+  >
+    <v-container>
+      <section
+        class="text-center mb-12"
+        aria-describedby="ecommerce-subtitle"
+      >
+        <h1
+          id="ecommerce-heading"
+          class="text-h3 font-weight-bold mb-4"
+        >
+          {{ t("pages.ecommerce.title") }}
+        </h1>
+        <p
+          id="ecommerce-subtitle"
+          class="text-body-1 text-medium-emphasis mx-auto"
+          style="max-width: 640px"
+        >
+          {{ t("pages.ecommerce.subtitle") }}
+        </p>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="ecommerce-features-title"
+      >
+        <h2
+          id="ecommerce-features-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.ecommerce.featuresTitle") }}
+        </h2>
+        <v-row dense>
+          <v-col
+            v-for="feature in featureCards"
+            :key="feature.title"
+            cols="12"
+            md="4"
+          >
+            <v-card
+              variant="tonal"
+              class="pa-6 h-100"
+            >
+              <div class="d-flex align-start mb-4">
+                <v-avatar
+                  color="primary"
+                  size="48"
+                  class="mr-4"
+                >
+                  <v-icon
+                    :icon="feature.icon"
+                    size="28"
+                    color="white"
+                    aria-hidden="true"
+                  />
+                </v-avatar>
+                <div>
+                  <h3 class="text-subtitle-1 font-weight-semibold mb-2">
+                    {{ feature.title }}
+                  </h3>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ feature.description }}
+                  </p>
+                </div>
+              </div>
+              <ul class="pl-6 text-body-2 text-medium-emphasis mb-0">
+                <li
+                  v-for="point in feature.points"
+                  :key="point"
+                  class="mb-1"
+                >
+                  {{ point }}
+                </li>
+              </ul>
+            </v-card>
+          </v-col>
+        </v-row>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="ecommerce-workflow-title"
+      >
+        <h2
+          id="ecommerce-workflow-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.ecommerce.workflowTitle") }}
+        </h2>
+        <ol class="d-flex flex-column gap-4 list-none pa-0">
+          <li
+            v-for="(step, index) in workflowSteps"
+            :key="step.title"
+          >
+            <v-sheet
+              class="pa-6 rounded-lg d-flex align-start"
+              color="surface-variant"
+              variant="tonal"
+            >
+              <div
+                class="d-flex align-center justify-center rounded-circle mr-4"
+                style="width: 40px; height: 40px"
+                :aria-label="t('pages.ecommerce.stepLabel', { number: index + 1 })"
+              >
+                <span class="text-subtitle-1 font-weight-semibold">{{ index + 1 }}</span>
+              </div>
+              <div>
+                <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                  {{ step.title }}
+                </h3>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ step.description }}
+                </p>
+              </div>
+            </v-sheet>
+          </li>
+        </ol>
+      </section>
+
+      <section aria-labelledby="ecommerce-cta-title">
+        <v-card
+          class="pa-8"
+          color="primary"
+          variant="flat"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div>
+              <h2
+                id="ecommerce-cta-title"
+                class="text-h4 font-weight-semibold text-white mb-2"
+              >
+                {{ t("pages.ecommerce.cta.title") }}
+              </h2>
+              <p class="text-body-1 text-white text-opacity-80 mb-0" style="max-width: 520px">
+                {{ t("pages.ecommerce.cta.description") }}
+              </p>
+            </div>
+            <v-btn
+              :to="contactLink"
+              color="white"
+              variant="flat"
+              size="large"
+              class="text-primary"
+              :aria-label="t('pages.ecommerce.cta.buttonAria')"
+            >
+              {{ t("pages.ecommerce.cta.button") }}
+            </v-btn>
+          </div>
+        </v-card>
+      </section>
+    </v-container>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+const localePath = useLocalePath();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.ecommerce.title");
+  const description = t("seo.ecommerce.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+const featureCards = computed(() => [
+  {
+    icon: "mdi-storefront-outline",
+    title: t("pages.ecommerce.features.catalog.title"),
+    description: t("pages.ecommerce.features.catalog.description"),
+    points: [
+      t("pages.ecommerce.features.catalog.points.0"),
+      t("pages.ecommerce.features.catalog.points.1"),
+      t("pages.ecommerce.features.catalog.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-credit-card-check-outline",
+    title: t("pages.ecommerce.features.checkout.title"),
+    description: t("pages.ecommerce.features.checkout.description"),
+    points: [
+      t("pages.ecommerce.features.checkout.points.0"),
+      t("pages.ecommerce.features.checkout.points.1"),
+      t("pages.ecommerce.features.checkout.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-bullhorn-outline",
+    title: t("pages.ecommerce.features.marketing.title"),
+    description: t("pages.ecommerce.features.marketing.description"),
+    points: [
+      t("pages.ecommerce.features.marketing.points.0"),
+      t("pages.ecommerce.features.marketing.points.1"),
+      t("pages.ecommerce.features.marketing.points.2"),
+    ],
+  },
+]);
+
+const workflowSteps = computed(() => [
+  {
+    title: t("pages.ecommerce.workflow.steps.launch.title"),
+    description: t("pages.ecommerce.workflow.steps.launch.description"),
+  },
+  {
+    title: t("pages.ecommerce.workflow.steps.optimize.title"),
+    description: t("pages.ecommerce.workflow.steps.optimize.description"),
+  },
+  {
+    title: t("pages.ecommerce.workflow.steps.scale.title"),
+    description: t("pages.ecommerce.workflow.steps.scale.description"),
+  },
+]);
+
+const contactLink = computed(() => localePath("/contact"));
+</script>

--- a/pages/education.vue
+++ b/pages/education.vue
@@ -1,0 +1,241 @@
+<template>
+  <main
+    class="py-12"
+    aria-labelledby="education-heading"
+  >
+    <v-container>
+      <section
+        class="text-center mb-12"
+        aria-describedby="education-subtitle"
+      >
+        <h1
+          id="education-heading"
+          class="text-h3 font-weight-bold mb-4"
+        >
+          {{ t("pages.education.title") }}
+        </h1>
+        <p
+          id="education-subtitle"
+          class="text-body-1 text-medium-emphasis mx-auto"
+          style="max-width: 640px"
+        >
+          {{ t("pages.education.subtitle") }}
+        </p>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="education-features-title"
+      >
+        <h2
+          id="education-features-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.education.featuresTitle") }}
+        </h2>
+        <v-row dense>
+          <v-col
+            v-for="feature in featureCards"
+            :key="feature.title"
+            cols="12"
+            md="4"
+          >
+            <v-card
+              variant="tonal"
+              class="pa-6 h-100"
+            >
+              <div class="d-flex align-start mb-4">
+                <v-avatar
+                  color="primary"
+                  size="48"
+                  class="mr-4"
+                >
+                  <v-icon
+                    :icon="feature.icon"
+                    size="28"
+                    color="white"
+                    aria-hidden="true"
+                  />
+                </v-avatar>
+                <div>
+                  <h3 class="text-subtitle-1 font-weight-semibold mb-2">
+                    {{ feature.title }}
+                  </h3>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ feature.description }}
+                  </p>
+                </div>
+              </div>
+              <ul class="pl-6 text-body-2 text-medium-emphasis mb-0">
+                <li
+                  v-for="point in feature.points"
+                  :key="point"
+                  class="mb-1"
+                >
+                  {{ point }}
+                </li>
+              </ul>
+            </v-card>
+          </v-col>
+        </v-row>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="education-workflow-title"
+      >
+        <h2
+          id="education-workflow-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.education.workflowTitle") }}
+        </h2>
+        <ol class="d-flex flex-column gap-4 list-none pa-0">
+          <li
+            v-for="(step, index) in workflowSteps"
+            :key="step.title"
+          >
+            <v-sheet
+              class="pa-6 rounded-lg d-flex align-start"
+              color="surface-variant"
+              variant="tonal"
+            >
+              <div
+                class="d-flex align-center justify-center rounded-circle mr-4"
+                style="width: 40px; height: 40px"
+                :aria-label="t('pages.education.stepLabel', { number: index + 1 })"
+              >
+                <span class="text-subtitle-1 font-weight-semibold">{{ index + 1 }}</span>
+              </div>
+              <div>
+                <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                  {{ step.title }}
+                </h3>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ step.description }}
+                </p>
+              </div>
+            </v-sheet>
+          </li>
+        </ol>
+      </section>
+
+      <section aria-labelledby="education-cta-title">
+        <v-card
+          class="pa-8"
+          color="primary"
+          variant="flat"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div>
+              <h2
+                id="education-cta-title"
+                class="text-h4 font-weight-semibold text-white mb-2"
+              >
+                {{ t("pages.education.cta.title") }}
+              </h2>
+              <p class="text-body-1 text-white text-opacity-80 mb-0" style="max-width: 520px">
+                {{ t("pages.education.cta.description") }}
+              </p>
+            </div>
+            <v-btn
+              :to="contactLink"
+              color="white"
+              variant="flat"
+              size="large"
+              class="text-primary"
+              :aria-label="t('pages.education.cta.buttonAria')"
+            >
+              {{ t("pages.education.cta.button") }}
+            </v-btn>
+          </div>
+        </v-card>
+      </section>
+    </v-container>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+const localePath = useLocalePath();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.education.title");
+  const description = t("seo.education.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+const featureCards = computed(() => [
+  {
+    icon: "mdi-book-open-page-variant-outline",
+    title: t("pages.education.features.curriculum.title"),
+    description: t("pages.education.features.curriculum.description"),
+    points: [
+      t("pages.education.features.curriculum.points.0"),
+      t("pages.education.features.curriculum.points.1"),
+      t("pages.education.features.curriculum.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-account-multiple-check-outline",
+    title: t("pages.education.features.collaboration.title"),
+    description: t("pages.education.features.collaboration.description"),
+    points: [
+      t("pages.education.features.collaboration.points.0"),
+      t("pages.education.features.collaboration.points.1"),
+      t("pages.education.features.collaboration.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-chart-box-outline",
+    title: t("pages.education.features.analytics.title"),
+    description: t("pages.education.features.analytics.description"),
+    points: [
+      t("pages.education.features.analytics.points.0"),
+      t("pages.education.features.analytics.points.1"),
+      t("pages.education.features.analytics.points.2"),
+    ],
+  },
+]);
+
+const workflowSteps = computed(() => [
+  {
+    title: t("pages.education.workflow.steps.design.title"),
+    description: t("pages.education.workflow.steps.design.description"),
+  },
+  {
+    title: t("pages.education.workflow.steps.deliver.title"),
+    description: t("pages.education.workflow.steps.deliver.description"),
+  },
+  {
+    title: t("pages.education.workflow.steps.reflect.title"),
+    description: t("pages.education.workflow.steps.reflect.description"),
+  },
+]);
+
+const contactLink = computed(() => localePath("/contact"));
+</script>

--- a/pages/game.vue
+++ b/pages/game.vue
@@ -1,0 +1,241 @@
+<template>
+  <main
+    class="py-12"
+    aria-labelledby="game-heading"
+  >
+    <v-container>
+      <section
+        class="text-center mb-12"
+        aria-describedby="game-subtitle"
+      >
+        <h1
+          id="game-heading"
+          class="text-h3 font-weight-bold mb-4"
+        >
+          {{ t("pages.game.title") }}
+        </h1>
+        <p
+          id="game-subtitle"
+          class="text-body-1 text-medium-emphasis mx-auto"
+          style="max-width: 640px"
+        >
+          {{ t("pages.game.subtitle") }}
+        </p>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="game-features-title"
+      >
+        <h2
+          id="game-features-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.game.featuresTitle") }}
+        </h2>
+        <v-row dense>
+          <v-col
+            v-for="feature in featureCards"
+            :key="feature.title"
+            cols="12"
+            md="4"
+          >
+            <v-card
+              variant="tonal"
+              class="pa-6 h-100"
+            >
+              <div class="d-flex align-start mb-4">
+                <v-avatar
+                  color="primary"
+                  size="48"
+                  class="mr-4"
+                >
+                  <v-icon
+                    :icon="feature.icon"
+                    size="28"
+                    color="white"
+                    aria-hidden="true"
+                  />
+                </v-avatar>
+                <div>
+                  <h3 class="text-subtitle-1 font-weight-semibold mb-2">
+                    {{ feature.title }}
+                  </h3>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ feature.description }}
+                  </p>
+                </div>
+              </div>
+              <ul class="pl-6 text-body-2 text-medium-emphasis mb-0">
+                <li
+                  v-for="point in feature.points"
+                  :key="point"
+                  class="mb-1"
+                >
+                  {{ point }}
+                </li>
+              </ul>
+            </v-card>
+          </v-col>
+        </v-row>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="game-workflow-title"
+      >
+        <h2
+          id="game-workflow-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.game.workflowTitle") }}
+        </h2>
+        <ol class="d-flex flex-column gap-4 list-none pa-0">
+          <li
+            v-for="(step, index) in workflowSteps"
+            :key="step.title"
+          >
+            <v-sheet
+              class="pa-6 rounded-lg d-flex align-start"
+              color="surface-variant"
+              variant="tonal"
+            >
+              <div
+                class="d-flex align-center justify-center rounded-circle mr-4"
+                style="width: 40px; height: 40px"
+                :aria-label="t('pages.game.stepLabel', { number: index + 1 })"
+              >
+                <span class="text-subtitle-1 font-weight-semibold">{{ index + 1 }}</span>
+              </div>
+              <div>
+                <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                  {{ step.title }}
+                </h3>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ step.description }}
+                </p>
+              </div>
+            </v-sheet>
+          </li>
+        </ol>
+      </section>
+
+      <section aria-labelledby="game-cta-title">
+        <v-card
+          class="pa-8"
+          color="primary"
+          variant="flat"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div>
+              <h2
+                id="game-cta-title"
+                class="text-h4 font-weight-semibold text-white mb-2"
+              >
+                {{ t("pages.game.cta.title") }}
+              </h2>
+              <p class="text-body-1 text-white text-opacity-80 mb-0" style="max-width: 520px">
+                {{ t("pages.game.cta.description") }}
+              </p>
+            </div>
+            <v-btn
+              :to="contactLink"
+              color="white"
+              variant="flat"
+              size="large"
+              class="text-primary"
+              :aria-label="t('pages.game.cta.buttonAria')"
+            >
+              {{ t("pages.game.cta.button") }}
+            </v-btn>
+          </div>
+        </v-card>
+      </section>
+    </v-container>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+const localePath = useLocalePath();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.game.title");
+  const description = t("seo.game.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+const featureCards = computed(() => [
+  {
+    icon: "mdi-account-group-outline",
+    title: t("pages.game.features.community.title"),
+    description: t("pages.game.features.community.description"),
+    points: [
+      t("pages.game.features.community.points.0"),
+      t("pages.game.features.community.points.1"),
+      t("pages.game.features.community.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-controller-classic-outline",
+    title: t("pages.game.features.monetization.title"),
+    description: t("pages.game.features.monetization.description"),
+    points: [
+      t("pages.game.features.monetization.points.0"),
+      t("pages.game.features.monetization.points.1"),
+      t("pages.game.features.monetization.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-trophy-outline",
+    title: t("pages.game.features.events.title"),
+    description: t("pages.game.features.events.description"),
+    points: [
+      t("pages.game.features.events.points.0"),
+      t("pages.game.features.events.points.1"),
+      t("pages.game.features.events.points.2"),
+    ],
+  },
+]);
+
+const workflowSteps = computed(() => [
+  {
+    title: t("pages.game.workflow.steps.launch.title"),
+    description: t("pages.game.workflow.steps.launch.description"),
+  },
+  {
+    title: t("pages.game.workflow.steps.engage.title"),
+    description: t("pages.game.workflow.steps.engage.description"),
+  },
+  {
+    title: t("pages.game.workflow.steps.grow.title"),
+    description: t("pages.game.workflow.steps.grow.description"),
+  },
+]);
+
+const contactLink = computed(() => localePath("/contact"));
+</script>

--- a/pages/job.vue
+++ b/pages/job.vue
@@ -1,0 +1,241 @@
+<template>
+  <main
+    class="py-12"
+    aria-labelledby="job-heading"
+  >
+    <v-container>
+      <section
+        class="text-center mb-12"
+        aria-describedby="job-subtitle"
+      >
+        <h1
+          id="job-heading"
+          class="text-h3 font-weight-bold mb-4"
+        >
+          {{ t("pages.job.title") }}
+        </h1>
+        <p
+          id="job-subtitle"
+          class="text-body-1 text-medium-emphasis mx-auto"
+          style="max-width: 640px"
+        >
+          {{ t("pages.job.subtitle") }}
+        </p>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="job-features-title"
+      >
+        <h2
+          id="job-features-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.job.featuresTitle") }}
+        </h2>
+        <v-row dense>
+          <v-col
+            v-for="feature in featureCards"
+            :key="feature.title"
+            cols="12"
+            md="4"
+          >
+            <v-card
+              variant="tonal"
+              class="pa-6 h-100"
+            >
+              <div class="d-flex align-start mb-4">
+                <v-avatar
+                  color="primary"
+                  size="48"
+                  class="mr-4"
+                >
+                  <v-icon
+                    :icon="feature.icon"
+                    size="28"
+                    color="white"
+                    aria-hidden="true"
+                  />
+                </v-avatar>
+                <div>
+                  <h3 class="text-subtitle-1 font-weight-semibold mb-2">
+                    {{ feature.title }}
+                  </h3>
+                  <p class="text-body-2 text-medium-emphasis mb-0">
+                    {{ feature.description }}
+                  </p>
+                </div>
+              </div>
+              <ul class="pl-6 text-body-2 text-medium-emphasis mb-0">
+                <li
+                  v-for="point in feature.points"
+                  :key="point"
+                  class="mb-1"
+                >
+                  {{ point }}
+                </li>
+              </ul>
+            </v-card>
+          </v-col>
+        </v-row>
+      </section>
+
+      <section
+        class="mb-12"
+        aria-labelledby="job-workflow-title"
+      >
+        <h2
+          id="job-workflow-title"
+          class="text-h4 font-weight-semibold mb-6"
+        >
+          {{ t("pages.job.workflowTitle") }}
+        </h2>
+        <ol class="d-flex flex-column gap-4 list-none pa-0">
+          <li
+            v-for="(step, index) in workflowSteps"
+            :key="step.title"
+          >
+            <v-sheet
+              class="pa-6 rounded-lg d-flex align-start"
+              color="surface-variant"
+              variant="tonal"
+            >
+              <div
+                class="d-flex align-center justify-center rounded-circle mr-4"
+                style="width: 40px; height: 40px"
+                :aria-label="t('pages.job.stepLabel', { number: index + 1 })"
+              >
+                <span class="text-subtitle-1 font-weight-semibold">{{ index + 1 }}</span>
+              </div>
+              <div>
+                <h3 class="text-subtitle-1 font-weight-semibold mb-1">
+                  {{ step.title }}
+                </h3>
+                <p class="text-body-2 text-medium-emphasis mb-0">
+                  {{ step.description }}
+                </p>
+              </div>
+            </v-sheet>
+          </li>
+        </ol>
+      </section>
+
+      <section aria-labelledby="job-resources-title">
+        <v-card
+          class="pa-8"
+          color="primary"
+          variant="flat"
+        >
+          <div class="d-flex flex-column flex-md-row align-md-center justify-space-between gap-6">
+            <div>
+              <h2
+                id="job-resources-title"
+                class="text-h4 font-weight-semibold text-white mb-2"
+              >
+                {{ t("pages.job.cta.title") }}
+              </h2>
+              <p class="text-body-1 text-white text-opacity-80 mb-0" style="max-width: 520px">
+                {{ t("pages.job.cta.description") }}
+              </p>
+            </div>
+            <v-btn
+              :to="contactLink"
+              color="white"
+              variant="flat"
+              size="large"
+              class="text-primary"
+              :aria-label="t('pages.job.cta.buttonAria')"
+            >
+              {{ t("pages.job.cta.button") }}
+            </v-btn>
+          </div>
+        </v-card>
+      </section>
+    </v-container>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const { t, locale, localeProperties } = useI18n();
+const route = useRoute();
+const runtimeConfig = useRuntimeConfig();
+const localePath = useLocalePath();
+
+const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
+
+useHead(() => {
+  const title = t("seo.job.title");
+  const description = t("seo.job.description");
+  const canonical = new URL(route.path, baseUrl.value).toString();
+  const iso = localeProperties.value?.iso ?? locale.value;
+
+  return {
+    title,
+    meta: [
+      { key: "description", name: "description", content: description },
+      { key: "og:title", property: "og:title", content: title },
+      { key: "og:description", property: "og:description", content: description },
+      { key: "og:type", property: "og:type", content: "website" },
+      { key: "og:url", property: "og:url", content: canonical },
+      { key: "og:locale", property: "og:locale", content: iso },
+      { key: "twitter:card", name: "twitter:card", content: "summary_large_image" },
+      { key: "twitter:title", name: "twitter:title", content: title },
+      { key: "twitter:description", name: "twitter:description", content: description },
+      { key: "twitter:url", name: "twitter:url", content: canonical },
+    ],
+    link: [{ rel: "canonical", href: canonical }],
+  };
+});
+
+const featureCards = computed(() => [
+  {
+    icon: "mdi-briefcase-search-outline",
+    title: t("pages.job.features.matching.title"),
+    description: t("pages.job.features.matching.description"),
+    points: [
+      t("pages.job.features.matching.points.0"),
+      t("pages.job.features.matching.points.1"),
+      t("pages.job.features.matching.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-robot-happy-outline",
+    title: t("pages.job.features.automation.title"),
+    description: t("pages.job.features.automation.description"),
+    points: [
+      t("pages.job.features.automation.points.0"),
+      t("pages.job.features.automation.points.1"),
+      t("pages.job.features.automation.points.2"),
+    ],
+  },
+  {
+    icon: "mdi-chart-line-variant",
+    title: t("pages.job.features.insights.title"),
+    description: t("pages.job.features.insights.description"),
+    points: [
+      t("pages.job.features.insights.points.0"),
+      t("pages.job.features.insights.points.1"),
+      t("pages.job.features.insights.points.2"),
+    ],
+  },
+]);
+
+const workflowSteps = computed(() => [
+  {
+    title: t("pages.job.workflow.steps.publish.title"),
+    description: t("pages.job.workflow.steps.publish.description"),
+  },
+  {
+    title: t("pages.job.workflow.steps.review.title"),
+    description: t("pages.job.workflow.steps.review.description"),
+  },
+  {
+    title: t("pages.job.workflow.steps.hire.title"),
+    description: t("pages.job.workflow.steps.hire.description"),
+  },
+]);
+
+const contactLink = computed(() => localePath("/contact"));
+</script>


### PR DESCRIPTION
## Summary
- add dedicated job, gaming, e-commerce, and education landing pages with localized content, feature highlights, and workflow callouts
- expose the new vertical pages through the primary sidebar navigation
- seed all locales and SEO metadata with the new industry-facing copy

## Testing
- `pnpm lint` *(fails: existing lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7b4c81308326b2dfdc1a6ee3aa9d