### PR TITLE
Show language flags in locale menu

### DIFF
--- a/components/layout/AppBar/LocaleMenu.vue
+++ b/components/layout/AppBar/LocaleMenu.vue
@@ -7,7 +7,14 @@
         :aria-label="`Language: ${props.formatLabel(props.current)}`"
         v-bind="languageProps"
       >
+        <span
+          v-if="currentFlag"
+          :class="['fi', `fi-${currentFlag}`]"
+          class="block h-[18px] w-[24px] rounded-sm shadow-sm"
+          aria-hidden="true"
+        />
         <AppIcon
+          v-else
           name="mdi:flag-outline"
           :size="22"
         />
@@ -47,6 +54,14 @@
           :aria-checked="l === props.current"
           @click="emit('change', l)"
         >
+          <template #prepend>
+            <span
+              v-if="getFlag(l)"
+              :class="['fi', `fi-${getFlag(l)}`]"
+              class="mr-3 block h-[16px] w-[22px] rounded-sm shadow-sm"
+              aria-hidden="true"
+            />
+          </template>
           <template #append>
             <AppIcon
               v-if="l === props.current"
@@ -61,6 +76,10 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
+type LocaleMetadata = Record<string, { flag?: string }>;
+
 const props = defineProps<{
   locales: string[];
   current: string;
@@ -68,6 +87,14 @@ const props = defineProps<{
   formatLabel: (l: string) => string;
   title: string;
   subtitle?: string;
+  localeMetadata?: LocaleMetadata;
 }>();
 const emit = defineEmits(["change"]);
+
+const metadata = computed<LocaleMetadata>(() => props.localeMetadata ?? {});
+const currentFlag = computed(() => metadata.value[props.current]?.flag ?? "");
+
+function getFlag(code: string): string {
+  return metadata.value[code]?.flag ?? "";
+}
 </script>

--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -75,6 +75,7 @@
             :current="props.locale"
             :icon-trigger-classes="iconTriggerClasses"
             :format-label="formatLocaleLabel"
+            :locale-metadata="localeMetadata"
             :title="localeMenuTitle"
             :subtitle="localeMenuSubtitle"
             @change="changeLocale"
@@ -124,6 +125,17 @@ const auth = useAuthSession();
 
 const iconTriggerClasses =
   "flex h-10 w-10 items-center justify-center rounded-full bg-transparent text-foreground transition hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2";
+
+const localeMetadata = {
+  en: { label: "English", flag: "gb" },
+  de: { label: "Deutsch", flag: "de" },
+  fr: { label: "Français", flag: "fr" },
+  es: { label: "Español", flag: "es" },
+  it: { label: "Italiano", flag: "it" },
+  ru: { label: "Русский", flag: "ru" },
+  ar: { label: "العربية", flag: "tn" },
+  "zh-cn": { label: "中文 (简体)", flag: "cn" },
+} as const satisfies Record<string, { label: string; flag: string }>;
 
 /** Dégradés dynamiques depuis primary + mode sombre */
 const { barGradient, isDark: gradientIsDark } = usePrimaryGradient();
@@ -217,26 +229,7 @@ const userMenuItems = computed<UserMenuItem[]>(() => {
 });
 
 function formatLocaleLabel(v: string) {
-  switch (v) {
-    case "en":
-      return "English";
-    case "de":
-      return "Deutsch";
-    case "fr":
-      return "Français";
-    case "es":
-      return "Español";
-    case "it":
-      return "Italiano";
-    case "ru":
-      return "Русский";
-    case "ar":
-      return "العربية";
-    case "zh-cn":
-      return "中文 (简体)";
-    default:
-      return v;
-  }
+  return localeMetadata[v]?.label ?? v;
 }
 function changeLocale(value: string) {
   emit("update:locale", value);


### PR DESCRIPTION
## Summary
- display each locale with its flag inside the language picker and show the active flag on the trigger
- centralize locale metadata so the locale labels and flag codes stay consistent

## Testing
- pnpm lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dc848f2c608326adc544dace97a16d