### PR TITLE
feat: add messenger menu and pages

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,5 +1,17 @@
 <template>
   <div class="flex items-center gap-3">
+    <MessengerMenu
+      :conversations="props.messengerConversations"
+      :icon-trigger-classes="props.iconTriggerClasses"
+      :title="props.messengerTitle"
+      :subtitle="props.messengerSubtitle"
+      :view-all-label="props.messengerViewAll"
+      :button-label="props.messengerButtonLabel"
+      :unread-count="props.messengerUnreadCount"
+      :empty-text="props.messengerEmpty"
+      :unknown-label="props.messengerUnknownLabel"
+      :loading="props.messengerLoading"
+    />
     <NotificationMenu
       :items="props.notifications"
       :icon-trigger-classes="props.iconTriggerClasses"
@@ -57,7 +69,9 @@
 
 <script setup lang="ts">
 import NotificationMenu from "./NotificationMenu.vue";
+import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
+import type { MessengerConversation } from "~/types/messenger";
 
 const props = defineProps<{
   isMobile: boolean;
@@ -70,6 +84,15 @@ const props = defineProps<{
   notificationsEmpty: string;
   notificationsMarkAll: string;
   notificationsButtonLabel: string;
+  messengerConversations: MessengerConversation[];
+  messengerUnreadCount: number;
+  messengerButtonLabel: string;
+  messengerTitle: string;
+  messengerSubtitle?: string;
+  messengerEmpty: string;
+  messengerViewAll: string;
+  messengerUnknownLabel: string;
+  messengerLoading: boolean;
 }>();
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
 </script>

--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -54,6 +54,15 @@
         :notifications-empty="notificationsEmpty"
         :notifications-mark-all="notificationsMarkAll"
         :notifications-button-label="notificationsButtonLabel"
+        :messenger-conversations="messengerPreviewConversations"
+        :messenger-unread-count="messengerUnreadCount"
+        :messenger-button-label="messengerButtonLabel"
+        :messenger-title="messengerTitle"
+        :messenger-subtitle="messengerSubtitle"
+        :messenger-empty="messengerEmpty"
+        :messenger-view-all="messengerViewAll"
+        :messenger-unknown-label="messengerUnknownLabel"
+        :messenger-loading="messengerMenuLoading"
         @toggle-right="$emit('toggle-right')"
         @mark-all-notifications="markAllNotifications"
       >
@@ -94,6 +103,7 @@ import LocaleMenu from "./AppBar/LocaleMenu.vue";
 import RightControls from "./AppBar/RightControls.vue";
 import { usePrimaryGradient } from "~/composables/usePrimaryGradient";
 import { useAuthSession } from "~/stores/auth-session";
+import { useMessengerStore } from "~/stores/messenger";
 import type { AppNotification } from "~/types/layout";
 
 type AppIcon = { name: string; label: string; size?: number; to: string };
@@ -121,6 +131,7 @@ const emit = defineEmits(["toggle-left", "toggle-right", "go-back", "refresh", "
 const { t } = useI18n();
 const config = useConfig();
 const auth = useAuthSession();
+const messenger = useMessengerStore();
 
 const iconTriggerClasses =
   "flex h-10 w-10 items-center justify-center rounded-full bg-transparent text-foreground transition hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70 focus-visible:ring-offset-2";
@@ -193,6 +204,35 @@ const notificationsButtonLabel = computed(() => {
   }
   return t("layout.actions.notifications");
 });
+
+const messengerPreviewConversations = computed(
+  () => messenger.previewConversations.value ?? [],
+);
+const messengerUnreadCount = computed(() => messenger.unreadTotal.value);
+const messengerTitle = computed(() => t("layout.messengerMenu.title"));
+const messengerSubtitle = computed(() => {
+  const raw = t("layout.messengerMenu.subtitle");
+  return raw === "layout.messengerMenu.subtitle" ? undefined : raw;
+});
+const messengerEmpty = computed(() => t("layout.messengerMenu.empty"));
+const messengerViewAll = computed(() => t("layout.messengerMenu.viewAll"));
+const messengerUnknownLabel = computed(() => t("messenger.unknownParticipant"));
+const messengerMenuLoading = computed(() => messenger.loadingPreview.value);
+const messengerButtonLabel = computed(() => {
+  const count = messengerUnreadCount.value;
+  if (count > 0) {
+    return t("layout.messengerMenu.badgeLabel", { count });
+  }
+  return t("layout.actions.messages");
+});
+
+if (import.meta.client) {
+  onMounted(() => {
+    if (!messengerPreviewConversations.value.length) {
+      messenger.fetchThreads({ limit: 3 }).catch(() => {});
+    }
+  });
+}
 
 const userSignedInText = computed(() => t("layout.userMenu.signedInAs"));
 const userGuestTitle = computed(() => t("layout.userMenu.guestTitle"));

--- a/components/messenger/ChatPane.vue
+++ b/components/messenger/ChatPane.vue
@@ -1,0 +1,378 @@
+<template>
+  <section class="flex h-full flex-1 flex-col">
+    <header
+      v-if="conversation"
+      class="flex items-center justify-between border-b border-border px-4 py-3"
+    >
+      <div class="flex min-w-0 items-center gap-3">
+        <v-avatar
+          :size="44"
+          class="bg-muted text-sm font-semibold text-muted-foreground"
+        >
+          <img
+            v-if="avatar.url"
+            :alt="conversationTitle"
+            :src="avatar.url"
+          >
+          <span v-else>
+            {{ avatar.initials }}
+          </span>
+        </v-avatar>
+        <div class="min-w-0">
+          <h2 class="truncate text-base font-semibold">
+            {{ conversationTitle }}
+          </h2>
+          <p class="truncate text-xs text-muted-foreground">
+            {{ participantsSubtitle }}
+          </p>
+        </div>
+      </div>
+      <div class="flex items-center gap-2 text-muted-foreground">
+        <v-btn
+          v-if="hasMore"
+          variant="text"
+          density="comfortable"
+          size="small"
+          :disabled="loadingOlder"
+          @click="loadOlder"
+        >
+          {{ props.loadOlderLabel }}
+        </v-btn>
+      </div>
+    </header>
+    <div
+      v-else
+      class="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center"
+    >
+      <div class="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <AppIcon
+          name="mdi:message-outline"
+          :size="36"
+        />
+      </div>
+      <div class="space-y-1">
+        <p class="text-lg font-semibold">
+          {{ props.emptyTitle }}
+        </p>
+        <p class="text-sm text-muted-foreground">
+          {{ props.emptyDescription }}
+        </p>
+      </div>
+      <v-btn
+        color="primary"
+        variant="flat"
+        :to="props.emptyCtaTo"
+      >
+        {{ props.emptyCtaLabel }}
+      </v-btn>
+    </div>
+
+    <div
+      v-if="conversation"
+      ref="messagesContainer"
+      class="flex-1 overflow-y-auto px-4 py-6"
+      @scroll.passive="handleScroll"
+    >
+      <div class="mx-auto flex w-full max-w-3xl flex-col gap-4">
+        <div
+          v-for="message in messages"
+          :key="message.id"
+          :class="[
+            'flex w-full flex-col gap-1',
+            isOwnMessage(message) ? 'items-end' : 'items-start',
+          ]"
+        >
+          <div
+            :class="[
+              'max-w-[80%] rounded-2xl px-4 py-2 text-sm shadow-sm transition-colors',
+              isOwnMessage(message)
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-foreground',
+            ]"
+          >
+            <p class="whitespace-pre-line break-words">
+              {{ message.content }}
+            </p>
+          </div>
+          <div class="flex items-center gap-2 text-[11px] text-muted-foreground">
+            <span>
+              {{ messageTime(message.createdAt) }}
+            </span>
+            <span v-if="message.status === 'pending'">
+              {{ props.sendingLabel }}
+            </span>
+            <span
+              v-else-if="message.status === 'error'"
+              class="text-destructive"
+            >
+              {{ props.sendErrorLabel }}
+            </span>
+          </div>
+        </div>
+        <div v-if="!messages.length" class="py-10 text-center text-sm text-muted-foreground">
+          {{ props.noMessagesLabel }}
+        </div>
+      </div>
+    </div>
+
+    <div
+      v-if="conversation"
+      class="border-t border-border px-4 py-4"
+    >
+      <div class="mx-auto flex w-full max-w-3xl flex-col gap-2">
+        <v-textarea
+          v-model="draft"
+          :placeholder="props.composerPlaceholder"
+          auto-grow
+          max-rows="6"
+          rows="1"
+          variant="solo"
+          density="comfortable"
+          class="w-full"
+          :disabled="sending || !conversation"
+          @keydown="handleKeydown"
+        />
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-xs text-muted-foreground">
+            {{ props.shortcutsHint }}
+          </span>
+          <div class="flex items-center gap-2">
+            <v-btn
+              color="primary"
+              :disabled="sending || !draft.trim()"
+              :loading="sending"
+              @click="send"
+            >
+              {{ props.sendLabel }}
+            </v-btn>
+          </div>
+        </div>
+        <p
+          v-if="sendError"
+          class="text-sm text-destructive"
+        >
+          {{ sendError }}
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { useI18n } from "vue-i18n";
+import { useAuthSession } from "~/stores/auth-session";
+import { useMessengerStore } from "~/stores/messenger";
+import { formatRelativeTime } from "~/lib/datetime/relative-time";
+import { resolveConversationAvatar, resolveConversationTitle } from "~/lib/messenger/display";
+import type { MessengerMessage } from "~/types/messenger";
+
+const props = defineProps<{
+  composerPlaceholder: string;
+  sendLabel: string;
+  sendingLabel: string;
+  sendErrorLabel: string;
+  shortcutsHint: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  emptyCtaLabel: string;
+  emptyCtaTo?: string;
+  noMessagesLabel: string;
+  loadOlderLabel: string;
+  participantsLabel: string;
+  unknownLabel: string;
+}>();
+
+const auth = useAuthSession();
+const messenger = useMessengerStore();
+const { locale } = useI18n();
+
+const messagesContainer = ref<HTMLDivElement | null>(null);
+const draft = ref("");
+const autoScroll = ref(true);
+
+const conversation = computed(() => messenger.activeConversation.value);
+const messages = computed<MessengerMessage[]>(() => messenger.currentMessages.value ?? []);
+const sending = computed(() => messenger.sendingMessage.value);
+const sendError = computed(() => messenger.sendError.value);
+const pagination = computed(() => {
+  const current = conversation.value;
+  if (!current) {
+    return undefined;
+  }
+
+  return messenger.pagination.value[current.id];
+});
+
+const loadingOlder = computed(() => pagination.value?.pending ?? false);
+const hasMore = computed(() => pagination.value?.hasMore ?? false);
+
+const conversationTitle = computed(() => {
+  if (!conversation.value) {
+    return "";
+  }
+
+  const userId = auth.currentUser.value?.id ?? null;
+  return resolveConversationTitle(conversation.value, userId, props.unknownLabel);
+});
+
+const participantsSubtitle = computed(() => {
+  if (!conversation.value) {
+    return "";
+  }
+
+  const participants = conversation.value.participants ?? [];
+  const count = Math.max(participants.length - 1, 0);
+
+  return props.participantsLabel.replace("{count}", String(count));
+});
+
+const avatar = computed(() => {
+  if (!conversation.value) {
+    return { url: null, initials: props.unknownLabel.slice(0, 2).toUpperCase() };
+  }
+
+  const userId = auth.currentUser.value?.id ?? null;
+  return resolveConversationAvatar(
+    conversation.value,
+    userId,
+    props.unknownLabel.slice(0, 2).toUpperCase(),
+  );
+});
+
+function isOwnMessage(message: MessengerMessage) {
+  const userId = auth.currentUser.value?.id;
+  return message.sender?.id === userId;
+}
+
+function messageTime(value: string) {
+  return formatRelativeTime(value, locale.value);
+}
+
+function handleKeydown(event: KeyboardEvent) {
+  if (event.key === "Enter" && (event.ctrlKey || event.metaKey)) {
+    event.preventDefault();
+    send();
+  }
+}
+
+async function send() {
+  if (!conversation.value) {
+    return;
+  }
+
+  const content = draft.value.trim();
+
+  if (!content) {
+    return;
+  }
+
+  await messenger.sendMessage(conversation.value.id, { content });
+  draft.value = "";
+
+  await nextTick();
+  scrollToBottom(true);
+  markAsRead();
+}
+
+function scrollToBottom(force = false) {
+  const element = messagesContainer.value;
+
+  if (!element) {
+    return;
+  }
+
+  if (!force && !autoScroll.value) {
+    return;
+  }
+
+  element.scrollTo({
+    top: element.scrollHeight,
+    behavior: force ? "auto" : "smooth",
+  });
+}
+
+function nearBottom(): boolean {
+  const element = messagesContainer.value;
+
+  if (!element) {
+    return false;
+  }
+
+  const distance = element.scrollHeight - element.scrollTop - element.clientHeight;
+  return distance < 120;
+}
+
+function handleScroll() {
+  autoScroll.value = nearBottom();
+
+  if (autoScroll.value) {
+    markAsRead();
+  }
+}
+
+function markAsRead() {
+  if (!conversation.value || conversation.value.unreadCount <= 0) {
+    return;
+  }
+
+  const lastMessage = messages.value[messages.value.length - 1];
+
+  if (!lastMessage) {
+    return;
+  }
+
+  messenger.markConversationRead(conversation.value.id, lastMessage.id);
+}
+
+async function loadOlder() {
+  if (!conversation.value || !hasMore.value || loadingOlder.value) {
+    return;
+  }
+
+  await messenger.fetchMessages(conversation.value.id, { before: pagination.value?.before });
+}
+
+watch(
+  () => conversation.value?.id,
+  () => {
+    draft.value = "";
+    nextTick(() => {
+      scrollToBottom(true);
+      markAsRead();
+    });
+  },
+);
+
+watch(
+  () => messages.value.length,
+  () => {
+    nextTick(() => {
+      scrollToBottom(false);
+      if (autoScroll.value) {
+        markAsRead();
+      }
+    });
+  },
+);
+
+watch(
+  () => sendError.value,
+  (error) => {
+    if (error) {
+      autoScroll.value = true;
+    }
+  },
+);
+
+watch(
+  () => sending.value,
+  (isSending, wasSending) => {
+    if (!isSending && wasSending) {
+      nextTick(() => {
+        scrollToBottom(true);
+      });
+    }
+  },
+);
+</script>

