### PR TITLE
Display authenticated user avatar in app bar

### DIFF
--- a/components/layout/AppBar/UserMenu.vue
+++ b/components/layout/AppBar/UserMenu.vue
@@ -7,10 +7,30 @@
         aria-label="Profile"
         v-bind="profileProps"
       >
-        <AppIcon
-          name="mdi:person-outline"
-          :size="22"
-        />
+        <template v-if="props.user">
+          <v-avatar
+            size="36"
+            :class="avatarClasses"
+          >
+            <v-img
+              v-if="props.user.photo"
+              :src="props.user.photo"
+              :alt="heading"
+              cover
+            />
+            <template v-else>
+              <span class="font-semibold uppercase">
+                {{ initials }}
+              </span>
+            </template>
+          </v-avatar>
+        </template>
+        <template v-else>
+          <AppIcon
+            name="mdi:person-outline"
+            :size="22"
+          />
+        </template>
       </button>
     </template>
     <v-card
@@ -109,6 +129,14 @@ const subheading = computed(() => {
   if (props.user.username) return `${props.signedInText} ${props.user.username}`;
 
   return props.signedInText;
+});
+
+const avatarClasses = computed(() => {
+  if (props.user?.photo) {
+    return "bg-transparent";
+  }
+
+  return "bg-primary/10 text-primary";
 });
 
 const initials = computed(() => {


### PR DESCRIPTION
## Summary
- show the authenticated user's avatar in the app bar trigger instead of a generic icon
- fall back to user initials and retain the neutral background when no photo is available

## Testing
- `pnpm lint` *(hangs in container and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9156c4bc8326a4a8d7b25886ed86