### PR TITLE
Add Simplified Chinese locale to language menu

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -5,13 +5,14 @@ import fr from "./locales/fr.json";
 import es from "./locales/es.json";
 import it from "./locales/it.json";
 import ru from "./locales/ru.json";
+import zhCN from "./locales/zh-cn.json";
 
 export default defineI18nConfig(() => ({
   legacy: false,
   globalInjection: true,
   locale: "en",
   fallbackLocale: "en",
-  availableLocales: ["en", "fr", "de", "es", "it", "ru", "ar"],
+  availableLocales: ["en", "fr", "de", "es", "it", "ru", "ar", "zh-cn"],
   messages: {
     en,
     fr,
@@ -20,5 +21,6 @@ export default defineI18nConfig(() => ({
     it,
     ru,
     ar,
+    "zh-cn": zhCN,
   },
 }));

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -445,6 +445,7 @@ export default defineNuxtConfig({
       { code: "it", name: "Italian", iso: "it-IT", icon: "fi-it it", file: "it.json" },
       { code: "es", name: "Spanish", iso: "es-ES", icon: "fi-es es", file: "es.json" },
       { code: "ru", name: "Russian", iso: "ru-RU", icon: "fi-ru ru", file: "ru.json" },
+      { code: "zh-cn", name: "中文 (简体)", iso: "zh-CN", icon: "fi-cn cn", file: "zh-cn.json" },
     ],
     baseUrl: "https://bro-world-space.com",
   },


### PR DESCRIPTION
## Summary
- import the Simplified Chinese translation bundle in the i18n configuration
- expose the zh-CN locale to Nuxt so it appears in the language selector

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc911a2790832683bac40fd220d897