--- a/components/messenger/ConversationsList.vue
+++ b/components/messenger/ConversationsList.vue
@@ -1,0 +1,197 @@
+<template>
+  <aside
+    class="flex h-full flex-col border-border bg-card"
+    :class="[
+      'w-full md:w-[320px]',
+      'border-b md:border-b-0 md:border-r',
+    ]"
+  >
+    <div class="border-b border-border px-4 py-3">
+      <v-text-field
+        v-model="query"
+        :placeholder="props.searchPlaceholder"
+        density="comfortable"
+        hide-details
+        variant="solo"
+        color="primary"
+        prepend-inner-icon="mdi:magnify"
+        clearable
+        :aria-label="props.searchPlaceholder"
+      />
+    </div>
+    <div class="flex-1 overflow-y-auto">
+      <div
+        v-if="props.loading"
+        class="flex flex-col gap-4 px-4 py-6"
+      >
+        <div
+          v-for="index in 6"
+          :key="index"
+          class="flex items-center gap-3"
+        >
+          <v-skeleton-loader
+            class="rounded-full"
+            height="42"
+            type="avatar"
+            width="42"
+          />
+          <div class="flex flex-1 flex-col gap-2">
+            <v-skeleton-loader height="12" type="text" />
+            <v-skeleton-loader height="10" type="text" />
+          </div>
+        </div>
+      </div>
+      <template v-else>
+        <v-list
+          v-if="filteredConversations.length"
+          class="py-0"
+          density="comfortable"
+          nav
+        >
+          <v-list-item
+            v-for="conversation in filteredConversations"
+            :key="conversation.id"
+            :value="conversation.id"
+            :class="[
+              'px-4 py-3 transition-colors',
+              conversation.id === props.activeId
+                ? 'bg-primary/10 text-primary-foreground dark:bg-primary/20'
+                : 'hover:bg-muted/70 dark:hover:bg-muted/40',
+            ]"
+            role="button"
+            @click="handleSelect(conversation.id)"
+          >
+            <template #prepend>
+              <v-avatar
+                :size="44"
+                class="bg-muted text-sm font-semibold text-muted-foreground"
+              >
+                <img
+                  v-if="conversation.avatarUrl"
+                  :alt="conversation.title"
+                  :src="conversation.avatarUrl"
+                >
+                <span v-else>
+                  {{ conversation.initials }}
+                </span>
+              </v-avatar>
+            </template>
+            <div class="flex flex-1 flex-col gap-1 overflow-hidden">
+              <div class="flex items-center justify-between gap-2">
+                <p class="truncate text-sm font-semibold">
+                  {{ conversation.title }}
+                </p>
+                <span class="whitespace-nowrap text-xs text-muted-foreground">
+                  {{ conversation.timeAgo }}
+                </span>
+              </div>
+              <div class="flex items-center justify-between gap-2">
+                <p class="line-clamp-1 text-xs text-muted-foreground">
+                  <span v-if="conversation.sender" class="font-medium text-foreground">
+                    {{ conversation.sender }}
+                  </span>
+                  <span v-if="conversation.sender && conversation.snippet">
+                    &nbsp;&mdash;&nbsp;
+                  </span>
+                  <span>
+                    {{ conversation.snippet || props.emptyLabel }}
+                  </span>
+                </p>
+                <span
+                  v-if="conversation.unreadCount"
+                  class="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground"
+                >
+                  {{ conversation.unreadCount > 99 ? '99+' : conversation.unreadCount }}
+                </span>
+              </div>
+            </div>
+          </v-list-item>
+        </v-list>
+        <div
+          v-else
+          class="flex h-full flex-col items-center justify-center gap-3 px-8 py-12 text-center"
+        >
+          <div class="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <AppIcon
+              name="mdi:message-reply-text"
+              :size="32"
+            />
+          </div>
+          <p class="text-sm font-medium">
+            {{ props.emptyLabel }}
+          </p>
+        </div>
+      </template>
+    </div>
+  </aside>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import { useAuthSession } from "~/stores/auth-session";
+import { formatRelativeTime } from "~/lib/datetime/relative-time";
+import {
+  resolveConversationAvatar,
+  resolveConversationTitle,
+  resolveMessageSender,
+} from "~/lib/messenger/display";
+import type { MessengerConversation } from "~/types/messenger";
+
+const props = defineProps<{
+  conversations: MessengerConversation[];
+  activeId: string | null;
+  loading: boolean;
+  searchPlaceholder: string;
+  emptyLabel: string;
+  unknownLabel: string;
+}>();
+
+const emit = defineEmits<{
+  (e: "select", id: string): void;
+}>();
+
+const auth = useAuthSession();
+const { locale } = useI18n();
+const query = ref("");
+
+const normalizedConversations = computed(() => {
+  const currentUserId = auth.currentUser.value?.id ?? null;
+  const fallbackInitials = props.unknownLabel.slice(0, 2).toUpperCase();
+
+  return props.conversations.map((conversation) => {
+    const title = resolveConversationTitle(conversation, currentUserId, props.unknownLabel);
+    const avatar = resolveConversationAvatar(conversation, currentUserId, fallbackInitials);
+    const lastMessage = conversation.lastMessage ?? null;
+
+    return {
+      id: conversation.id,
+      title,
+      avatarUrl: avatar.url,
+      initials: avatar.initials,
+      snippet: lastMessage?.content ?? "",
+      sender: resolveMessageSender(lastMessage, ""),
+      timeAgo: formatRelativeTime(lastMessage?.createdAt ?? conversation.updatedAt, locale.value),
+      unreadCount: conversation.unreadCount ?? 0,
+    };
+  });
+});
+
+const filteredConversations = computed(() => {
+  const term = query.value.trim().toLowerCase();
+
+  if (!term) {
+    return normalizedConversations.value;
+  }
+
+  return normalizedConversations.value.filter((conversation) => {
+    return [conversation.title, conversation.snippet, conversation.sender]
+      .filter(Boolean)
+      .some((entry) => entry.toLowerCase().includes(term));
+  });
+});
+
+function handleSelect(id: string) {
+  emit("select", id);
+}
+</script>

--- a/components/messenger/MessengerMenu.vue
+++ b/components/messenger/MessengerMenu.vue
@@ -1,0 +1,255 @@
+<template>
+  <v-menu
+    v-model="open"
+    location="bottom end"
+    offset="8"
+  >
+    <template #activator="{ props: menuProps }">
+      <button
+        type="button"
+        :class="props.iconTriggerClasses"
+        :aria-label="props.buttonLabel"
+        v-bind="menuProps"
+      >
+        <v-badge
+          v-if="props.unreadCount > 0"
+          :content="props.unreadCount"
+          color="primary"
+          floating
+          max="99"
+          offset-x="4"
+          offset-y="2"
+          size="small"
+        >
+          <AppIcon
+            name="mdi:message-outline"
+            :size="26"
+          />
+        </v-badge>
+        <template v-else>
+          <AppIcon
+            name="mdi:message-outline"
+            :size="26"
+          />
+        </template>
+      </button>
+    </template>
+    <v-card
+      class="min-w-[320px] overflow-hidden"
+      elevation="12"
+    >
+      <div class="flex items-center justify-between px-4 py-3">
+        <div>
+          <p class="text-sm font-semibold leading-tight">
+            {{ props.title }}
+          </p>
+          <p
+            v-if="props.subtitle"
+            class="text-xs text-muted-foreground"
+          >
+            {{ props.subtitle }}
+          </p>
+        </div>
+        <v-btn
+          variant="text"
+          size="small"
+          class="text-primary"
+          :aria-label="props.viewAllLabel"
+          @click="handleViewAll"
+        >
+          {{ props.viewAllLabel }}
+        </v-btn>
+      </div>
+      <v-divider />
+      <div v-if="props.loading" class="flex flex-col gap-3 px-4 py-6">
+        <div
+          v-for="index in 3"
+          :key="index"
+          class="flex items-center gap-3"
+        >
+          <v-skeleton-loader
+            class="rounded-full"
+            height="40"
+            type="avatar"
+            width="40"
+          />
+          <div class="flex flex-1 flex-col gap-2">
+            <v-skeleton-loader
+              height="12"
+              type="text"
+            />
+            <v-skeleton-loader
+              height="10"
+              type="text"
+            />
+          </div>
+        </div>
+      </div>
+      <template v-else>
+        <v-list
+          v-if="previews.length"
+          class="py-0"
+          density="compact"
+          lines="two"
+        >
+          <v-list-item
+            v-for="preview in previews"
+            :key="preview.id"
+            :class="[
+              'px-4 py-3 transition-colors',
+              preview.unread ? 'bg-primary/5 dark:bg-primary/15' : '',
+            ]"
+            link
+            @click="openConversation(preview.id)"
+          >
+            <template #prepend>
+              <v-avatar
+                :size="40"
+                class="bg-muted text-sm font-semibold text-muted-foreground"
+              >
+                <img
+                  v-if="preview.avatarUrl"
+                  :alt="preview.title"
+                  :src="preview.avatarUrl"
+                >
+                <span v-else>
+                  {{ preview.initials }}
+                </span>
+              </v-avatar>
+            </template>
+            <div class="flex flex-col gap-1">
+              <p class="text-sm font-medium leading-tight">
+                {{ preview.title }}
+              </p>
+              <p class="line-clamp-2 text-xs text-muted-foreground leading-relaxed">
+                <span v-if="preview.sender" class="font-medium text-foreground">
+                  {{ preview.sender }}
+                </span>
+                <span v-if="preview.sender && preview.snippet">
+                  &nbsp;&mdash;&nbsp;
+                </span>
+                <span>
+                  {{ preview.snippet || props.emptyText }}
+                </span>
+              </p>
+            </div>
+            <template #append>
+              <div class="flex flex-col items-end gap-2">
+                <span class="text-xs text-muted-foreground">
+                  {{ preview.timeAgo }}
+                </span>
+                <span
+                  v-if="preview.unread && preview.unreadCount"
+                  class="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground"
+                >
+                  {{ preview.unreadCount > 99 ? '99+' : preview.unreadCount }}
+                </span>
+                <span
+                  v-else-if="preview.unread"
+                  class="h-2 w-2 rounded-full bg-primary"
+                />
+              </div>
+            </template>
+          </v-list-item>
+        </v-list>
+        <div
+          v-else
+          class="flex flex-col items-center justify-center gap-2 px-6 py-8 text-center"
+        >
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <AppIcon
+              name="mdi:message-plus-outline"
+              :size="28"
+            />
+          </div>
+          <p class="text-sm font-medium">
+            {{ props.emptyText }}
+          </p>
+        </div>
+      </template>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { useAuthSession } from "~/stores/auth-session";
+import {
+  resolveConversationAvatar,
+  resolveConversationTitle,
+  resolveMessageSender,
+} from "~/lib/messenger/display";
+import { formatRelativeTime } from "~/lib/datetime/relative-time";
+import type { MessengerConversation } from "~/types/messenger";
+
+interface MessengerPreviewEntry {
+  id: string;
+  title: string;
+  sender: string;
+  snippet: string;
+  timeAgo: string;
+  unread: boolean;
+  unreadCount: number;
+  avatarUrl: string | null;
+  initials: string;
+}
+
+const props = defineProps<{
+  iconTriggerClasses: string;
+  conversations: MessengerConversation[];
+  title: string;
+  subtitle?: string;
+  viewAllLabel: string;
+  buttonLabel: string;
+  emptyText: string;
+  unknownLabel: string;
+  loading: boolean;
+}>();
+
+const router = useRouter();
+const { locale } = useI18n();
+const auth = useAuthSession();
+const currentUserId = computed(() => auth.currentUser.value?.id ?? null);
+const fallbackInitials = computed(() => props.unknownLabel.slice(0, 2).toUpperCase());
+const open = ref(false);
+
+const previews = computed<MessengerPreviewEntry[]>(() => {
+  const userId = currentUserId.value;
+  const initialsFallback = fallbackInitials.value;
+
+  return props.conversations.slice(0, 3).map((conversation) => {
+    const title = resolveConversationTitle(conversation, userId, props.unknownLabel);
+    const lastMessage = conversation.lastMessage ?? null;
+    const snippet = lastMessage?.content ?? "";
+    const sender = resolveMessageSender(lastMessage, "");
+    const avatar = resolveConversationAvatar(conversation, userId, initialsFallback);
+
+    return {
+      id: conversation.id,
+      title,
+      sender,
+      snippet,
+      unread: (conversation.unreadCount ?? 0) > 0,
+      unreadCount: conversation.unreadCount ?? 0,
+      avatarUrl: avatar.url,
+      initials: avatar.initials,
+      timeAgo: formatRelativeTime(
+        conversation.lastMessage?.createdAt ?? conversation.updatedAt,
+        locale.value,
+      ),
+    };
+  });
+});
+
+function openConversation(id: string) {
+  open.value = false;
+  router.push({ path: `/messenger/${id}` });
+}
+
+function handleViewAll() {
+  open.value = false;
+  router.push({ path: "/messenger" });
+}
+</script>

--- a/i18n/locales/ar.json
+++ b/i18n/locales/ar.json
@@ -11,6 +11,7 @@
       "goBack": "العودة",
       "refresh": "تحديث",
       "notifications": "فتح الإشعارات",
+      "messages": "فتح الرسائل",
       "cart": "فتح الحقيبة",
       "profile": "فتح قائمة الملف الشخصي",
       "viewProfile": "عرض الملف الشخصي",
@@ -40,6 +41,13 @@
           "time": "منذ ساعة"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "الرسائل",
+      "subtitle": "أحدث المحادثات",
+      "viewAll": "عرض الكل",
+      "empty": "لا توجد رسائل جديدة",
+      "badgeLabel": "{count} رسالة غير مقروءة"
     },
     "userMenu": {
       "signedInAs": "مسجل الدخول باسم",
@@ -172,6 +180,23 @@
       "GetStartedAndStartBuildingAwesomeUI": "ابدأ واصنع واجهات مدهشة",
       "GetStarted": "ابدأ الآن"
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "ابحث في المحادثات",
+    "emptyList": "لا توجد محادثات بعد",
+    "unknownParticipant": "غير معروف",
+    "emptyTitle": "اختر محادثة",
+    "emptyDescription": "اختر محادثة من القائمة لقراءة الرسائل وإرسالها.",
+    "emptyCtaLabel": "ابدأ محادثة",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "اكتب رسالة...",
+    "sendLabel": "إرسال",
+    "sendingLabel": "جارٍ الإرسال...",
+    "sendErrorStatus": "لم يتم التسليم",
+    "shortcutsHint": "اضغط Ctrl+Enter للإرسال",
+    "noMessages": "لا توجد رسائل بعد",
+    "loadOlder": "تحميل الرسائل السابقة",
+    "participantsLabel": "{count} مشارك"
   },
   "auth": {
     "Account": "الحساب",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -11,6 +11,7 @@
       "goBack": "Zurück",
       "refresh": "Aktualisieren",
       "notifications": "Benachrichtigungen öffnen",
+      "messages": "Messenger öffnen",
       "cart": "Einkaufstasche öffnen",
       "profile": "Profilmenü öffnen",
       "viewProfile": "Profil ansehen",
@@ -40,6 +41,13 @@
           "time": "vor 1 Std."
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Nachrichten",
+      "subtitle": "Aktuelle Unterhaltungen",
+      "viewAll": "Alle anzeigen",
+      "empty": "Keine neuen Nachrichten",
+      "badgeLabel": "{count} ungelesene Nachrichten"
     },
     "userMenu": {
       "signedInAs": "Angemeldet als",
@@ -172,6 +180,23 @@
       "GetStartedAndStartBuildingAwesomeUI": "Leg los und baue beeindruckende Benutzeroberflächen",
       "GetStarted": "Jetzt starten"
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Konversationen durchsuchen",
+    "emptyList": "Noch keine Konversationen",
+    "unknownParticipant": "Unbekannt",
+    "emptyTitle": "Wähle eine Konversation",
+    "emptyDescription": "Wähle eine Konversation aus der Liste, um Nachrichten zu lesen und zu senden.",
+    "emptyCtaLabel": "Konversation starten",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Nachricht schreiben...",
+    "sendLabel": "Senden",
+    "sendingLabel": "Senden…",
+    "sendErrorStatus": "Nicht zugestellt",
+    "shortcutsHint": "Drücke Strg+Enter zum Senden",
+    "noMessages": "Noch keine Nachrichten",
+    "loadOlder": "Ältere Nachrichten laden",
+    "participantsLabel": "{count} Teilnehmende"
   },
   "auth": {
     "Account": "Konto",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -11,6 +11,7 @@
       "goBack": "Go back",
       "refresh": "Refresh",
       "notifications": "Open notifications",
+      "messages": "Open messenger",
       "cart": "Open bag",
       "profile": "Open profile menu",
       "viewProfile": "View profile",
@@ -40,6 +41,13 @@
           "time": "1h ago"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Messages",
+      "subtitle": "Recent conversations",
+      "viewAll": "View all",
+      "empty": "You're up to date!",
+      "badgeLabel": "{count} unread messages"
     },
     "userMenu": {
       "signedInAs": "Signed in as",
@@ -124,6 +132,23 @@
       "livesIn": "Lives in {location}",
       "from": "From {location}"
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Search conversations",
+    "emptyList": "No conversations yet",
+    "unknownParticipant": "Unknown",
+    "emptyTitle": "Select a conversation",
+    "emptyDescription": "Choose a conversation from the list to read and send messages.",
+    "emptyCtaLabel": "Start a conversation",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Write a message...",
+    "sendLabel": "Send",
+    "sendingLabel": "Sending…",
+    "sendErrorStatus": "Not delivered",
+    "shortcutsHint": "Press Ctrl+Enter to send",
+    "noMessages": "No messages yet",
+    "loadOlder": "Load earlier messages",
+    "participantsLabel": "{count} participants"
   },
   "banner": {
     "Content": "For Tailwind CSS v3 docs, [**click here**](https://v1.inspira-ui.com)."

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -11,6 +11,7 @@
       "goBack": "Volver",
       "refresh": "Actualizar",
       "notifications": "Abrir notificaciones",
+      "messages": "Abrir Messenger",
       "cart": "Abrir bolsa",
       "profile": "Abrir menú de perfil",
       "viewProfile": "Ver perfil",
@@ -40,6 +41,13 @@
           "time": "hace 1 h"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Mensajes",
+      "subtitle": "Conversaciones recientes",
+      "viewAll": "Ver todo",
+      "empty": "No hay mensajes nuevos",
+      "badgeLabel": "{count} mensajes sin leer"
     },
     "userMenu": {
       "signedInAs": "Conectado como",
@@ -800,6 +808,23 @@
         "buttonAria": "Open the contact page"
       }
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Buscar conversaciones",
+    "emptyList": "Todavía no hay conversaciones",
+    "unknownParticipant": "Desconocido",
+    "emptyTitle": "Selecciona una conversación",
+    "emptyDescription": "Elige una conversación de la lista para leer y enviar mensajes.",
+    "emptyCtaLabel": "Iniciar una conversación",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Escribe un mensaje...",
+    "sendLabel": "Enviar",
+    "sendingLabel": "Enviando…",
+    "sendErrorStatus": "No entregado",
+    "shortcutsHint": "Presiona Ctrl+Enter para enviar",
+    "noMessages": "Aún no hay mensajes",
+    "loadOlder": "Cargar mensajes anteriores",
+    "participantsLabel": "{count} participantes"
   },
   "auth": {
     "Account": "Cuenta",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -11,6 +11,7 @@
       "goBack": "Revenir en arrière",
       "refresh": "Actualiser",
       "notifications": "Ouvrir les notifications",
+      "messages": "Ouvrir Messenger",
       "cart": "Ouvrir le sac",
       "profile": "Ouvrir le menu profil",
       "viewProfile": "Voir le profil",
@@ -40,6 +41,13 @@
           "time": "il y a 1 h"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Messages",
+      "subtitle": "Conversations récentes",
+      "viewAll": "Tout voir",
+      "empty": "Aucun nouveau message",
+      "badgeLabel": "{count} messages non lus"
     },
     "userMenu": {
       "signedInAs": "Connecté en tant que",
@@ -172,6 +180,23 @@
       "GetStartedAndStartBuildingAwesomeUI": "Commencez et créez une interface incroyable",
       "GetStarted": "Commencer"
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Rechercher une conversation",
+    "emptyList": "Aucune conversation pour le moment",
+    "unknownParticipant": "Inconnu",
+    "emptyTitle": "Sélectionnez une conversation",
+    "emptyDescription": "Choisissez une conversation dans la liste pour lire et envoyer des messages.",
+    "emptyCtaLabel": "Commencer une conversation",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Écrire un message…",
+    "sendLabel": "Envoyer",
+    "sendingLabel": "Envoi…",
+    "sendErrorStatus": "Non remis",
+    "shortcutsHint": "Appuyez sur Ctrl+Entrée pour envoyer",
+    "noMessages": "Aucun message pour le moment",
+    "loadOlder": "Charger les messages précédents",
+    "participantsLabel": "{count} participants"
   },
   "auth": {
     "Account": "Compte",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -11,6 +11,7 @@
       "goBack": "Torna indietro",
       "refresh": "Aggiorna",
       "notifications": "Apri notifiche",
+      "messages": "Apri Messenger",
       "cart": "Apri borsa",
       "profile": "Apri menu profilo",
       "viewProfile": "Vedi profilo",
@@ -40,6 +41,13 @@
           "time": "1 h fa"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Messaggi",
+      "subtitle": "Conversazioni recenti",
+      "viewAll": "Vedi tutto",
+      "empty": "Nessun nuovo messaggio",
+      "badgeLabel": "{count} messaggi non letti"
     },
     "userMenu": {
       "signedInAs": "Connesso come",
@@ -800,6 +808,23 @@
         "buttonAria": "Open the contact page"
       }
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Cerca conversazioni",
+    "emptyList": "Ancora nessuna conversazione",
+    "unknownParticipant": "Sconosciuto",
+    "emptyTitle": "Seleziona una conversazione",
+    "emptyDescription": "Scegli una conversazione dall'elenco per leggere e inviare messaggi.",
+    "emptyCtaLabel": "Avvia una conversazione",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Scrivi un messaggio...",
+    "sendLabel": "Invia",
+    "sendingLabel": "Invio…",
+    "sendErrorStatus": "Non consegnato",
+    "shortcutsHint": "Premi Ctrl+Invio per inviare",
+    "noMessages": "Ancora nessun messaggio",
+    "loadOlder": "Carica messaggi precedenti",
+    "participantsLabel": "{count} partecipanti"
   },
   "auth": {
     "Account": "Account",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -11,6 +11,7 @@
       "goBack": "Назад",
       "refresh": "Обновить",
       "notifications": "Открыть уведомления",
+      "messages": "Открыть мессенджер",
       "cart": "Открыть сумку",
       "profile": "Открыть меню профиля",
       "viewProfile": "Просмотреть профиль",
@@ -40,6 +41,13 @@
           "time": "1 ч назад"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "Сообщения",
+      "subtitle": "Последние беседы",
+      "viewAll": "Показать все",
+      "empty": "Новых сообщений нет",
+      "badgeLabel": "{count} непрочитанных сообщений"
     },
     "userMenu": {
       "signedInAs": "Выполнен вход как",
@@ -800,6 +808,23 @@
         "buttonAria": "Open the contact page"
       }
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "Поиск по перепискам",
+    "emptyList": "Пока нет переписок",
+    "unknownParticipant": "Неизвестно",
+    "emptyTitle": "Выберите беседу",
+    "emptyDescription": "Выберите беседу из списка, чтобы читать и отправлять сообщения.",
+    "emptyCtaLabel": "Начать беседу",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "Напишите сообщение...",
+    "sendLabel": "Отправить",
+    "sendingLabel": "Отправка…",
+    "sendErrorStatus": "Не доставлено",
+    "shortcutsHint": "Нажмите Ctrl+Enter для отправки",
+    "noMessages": "Сообщений пока нет",
+    "loadOlder": "Загрузить предыдущие сообщения",
+    "participantsLabel": "{count} участников"
   },
   "auth": {
     "Account": "Аккаунт",

--- a/i18n/locales/zh-cn.json
+++ b/i18n/locales/zh-cn.json
@@ -11,6 +11,7 @@
       "goBack": "返回",
       "refresh": "刷新",
       "notifications": "打开通知",
+      "messages": "打开消息",
       "cart": "打开包",
       "profile": "打开个人菜单",
       "viewProfile": "查看个人资料",
@@ -40,6 +41,13 @@
           "time": "1 小时前"
         }
       }
+    },
+    "messengerMenu": {
+      "title": "消息",
+      "subtitle": "最近的会话",
+      "viewAll": "查看全部",
+      "empty": "暂无新消息",
+      "badgeLabel": "{count} 条未读消息"
     },
     "userMenu": {
       "signedInAs": "已登录身份",
@@ -172,6 +180,23 @@
       "GetStartedAndStartBuildingAwesomeUI": "开始构建出色的 UI 吧",
       "GetStarted": "开始"
     }
+  },
+  "messenger": {
+    "searchPlaceholder": "搜索会话",
+    "emptyList": "暂无会话",
+    "unknownParticipant": "未知",
+    "emptyTitle": "选择一个会话",
+    "emptyDescription": "从列表中选择一个会话以阅读并发送消息。",
+    "emptyCtaLabel": "开始会话",
+    "emptyCtaLink": "/messenger",
+    "composerPlaceholder": "输入消息...",
+    "sendLabel": "发送",
+    "sendingLabel": "正在发送…",
+    "sendErrorStatus": "未送达",
+    "shortcutsHint": "按 Ctrl+Enter 发送",
+    "noMessages": "暂无消息",
+    "loadOlder": "加载更早的消息",
+    "participantsLabel": "{count} 位参与者"
   },
   "auth": {
     "Account": "账户",

--- a/lib/datetime/relative-time.ts
+++ b/lib/datetime/relative-time.ts
@@ -1,0 +1,39 @@
+export function formatRelativeTime(
+  value: string | null | undefined,
+  locale: string,
+): string {
+  if (!value) {
+    return "";
+  }
+
+  const timestamp = Date.parse(value);
+
+  if (Number.isNaN(timestamp)) {
+    return "";
+  }
+
+  const diff = timestamp - Date.now();
+  const seconds = Math.round(diff / 1000);
+  const absolute = Math.abs(seconds);
+
+  const table: Array<{ limit: number; divisor: number; unit: Intl.RelativeTimeFormatUnit }> = [
+    { limit: 60, divisor: 1, unit: "second" },
+    { limit: 3600, divisor: 60, unit: "minute" },
+    { limit: 86_400, divisor: 3600, unit: "hour" },
+    { limit: 604_800, divisor: 86_400, unit: "day" },
+    { limit: 2_629_746, divisor: 604_800, unit: "week" },
+    { limit: 31_556_952, divisor: 2_629_746, unit: "month" },
+    { limit: Number.POSITIVE_INFINITY, divisor: 31_556_952, unit: "year" },
+  ];
+
+  const formatter = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
+
+  for (const entry of table) {
+    if (absolute < entry.limit) {
+      const value = Math.round(seconds / entry.divisor);
+      return formatter.format(value, entry.unit);
+    }
+  }
+
+  return formatter.format(0, "second");
+}

--- a/lib/messenger/display.ts
+++ b/lib/messenger/display.ts
@@ -1,0 +1,67 @@
+import type { MessengerConversation, MessengerMessage, MessengerParticipant } from "~/types/messenger";
+
+export function resolveConversationTitle(
+  conversation: MessengerConversation,
+  currentUserId: string | null,
+  fallback: string,
+): string {
+  if (conversation.title) {
+    return conversation.title;
+  }
+
+  const participants = Array.isArray(conversation.participants)
+    ? conversation.participants
+    : [];
+
+  const others = participants.filter((participant) => participant.id !== currentUserId);
+  const base = (others.length ? others : participants)
+    .map((participant) => participant.displayName?.trim())
+    .filter(Boolean)
+    .join(", ");
+
+  return base || fallback;
+}
+
+export function resolveParticipantInitials(participant: MessengerParticipant | undefined, fallback: string): string {
+  if (!participant) {
+    return fallback;
+  }
+
+  if (!participant.displayName) {
+    return fallback;
+  }
+
+  return (
+    participant.displayName
+      .split(" ")
+      .map((segment) => segment.charAt(0))
+      .join("")
+      .slice(0, 2)
+      .toUpperCase() || fallback
+  );
+}
+
+export function resolveConversationAvatar(
+  conversation: MessengerConversation,
+  currentUserId: string | null,
+  fallback: string,
+): { url: string | null; initials: string } {
+  const participants = Array.isArray(conversation.participants)
+    ? conversation.participants
+    : [];
+
+  const target = participants.find((participant) => participant.id !== currentUserId) ?? participants[0];
+
+  return {
+    url: target?.avatarUrl ?? null,
+    initials: resolveParticipantInitials(target, fallback),
+  };
+}
+
+export function resolveMessageSender(message: MessengerMessage | null | undefined, fallback: string): string {
+  if (!message?.sender) {
+    return fallback;
+  }
+
+  return message.sender.displayName?.trim() || fallback;
+}

--- a/pages/messenger/[id].vue
+++ b/pages/messenger/[id].vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="flex h-[calc(100vh-50px)] flex-col md:flex-row">
+    <ConversationsList
+      :conversations="conversations"
+      :active-id="conversationId"
+      :loading="loading"
+      :search-placeholder="t('messenger.searchPlaceholder')"
+      :empty-label="t('messenger.emptyList')"
+      :unknown-label="t('messenger.unknownParticipant')"
+      @select="handleSelect"
+    />
+    <ChatPane
+      class="flex-1"
+      :composer-placeholder="t('messenger.composerPlaceholder')"
+      :send-label="t('messenger.sendLabel')"
+      :sending-label="t('messenger.sendingLabel')"
+      :send-error-label="t('messenger.sendErrorStatus')"
+      :shortcuts-hint="t('messenger.shortcutsHint')"
+      :empty-title="t('messenger.emptyTitle')"
+      :empty-description="t('messenger.emptyDescription')"
+      :empty-cta-label="t('messenger.emptyCtaLabel')"
+      :empty-cta-to="emptyCtaTo"
+      :no-messages-label="t('messenger.noMessages')"
+      :load-older-label="t('messenger.loadOlder')"
+      :participants-label="t('messenger.participantsLabel')"
+      :unknown-label="t('messenger.unknownParticipant')"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { callOnce, navigateTo } from "#imports";
+import ConversationsList from "~/components/messenger/ConversationsList.vue";
+import ChatPane from "~/components/messenger/ChatPane.vue";
+import { useMessengerStore } from "~/stores/messenger";
+
+const messenger = useMessengerStore();
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+
+await callOnce(() => messenger.fetchThreads({ limit: 50 }));
+
+const conversationId = computed(() => String(route.params.id ?? ""));
+const conversations = computed(() => messenger.orderedConversations.value ?? []);
+const loading = computed(() => messenger.loadingList.value);
+const emptyCtaTo = computed(() => {
+  const raw = t("messenger.emptyCtaLink");
+  return raw === "messenger.emptyCtaLink" ? undefined : raw;
+});
+
+async function ensureConversation(id: string) {
+  if (!id) {
+    const latest = messenger.latestConversationId.value;
+
+    if (latest) {
+      await navigateTo({ path: `/messenger/${latest}`, replace: true });
+    }
+
+    return;
+  }
+
+  const conversation = await messenger.openConversation(id);
+
+  if (!conversation) {
+    const fallback = messenger.latestConversationId.value;
+
+    if (fallback && fallback !== id) {
+      await navigateTo({ path: `/messenger/${fallback}`, replace: true });
+    } else {
+      await navigateTo({ path: "/messenger", replace: true });
+    }
+  }
+}
+
+await ensureConversation(conversationId.value);
+
+watch(
+  () => conversationId.value,
+  (id, previous) => {
+    if (id && id !== previous) {
+      ensureConversation(id);
+    }
+  },
+);
+
+function handleSelect(id: string) {
+  if (!id) {
+    return;
+  }
+
+  router.push({ path: `/messenger/${id}` });
+}
+</script>

--- a/pages/messenger/index.vue
+++ b/pages/messenger/index.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="flex h-[calc(100vh-50px)] flex-col md:flex-row">
+    <ConversationsList
+      :conversations="conversations"
+      :active-id="null"
+      :loading="loading"
+      :search-placeholder="t('messenger.searchPlaceholder')"
+      :empty-label="t('messenger.emptyList')"
+      :unknown-label="t('messenger.unknownParticipant')"
+      @select="handleSelect"
+    />
+    <div class="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-10 text-center">
+      <div class="flex h-20 w-20 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <AppIcon
+          name="mdi:message-outline"
+          :size="48"
+        />
+      </div>
+      <div class="space-y-2">
+        <h1 class="text-2xl font-semibold">
+          {{ t('messenger.emptyTitle') }}
+        </h1>
+        <p class="max-w-md text-sm text-muted-foreground">
+          {{ t('messenger.emptyDescription') }}
+        </p>
+      </div>
+      <v-btn
+        color="primary"
+        variant="flat"
+        :to="emptyCtaTo"
+        >
+        {{ t('messenger.emptyCtaLabel') }}
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import { useI18n } from "vue-i18n";
+import { callOnce, navigateTo } from "#imports";
+import ConversationsList from "~/components/messenger/ConversationsList.vue";
+import { useMessengerStore } from "~/stores/messenger";
+
+const messenger = useMessengerStore();
+const router = useRouter();
+const { t } = useI18n();
+
+await callOnce(() => messenger.fetchThreads({ limit: 50 }));
+
+const latestConversationId = messenger.latestConversationId.value;
+
+if (latestConversationId) {
+  await navigateTo({ path: `/messenger/${latestConversationId}`, replace: true });
+}
+
+const conversations = computed(() => messenger.orderedConversations.value ?? []);
+const loading = computed(() => messenger.loadingList.value);
+const emptyCtaTo = computed(() => {
+  const raw = t("messenger.emptyCtaLink");
+  return raw === "messenger.emptyCtaLink" ? undefined : raw;
+});
+
+function handleSelect(id: string) {
+  router.push({ path: `/messenger/${id}` });
+}
+</script>

--- a/stores/messenger.ts
+++ b/stores/messenger.ts
@@ -1,0 +1,968 @@
+import { computed, ref, shallowRef, watch } from "vue";
+import { defineStore } from "~/lib/pinia-shim";
+import { useAuthSession } from "~/stores/auth-session";
+import { useMercure } from "~/composables/useMercure";
+import type {
+  MessengerConversation,
+  MessengerConversationEnvelope,
+  MessengerMercureEnvelope,
+  MessengerMessage,
+  MessengerMessagesEnvelope,
+  MessengerParticipant,
+  MessengerSendMessagePayload,
+  MessengerThreadEnvelope,
+} from "~/types/messenger";
+import { useRequestFetch, useRuntimeConfig, useState } from "#imports";
+
+interface FetchThreadsOptions {
+  limit?: number;
+  offset?: number;
+  force?: boolean;
+}
+
+interface FetchMessagesOptions {
+  before?: string | null;
+  limit?: number;
+}
+
+interface NormalizedConversation extends MessengerConversation {
+  participants: MessengerParticipant[];
+}
+
+interface ConversationPaginationState {
+  before: string | null;
+  hasMore: boolean;
+  pending: boolean;
+}
+
+interface SendMessageState {
+  pending: boolean;
+  error: string | null;
+}
+
+const DEFAULT_PREVIEW_LIMIT = 3;
+const DEFAULT_LIST_LIMIT = 50;
+
+function resolveFetcher() {
+  if (import.meta.server) {
+    return useRequestFetch();
+  }
+
+  return $fetch;
+}
+
+function isIsoDate(value: string | undefined | null) {
+  if (!value) {
+    return false;
+  }
+
+  return !Number.isNaN(Date.parse(value));
+}
+
+function normalizeParticipant(participant: MessengerParticipant): MessengerParticipant {
+  return {
+    id: participant.id,
+    displayName: participant.displayName?.trim() || "",
+    avatarUrl: participant.avatarUrl ?? null,
+    isActive: participant.isActive ?? false,
+  };
+}
+
+function normalizeMessage(message: MessengerMessage): MessengerMessage {
+  return {
+    ...message,
+    conversationId: message.conversationId,
+    sender: normalizeParticipant(message.sender),
+    content: message.content ?? "",
+    createdAt: isIsoDate(message.createdAt) ? message.createdAt : new Date().toISOString(),
+    attachments: Array.isArray(message.attachments) ? [...message.attachments] : [],
+    status: message.status ?? "sent",
+    optimistic: Boolean(message.optimistic),
+  };
+}
+
+function normalizeConversation(conversation: MessengerConversation): NormalizedConversation {
+  return {
+    id: conversation.id,
+    title: conversation.title ?? null,
+    participants: Array.isArray(conversation.participants)
+      ? conversation.participants.map(normalizeParticipant)
+      : [],
+    lastMessage: conversation.lastMessage ? normalizeMessage(conversation.lastMessage) : null,
+    unreadCount: Math.max(Number(conversation.unreadCount ?? 0), 0),
+    updatedAt: isIsoDate(conversation.updatedAt)
+      ? conversation.updatedAt
+      : conversation.lastMessage?.createdAt ?? new Date().toISOString(),
+  };
+}
+
+function sortConversationIds(
+  conversations: Record<string, MessengerConversation>,
+  ids: string[],
+): string[] {
+  return [...ids].sort((a, b) => {
+    const left = conversations[a]?.updatedAt ?? "";
+    const right = conversations[b]?.updatedAt ?? "";
+
+    const leftTimestamp = Date.parse(left);
+    const rightTimestamp = Date.parse(right);
+
+    if (Number.isNaN(leftTimestamp) && Number.isNaN(rightTimestamp)) {
+      return 0;
+    }
+
+    if (Number.isNaN(leftTimestamp)) {
+      return 1;
+    }
+
+    if (Number.isNaN(rightTimestamp)) {
+      return -1;
+    }
+
+    return rightTimestamp - leftTimestamp;
+  });
+}
+
+function uniqueIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  ids.forEach((id) => {
+    if (!seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  });
+
+  return result;
+}
+
+function createOptimisticMessage(
+  conversationId: string,
+  sender: MessengerParticipant,
+  content: string,
+): MessengerMessage {
+  return {
+    id: `optimistic-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    conversationId,
+    sender,
+    content,
+    createdAt: new Date().toISOString(),
+    status: "pending",
+    optimistic: true,
+  };
+}
+
+export const useMessengerStore = defineStore("messenger", () => {
+  const auth = useAuthSession();
+  const runtimeConfig = useRuntimeConfig();
+  const fetcher = resolveFetcher();
+  const connectToMercure = import.meta.client ? useMercure() : null;
+
+  const conversations = useState<Record<string, NormalizedConversation>>("messenger-conversations", () => ({}));
+  const conversationOrder = useState<string[]>("messenger-conversation-order", () => []);
+  const messages = useState<Record<string, MessengerMessage[]>>("messenger-messages", () => ({}));
+  const pagination = useState<Record<string, ConversationPaginationState>>(
+    "messenger-pagination",
+    () => ({}),
+  );
+  const sendState = useState<Record<string, SendMessageState>>("messenger-send-state", () => ({}));
+  const activeConversationId = useState<string | null>("messenger-active-id", () => null);
+  const previewFetchedAt = useState<number | null>("messenger-preview-fetched", () => null);
+  const loadingPreview = useState<boolean>("messenger-preview-loading", () => false);
+  const loadingList = useState<boolean>("messenger-list-loading", () => false);
+  const loadingMessages = useState<Record<string, boolean>>("messenger-messages-loading", () => ({}));
+  const lastReadMessage = useState<Record<string, string | null>>("messenger-last-read", () => ({}));
+  const errorState = useState<string | null>("messenger-error", () => null);
+
+  const inboxSource = shallowRef<EventSource | null>(null);
+  const conversationSource = shallowRef<EventSource | null>(null);
+  const conversationSubscriptionId = ref<string | null>(null);
+
+  function resetState() {
+    conversations.value = {};
+    conversationOrder.value = [];
+    messages.value = {};
+    pagination.value = {} as Record<string, ConversationPaginationState>;
+    sendState.value = {} as Record<string, SendMessageState>;
+    activeConversationId.value = null;
+    previewFetchedAt.value = null;
+    loadingPreview.value = false;
+    loadingList.value = false;
+    loadingMessages.value = {} as Record<string, boolean>;
+    lastReadMessage.value = {} as Record<string, string | null>;
+    errorState.value = null;
+    closeInboxSource();
+    closeConversationSource();
+  }
+
+  function closeInboxSource() {
+    if (inboxSource.value) {
+      inboxSource.value.close();
+      inboxSource.value = null;
+    }
+  }
+
+  function closeConversationSource() {
+    if (conversationSource.value) {
+      conversationSource.value.close();
+      conversationSource.value = null;
+    }
+
+    conversationSubscriptionId.value = null;
+  }
+
+  function upsertConversation(conversation: MessengerConversation) {
+    const normalized = normalizeConversation(conversation);
+
+    conversations.value = {
+      ...conversations.value,
+      [normalized.id]: {
+        ...(conversations.value[normalized.id] ?? normalized),
+        ...normalized,
+      },
+    };
+
+    const mergedOrder = uniqueIds([normalized.id, ...conversationOrder.value]);
+    conversationOrder.value = sortConversationIds(conversations.value, mergedOrder);
+  }
+
+  function setConversations(list: MessengerConversation[]) {
+    const mapped: Record<string, NormalizedConversation> = {};
+    const ids: string[] = [];
+
+    list.forEach((conversation) => {
+      const normalized = normalizeConversation(conversation);
+      mapped[normalized.id] = {
+        ...(conversations.value[normalized.id] ?? normalized),
+        ...normalized,
+      };
+      ids.push(normalized.id);
+    });
+
+    conversations.value = {
+      ...conversations.value,
+      ...mapped,
+    };
+
+    const combinedIds = uniqueIds([...ids, ...conversationOrder.value]);
+    conversationOrder.value = sortConversationIds(conversations.value, combinedIds);
+  }
+
+  function getMessagesState(conversationId: string) {
+    return messages.value[conversationId] ?? [];
+  }
+
+  function setMessages(conversationId: string, list: MessengerMessage[]) {
+    const normalized = list.map(normalizeMessage);
+
+    messages.value = {
+      ...messages.value,
+      [conversationId]: normalized.sort((a, b) => {
+        const left = Date.parse(a.createdAt);
+        const right = Date.parse(b.createdAt);
+
+        if (Number.isNaN(left) || Number.isNaN(right)) {
+          return 0;
+        }
+
+        return left - right;
+      }),
+    };
+  }
+
+  function appendMessage(conversationId: string, message: MessengerMessage) {
+    const current = getMessagesState(conversationId);
+    const normalized = normalizeMessage(message);
+
+    if (current.some((entry) => entry.id === normalized.id)) {
+      return;
+    }
+
+    const next = [...current, normalized].sort((a, b) => {
+      const left = Date.parse(a.createdAt);
+      const right = Date.parse(b.createdAt);
+
+      if (Number.isNaN(left) || Number.isNaN(right)) {
+        return 0;
+      }
+
+      return left - right;
+    });
+
+    messages.value = {
+      ...messages.value,
+      [conversationId]: next,
+    };
+  }
+
+  function replaceMessage(conversationId: string, optimisticId: string, replacement: MessengerMessage) {
+    const current = getMessagesState(conversationId);
+    const index = current.findIndex((message) => message.id === optimisticId);
+
+    if (index === -1) {
+      appendMessage(conversationId, replacement);
+      return;
+    }
+
+    const updated = [...current];
+    updated.splice(index, 1, normalizeMessage(replacement));
+
+    messages.value = {
+      ...messages.value,
+      [conversationId]: updated,
+    };
+  }
+
+  function markMessageAsError(conversationId: string, messageId: string) {
+    const current = getMessagesState(conversationId);
+    const index = current.findIndex((message) => message.id === messageId);
+
+    if (index === -1) {
+      return;
+    }
+
+    const updated = [...current];
+    updated.splice(index, 1, {
+      ...current[index],
+      status: "error",
+      optimistic: false,
+    });
+
+    messages.value = {
+      ...messages.value,
+      [conversationId]: updated,
+    };
+  }
+
+  function removeMessage(conversationId: string, messageId: string) {
+    const current = getMessagesState(conversationId);
+
+    if (!current.some((message) => message.id === messageId)) {
+      return;
+    }
+
+    messages.value = {
+      ...messages.value,
+      [conversationId]: current.filter((message) => message.id !== messageId),
+    };
+  }
+
+  function setPagination(conversationId: string, state: Partial<ConversationPaginationState>) {
+    const previous = pagination.value[conversationId] ?? {
+      before: null,
+      hasMore: false,
+      pending: false,
+    };
+
+    pagination.value = {
+      ...pagination.value,
+      [conversationId]: {
+        ...previous,
+        ...state,
+      },
+    };
+  }
+
+  function setSendState(conversationId: string, state: Partial<SendMessageState>) {
+    const previous = sendState.value[conversationId] ?? { pending: false, error: null };
+
+    sendState.value = {
+      ...sendState.value,
+      [conversationId]: {
+        ...previous,
+        ...state,
+      },
+    };
+  }
+
+  function markConversationReadLocal(conversationId: string, lastMessageId: string | null) {
+    const conversation = conversations.value[conversationId];
+
+    if (!conversation) {
+      return;
+    }
+
+    conversations.value = {
+      ...conversations.value,
+      [conversationId]: {
+        ...conversation,
+        unreadCount: 0,
+      },
+    };
+
+    lastReadMessage.value = {
+      ...lastReadMessage.value,
+      [conversationId]: lastMessageId ?? conversation.lastMessage?.id ?? null,
+    };
+  }
+
+  async function fetchThreads(options: FetchThreadsOptions = {}) {
+    if (loadingPreview.value || loadingList.value) {
+      if (!options.force) {
+        return;
+      }
+    }
+
+    const limit = options.limit ?? DEFAULT_LIST_LIMIT;
+    const offset = options.offset ?? 0;
+    const now = Date.now();
+
+    if (!options.force && limit <= DEFAULT_PREVIEW_LIMIT && previewFetchedAt.value) {
+      if (now - previewFetchedAt.value < 30_000) {
+        return;
+      }
+    }
+
+    const params: Record<string, string | number> = { limit, offset };
+    const isPreview = limit <= DEFAULT_PREVIEW_LIMIT;
+
+    if (isPreview) {
+      loadingPreview.value = true;
+    } else {
+      loadingList.value = true;
+    }
+
+    try {
+      errorState.value = null;
+      const response = await fetcher<MessengerThreadEnvelope | MessengerConversation[]>(
+        "/api/v1/messenger/threads",
+        {
+          method: "GET",
+          params,
+        },
+      );
+
+      const data = Array.isArray((response as MessengerThreadEnvelope)?.data)
+        ? (response as MessengerThreadEnvelope).data
+        : Array.isArray(response)
+          ? response
+          : [];
+
+      if (data.length) {
+        setConversations(data);
+        if (isPreview) {
+          previewFetchedAt.value = now;
+        }
+      }
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error("Failed to fetch messenger threads", error);
+      }
+      errorState.value = error instanceof Error ? error.message : "Unable to load conversations.";
+    } finally {
+      if (isPreview) {
+        loadingPreview.value = false;
+      } else {
+        loadingList.value = false;
+      }
+    }
+  }
+
+  async function fetchConversation(conversationId: string) {
+    try {
+      errorState.value = null;
+      const response = await fetcher<MessengerConversationEnvelope | (MessengerConversation & { messages?: MessengerMessage[] })>(
+        `/api/v1/messenger/threads/${conversationId}`,
+      );
+
+      const payload = (response as MessengerConversationEnvelope)?.data
+        ? (response as MessengerConversationEnvelope).data
+        : (response as MessengerConversation & { messages?: MessengerMessage[] });
+
+      if (!payload) {
+        return null;
+      }
+
+      const { messages: initialMessages = [], ...conversation } = payload;
+      upsertConversation(conversation);
+
+      if (Array.isArray(initialMessages) && initialMessages.length) {
+        setMessages(conversationId, initialMessages);
+      }
+
+      return conversations.value[conversationId] ?? null;
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error(`Failed to fetch conversation ${conversationId}`, error);
+      }
+
+      errorState.value = error instanceof Error ? error.message : "Unable to load conversation.";
+      return null;
+    }
+  }
+
+  async function fetchMessages(conversationId: string, options: FetchMessagesOptions = {}) {
+    const state = pagination.value[conversationId] ?? { before: null, hasMore: true, pending: false };
+
+    if (state.pending) {
+      return;
+    }
+
+    if (!state.hasMore && !options.before) {
+      return;
+    }
+
+    const before = options.before ?? state.before;
+    const limit = options.limit ?? 50;
+
+    setPagination(conversationId, { pending: true });
+    loadingMessages.value = {
+      ...loadingMessages.value,
+      [conversationId]: true,
+    };
+
+    try {
+      const response = await fetcher<MessengerMessagesEnvelope | MessengerMessage[]>(
+        `/api/v1/messenger/threads/${conversationId}/messages`,
+        {
+          method: "GET",
+          params: {
+            before: before ?? undefined,
+            limit,
+          },
+        },
+      );
+
+      const list = Array.isArray((response as MessengerMessagesEnvelope)?.data)
+        ? (response as MessengerMessagesEnvelope).data
+        : Array.isArray(response)
+          ? response
+          : [];
+
+      if (!list.length) {
+        setPagination(conversationId, { pending: false, hasMore: false });
+        return;
+      }
+
+      const current = getMessagesState(conversationId);
+      const normalized = list.map(normalizeMessage);
+      const merged = uniqueIds([...normalized.map((message) => message.id), ...current.map((message) => message.id)]);
+
+      const mergedMessages = merged
+        .map((id) => normalized.find((message) => message.id === id) ?? current.find((message) => message.id === id)!)
+        .sort((a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt));
+
+      messages.value = {
+        ...messages.value,
+        [conversationId]: mergedMessages,
+      };
+
+      const lastItem = normalized[0];
+
+      setPagination(conversationId, {
+        pending: false,
+        hasMore: Boolean((response as MessengerMessagesEnvelope)?.hasMore ?? normalized.length === limit),
+        before: lastItem?.id ?? null,
+      });
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error(`Failed to fetch messages for conversation ${conversationId}`, error);
+      }
+
+      setPagination(conversationId, { pending: false });
+    } finally {
+      loadingMessages.value = {
+        ...loadingMessages.value,
+        [conversationId]: false,
+      };
+    }
+  }
+
+  async function markConversationRead(conversationId: string, lastMessageId?: string | null) {
+    const conversation = conversations.value[conversationId];
+
+    if (!conversation) {
+      return;
+    }
+
+    const lastMessage = lastMessageId ?? conversation.lastMessage?.id ?? null;
+    markConversationReadLocal(conversationId, lastMessage);
+
+    try {
+      await fetcher(`/api/v1/messenger/threads/${conversationId}/read`, {
+        method: "POST",
+        body: lastMessage ? { lastMessageId: lastMessage } : undefined,
+      });
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error(`Failed to mark conversation ${conversationId} as read`, error);
+      }
+    }
+  }
+
+  async function sendMessage(conversationId: string, payload: MessengerSendMessagePayload) {
+    const conversation = conversations.value[conversationId];
+    const currentUser = auth.currentUser.value;
+
+    if (!conversation || !currentUser) {
+      throw new Error("A conversation and authenticated user are required to send messages.");
+    }
+
+    const sender: MessengerParticipant = {
+      id: currentUser.id,
+      displayName:
+        [currentUser.firstName, currentUser.lastName].filter(Boolean).join(" ") || currentUser.username || "You",
+      avatarUrl: currentUser.photo ?? null,
+    };
+
+    const trimmedContent = payload.content?.trim();
+
+    if (!trimmedContent) {
+      return null;
+    }
+
+    const optimistic = createOptimisticMessage(conversationId, sender, trimmedContent);
+    appendMessage(conversationId, optimistic);
+    setSendState(conversationId, { pending: true, error: null });
+
+    try {
+      const response = await fetcher<MessengerMessage>(
+        `/api/v1/messenger/threads/${conversationId}/messages`,
+        {
+          method: "POST",
+          body: {
+            content: trimmedContent,
+            attachments: payload.attachments ?? [],
+          },
+        },
+      );
+
+      if (response && response.id) {
+        replaceMessage(conversationId, optimistic.id, {
+          ...response,
+          status: "sent",
+          optimistic: false,
+        });
+      } else {
+        removeMessage(conversationId, optimistic.id);
+      }
+
+      setSendState(conversationId, { pending: false, error: null });
+
+      upsertConversation({
+        ...conversation,
+        lastMessage: normalizeMessage(response ?? optimistic),
+        updatedAt: (response ?? optimistic).createdAt,
+        unreadCount: 0,
+      });
+
+      return response ?? optimistic;
+    } catch (error) {
+      setSendState(conversationId, {
+        pending: false,
+        error: error instanceof Error ? error.message : "Unable to send message.",
+      });
+      markMessageAsError(conversationId, optimistic.id);
+
+      if (import.meta.dev) {
+        console.error(`Failed to send message in conversation ${conversationId}`, error);
+      }
+
+      return null;
+    }
+  }
+
+  async function openConversation(conversationId: string) {
+    if (!conversationId) {
+      return null;
+    }
+
+    activeConversationId.value = conversationId;
+
+    if (!conversations.value[conversationId]) {
+      await fetchConversation(conversationId);
+    }
+
+    if (!messages.value[conversationId]) {
+      await fetchConversation(conversationId);
+    }
+
+    await fetchMessages(conversationId, { limit: 50 });
+    await subscribeToConversation(conversationId);
+
+    return conversations.value[conversationId] ?? null;
+  }
+
+  function handleMercurePayload(payload: MessengerMercureEnvelope) {
+    if (!payload?.conversationId) {
+      return;
+    }
+
+    const conversationId = payload.conversationId;
+
+    switch (payload.type) {
+      case "message.created": {
+        if (!payload.message) {
+          return;
+        }
+
+        const normalized = normalizeMessage(payload.message);
+        appendMessage(conversationId, { ...normalized, status: "sent", optimistic: false });
+
+        const conversation = conversations.value[conversationId];
+        const unreadCount = conversationId === activeConversationId.value
+          ? 0
+          : payload.unreadCount ?? (conversation?.unreadCount ?? 0) + 1;
+
+        upsertConversation({
+          ...(conversation ?? {
+            id: conversationId,
+            participants: normalized.sender ? [normalized.sender] : [],
+            lastMessage: normalized,
+            unreadCount,
+            updatedAt: normalized.createdAt,
+          }),
+          lastMessage: normalized,
+          unreadCount,
+          updatedAt: normalized.createdAt,
+        });
+
+        if (conversationId === activeConversationId.value) {
+          markConversationReadLocal(conversationId, normalized.id);
+        }
+
+        break;
+      }
+
+      case "conversation.updated": {
+        const conversation = conversations.value[conversationId];
+        const lastMessage = payload.lastMessage ? normalizeMessage(payload.lastMessage) : conversation?.lastMessage ?? null;
+
+        upsertConversation({
+          ...(conversation ?? {
+            id: conversationId,
+            participants: lastMessage ? [lastMessage.sender] : [],
+            lastMessage,
+            unreadCount: payload.unreadCount ?? 0,
+            updatedAt: lastMessage?.createdAt ?? new Date().toISOString(),
+          }),
+          lastMessage,
+          unreadCount: payload.unreadCount ?? conversation?.unreadCount ?? 0,
+          updatedAt: lastMessage?.createdAt ?? conversation?.updatedAt ?? new Date().toISOString(),
+        });
+
+        break;
+      }
+
+      case "message.read": {
+        if (payload.userId && payload.userId !== auth.currentUser.value?.id) {
+          break;
+        }
+
+        markConversationReadLocal(conversationId, payload.lastReadMessageId ?? null);
+        break;
+      }
+
+      default:
+        break;
+    }
+  }
+
+  function bindEventSource(source: EventSource | null) {
+    if (!source) {
+      return;
+    }
+
+    source.onmessage = (event) => {
+      try {
+        const payload = JSON.parse(event.data) as MessengerMercureEnvelope;
+        handleMercurePayload(payload);
+      } catch (error) {
+        if (import.meta.dev) {
+          console.error("Failed to parse Mercure payload", error);
+        }
+      }
+    };
+
+    source.onerror = (event) => {
+      if (import.meta.dev) {
+        console.error("Mercure connection error", event);
+      }
+    };
+  }
+
+  async function ensureMercureToken(): Promise<string | null> {
+    const token = auth.mercureToken.value;
+
+    if (token) {
+      return token;
+    }
+
+    const refreshed = await auth.refreshMercureToken();
+    return refreshed?.token ?? null;
+  }
+
+  async function connectInbox() {
+    if (import.meta.server) {
+      return null;
+    }
+
+    if (inboxSource.value) {
+      return inboxSource.value;
+    }
+
+    const userId = auth.currentUser.value?.id;
+    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? runtimeConfig.mercure?.hubUrl;
+
+    if (!userId || !hubUrl) {
+      return null;
+    }
+
+    if (!connectToMercure) {
+      return null;
+    }
+
+    try {
+      const token = await ensureMercureToken();
+
+      inboxSource.value = connectToMercure(hubUrl, {
+        token: token ?? undefined,
+        params: {
+          topic: `/messenger/users/${userId}`,
+        },
+      });
+      bindEventSource(inboxSource.value);
+      return inboxSource.value;
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error("Failed to connect to inbox Mercure topic", error);
+      }
+
+      return null;
+    }
+  }
+
+  async function subscribeToConversation(conversationId: string) {
+    if (import.meta.server) {
+      return;
+    }
+
+    if (!conversationId) {
+      return;
+    }
+
+    if (conversationSubscriptionId.value === conversationId) {
+      return;
+    }
+
+    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? runtimeConfig.mercure?.hubUrl;
+
+    if (!hubUrl || !connectToMercure) {
+      return;
+    }
+
+    try {
+      const token = await ensureMercureToken();
+      closeConversationSource();
+
+      conversationSource.value = connectToMercure(hubUrl, {
+        token: token ?? undefined,
+        params: {
+          topic: `/messenger/conversations/${conversationId}`,
+        },
+      });
+      conversationSubscriptionId.value = conversationId;
+      bindEventSource(conversationSource.value);
+    } catch (error) {
+      if (import.meta.dev) {
+        console.error(`Failed to subscribe to conversation ${conversationId}`, error);
+      }
+    }
+  }
+
+  watch(
+    () => auth.isAuthenticated.value,
+    (authenticated) => {
+      if (!authenticated) {
+        resetState();
+        return;
+      }
+
+      fetchThreads({ limit: DEFAULT_PREVIEW_LIMIT }).catch(() => {});
+      connectInbox()?.catch(() => {});
+    },
+    { immediate: true },
+  );
+
+  const previewConversations = computed(() =>
+    conversationOrder.value.slice(0, DEFAULT_PREVIEW_LIMIT).map((id) => conversations.value[id]).filter(Boolean),
+  );
+
+  const orderedConversations = computed(() => conversationOrder.value.map((id) => conversations.value[id]).filter(Boolean));
+
+  const unreadTotal = computed(() =>
+    orderedConversations.value.reduce((total, conversation) => total + (conversation?.unreadCount ?? 0), 0),
+  );
+
+  const activeConversation = computed(() => {
+    if (!activeConversationId.value) {
+      return null;
+    }
+
+    return conversations.value[activeConversationId.value] ?? null;
+  });
+
+  const currentMessages = computed(() => {
+    if (!activeConversationId.value) {
+      return [] as MessengerMessage[];
+    }
+
+    return messages.value[activeConversationId.value] ?? [];
+  });
+
+  const sendingMessage = computed(() => {
+    if (!activeConversationId.value) {
+      return false;
+    }
+
+    return sendState.value[activeConversationId.value]?.pending ?? false;
+  });
+
+  const sendError = computed(() => {
+    if (!activeConversationId.value) {
+      return null as string | null;
+    }
+
+    return sendState.value[activeConversationId.value]?.error ?? null;
+  });
+
+  const hasConversations = computed(() => orderedConversations.value.length > 0);
+  const latestConversationId = computed(() => conversationOrder.value[0] ?? null);
+
+  return {
+    conversations,
+    conversationOrder,
+    messages,
+    pagination,
+    sendState,
+    activeConversationId,
+    loadingPreview,
+    loadingList,
+    loadingMessages,
+    errorState,
+    previewConversations,
+    orderedConversations,
+    unreadTotal,
+    activeConversation,
+    currentMessages,
+    sendingMessage,
+    sendError,
+    hasConversations,
+    latestConversationId,
+    lastReadMessage,
+    fetchThreads,
+    fetchConversation,
+    fetchMessages,
+    markConversationRead,
+    sendMessage,
+    openConversation,
+    setPagination,
+    getMessagesState,
+    appendMessage,
+    markConversationReadLocal,
+    connectInbox,
+    subscribeToConversation,
+    resetState,
+  };
+});

--- a/types/messenger.ts
+++ b/types/messenger.ts
@@ -1,0 +1,71 @@
+export interface MessengerParticipant {
+  id: string;
+  displayName: string;
+  avatarUrl?: string | null;
+  isActive?: boolean;
+}
+
+export interface MessengerMessage {
+  id: string;
+  conversationId: string;
+  sender: MessengerParticipant;
+  content: string;
+  createdAt: string;
+  attachments?: MessengerAttachment[];
+  readAt?: string | null;
+  status?: MessengerMessageStatus;
+  optimistic?: boolean;
+}
+
+export interface MessengerAttachment {
+  id: string;
+  name: string;
+  url: string;
+  mimeType?: string;
+  size?: number;
+}
+
+export type MessengerMessageStatus = "pending" | "sent" | "error";
+
+export interface MessengerConversation {
+  id: string;
+  title?: string | null;
+  participants: MessengerParticipant[];
+  lastMessage: MessengerMessage | null;
+  unreadCount: number;
+  updatedAt: string;
+}
+
+export interface MessengerThreadEnvelope {
+  data: MessengerConversation[];
+  total?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface MessengerConversationEnvelope {
+  data: MessengerConversation & {
+    messages?: MessengerMessage[];
+  };
+}
+
+export interface MessengerMessagesEnvelope {
+  data: MessengerMessage[];
+  nextBefore?: string | null;
+  hasMore?: boolean;
+}
+
+export interface MessengerSendMessagePayload {
+  content: string;
+  attachments?: MessengerAttachment[];
+}
+
+export interface MessengerMercureEnvelope {
+  type: "message.created" | "message.read" | "conversation.updated";
+  conversationId: string;
+  message?: MessengerMessage;
+  lastMessage?: MessengerMessage | null;
+  unreadCount?: number;
+  lastReadMessageId?: string;
+  userId?: string;
+}


### PR DESCRIPTION
## Summary
- add MessengerMenu, ConversationsList, and ChatPane components to surface recent conversations and chat UI
- create messenger store, pages, and helper utilities with Mercure subscriptions for real-time updates
- update the app bar and locale files to expose the messenger menu and translations across supported languages

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8520d5e48326a20bd5b077decce8