### PR TITLE
feat: add admin site settings management

### DIFF
--- a/components/layout/AppBar/AppBrand.vue
+++ b/components/layout/AppBar/AppBrand.vue
@@ -1,21 +1,42 @@
+<!-- eslint-disable check-file/folder-naming-convention -->
 <template>
   <NuxtLink
     :to="to ?? '/'"
     class="flex items-center gap-2 rounded-xl px-2 py-1 font-semibold text-xl"
   >
-    <h1 class="z-2 relative text-center font-sans font-bold">
-      Bro
+    <h1 class="z-2 relative flex items-center gap-1 text-center font-sans font-bold">
+      <span v-if="brandParts.prefix" class="text-inherit">{{ brandParts.prefix }}</span>
       <ColourfulText
         :colors="colors"
-        text="World"
+        :text="brandParts.highlight"
       />
     </h1>
   </NuxtLink>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import { usePrimaryGradient } from "~/composables/usePrimaryGradient";
+import { useSiteSettingsState } from "~/composables/useSiteSettingsState";
+import { getDefaultSiteSettings } from "~/lib/settings/defaults";
 
 defineProps<{ to?: string }>();
 const { colors } = usePrimaryGradient({ steps: 5, lightDark: [0.88, 0.3] });
+
+const siteSettings = useSiteSettingsState();
+const brandName = computed(() => siteSettings.value?.siteName?.trim() || getDefaultSiteSettings().siteName);
+
+const brandParts = computed(() => {
+  const name = brandName.value;
+  const segments = name.split(/\s+/).filter(Boolean);
+
+  if (segments.length <= 1) {
+    return { prefix: "", highlight: name };
+  }
+
+  return {
+    prefix: segments.slice(0, -1).join(" "),
+    highlight: segments[segments.length - 1],
+  };
+});
 </script>

--- a/composables/useSiteSettingsState.ts
+++ b/composables/useSiteSettingsState.ts
@@ -1,0 +1,5 @@
+import type { SiteSettings } from "~/types/settings";
+
+export function useSiteSettingsState() {
+  return useState<SiteSettings | null>("site-settings", () => null);
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -84,6 +84,7 @@
         "profilePhotos": "Photos & media",
         "admin": "Administration",
         "adminGeneral": "General",
+        "adminSettings": "Site settings",
         "adminUserManagement": "User management",
         "adminBlog": "Blog",
         "help": "Help",
@@ -1361,6 +1362,66 @@
     "page": {
       "title": "Administration hub",
       "subtitle": "Manage the entire platform, monitor key metrics, and activate the right levers in a few clicks."
+    },
+    "settings": {
+      "metaTitle": "Site settings",
+      "page": {
+        "title": "Site settings",
+        "subtitle": "Configure the brand, theme palette, and navigation structure for your community."
+      },
+      "sections": {
+        "general": {
+          "title": "Brand identity",
+          "subtitle": "Update the site name and tagline displayed across the workspace."
+        },
+        "theme": {
+          "title": "Themes",
+          "subtitle": "Curate available themes and choose which one is active by default.",
+          "active": "Default theme"
+        },
+        "navigation": {
+          "title": "Navigation menu",
+          "subtitle": "Add, reorder, and secure sidebar entries for every audience.",
+          "children": "Child links"
+        }
+      },
+      "fields": {
+        "siteName": "Site name",
+        "tagline": "Tagline",
+        "themeName": "Theme name",
+        "themeDescription": "Description",
+        "themePrimary": "Primary color",
+        "themeAccent": "Accent color",
+        "themeSurface": "Surface color",
+        "menuLabel": "Menu label",
+        "menuPath": "Destination path",
+        "menuIcon": "Icon (optional)",
+        "menuAdmin": "Admin only",
+        "menuVisible": "Visible"
+      },
+      "placeholders": {
+        "siteName": "Enter a public site name",
+        "tagline": "Describe your mission in one sentence"
+      },
+      "actions": {
+        "save": "Save settings",
+        "reset": "Discard changes",
+        "addTheme": "Add theme",
+        "addMenu": "Add menu",
+        "addChild": "Add child link",
+        "removeMenu": "Remove",
+        "moveUp": "Move up",
+        "moveDown": "Move down"
+      },
+      "feedback": {
+        "saved": "Site configuration updated successfully.",
+        "error": "We couldn't update the configuration. Try again later."
+      },
+      "defaults": {
+        "themeName": "New theme",
+        "menuLabel": "New menu",
+        "submenuLabel": "New submenu"
+      }
     },
     "userManagement": {
       "title": "User management",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -84,6 +84,7 @@
         "profilePhotos": "Photos et médias",
         "admin": "Administration",
         "adminGeneral": "Général",
+        "adminSettings": "Paramètres du site",
         "adminUserManagement": "Gestion des utilisateurs",
         "adminBlog": "Blog",
         "help": "Aide",
@@ -1361,6 +1362,66 @@
     "page": {
       "title": "Espace d'administration",
       "subtitle": "Pilotez l'ensemble de la plateforme, suivez les indicateurs clés et activez les bons leviers en quelques clics."
+    },
+    "settings": {
+      "metaTitle": "Paramètres du site",
+      "page": {
+        "title": "Paramètres du site",
+        "subtitle": "Configurez l'identité de marque, la palette de thèmes et la navigation de votre communauté."
+      },
+      "sections": {
+        "general": {
+          "title": "Identité de marque",
+          "subtitle": "Mettez à jour le nom du site et la signature affichés sur l'ensemble de l'espace."
+        },
+        "theme": {
+          "title": "Thèmes",
+          "subtitle": "Composez les thèmes disponibles et choisissez celui appliqué par défaut.",
+          "active": "Thème par défaut"
+        },
+        "navigation": {
+          "title": "Menu de navigation",
+          "subtitle": "Ajoutez, réorganisez et sécurisez les entrées de la barre latérale.",
+          "children": "Liens enfants"
+        }
+      },
+      "fields": {
+        "siteName": "Nom du site",
+        "tagline": "Accroche",
+        "themeName": "Nom du thème",
+        "themeDescription": "Description",
+        "themePrimary": "Couleur principale",
+        "themeAccent": "Couleur d'accent",
+        "themeSurface": "Couleur de surface",
+        "menuLabel": "Libellé du menu",
+        "menuPath": "Chemin de destination",
+        "menuIcon": "Icône (optionnel)",
+        "menuAdmin": "Réservé aux admins",
+        "menuVisible": "Visible"
+      },
+      "placeholders": {
+        "siteName": "Saisissez le nom public du site",
+        "tagline": "Décrivez votre mission en une phrase"
+      },
+      "actions": {
+        "save": "Enregistrer",
+        "reset": "Annuler les modifications",
+        "addTheme": "Ajouter un thème",
+        "addMenu": "Ajouter un menu",
+        "addChild": "Ajouter un sous-lien",
+        "removeMenu": "Supprimer",
+        "moveUp": "Monter",
+        "moveDown": "Descendre"
+      },
+      "feedback": {
+        "saved": "Configuration mise à jour avec succès.",
+        "error": "Impossible de mettre à jour la configuration. Réessayez plus tard."
+      },
+      "defaults": {
+        "themeName": "Nouveau thème",
+        "menuLabel": "Nouveau menu",
+        "submenuLabel": "Nouveau sous-menu"
+      }
     },
     "userManagement": {
       "title": "Gestion des utilisateurs",

--- a/lib/settings/defaults.ts
+++ b/lib/settings/defaults.ts
@@ -1,0 +1,162 @@
+import type { SiteSettings, SiteMenuItem, SiteThemeDefinition } from "~/types/settings";
+
+function makeMenu(
+  menu: Omit<SiteMenuItem, "order"> & { order?: number },
+  children: SiteMenuItem[] = [],
+): SiteMenuItem {
+  return {
+    ...menu,
+    order: menu.order ?? 0,
+    children: children.map((child, index) => ({ ...child, order: child.order ?? index })),
+  };
+}
+
+function makeTheme(theme: SiteThemeDefinition): SiteThemeDefinition {
+  return { ...theme };
+}
+
+export const defaultSiteSettings: SiteSettings = {
+  siteName: "BroWorld",
+  tagline: "Build vibrant communities with a bold design system.",
+  activeThemeId: "aurora",
+  themes: [
+    makeTheme({
+      id: "aurora",
+      name: "Aurora",
+      description: "Gradient-rich palette blending violet and pink hues.",
+      primaryColor: "#7C3AED",
+      accentColor: "#F472B6",
+      surfaceColor: "#F4F7FC",
+    }),
+    makeTheme({
+      id: "midnight",
+      name: "Midnight",
+      description: "Deep blues with electric highlights for dark interfaces.",
+      primaryColor: "#2563EB",
+      accentColor: "#38BDF8",
+      surfaceColor: "#0F172A",
+    }),
+    makeTheme({
+      id: "sunrise",
+      name: "Sunrise",
+      description: "Warm oranges and amber notes for optimistic products.",
+      primaryColor: "#EA580C",
+      accentColor: "#F97316",
+      surfaceColor: "#FFF7ED",
+    }),
+  ],
+  menus: [
+    makeMenu({
+      id: "jobs",
+      label: "layout.sidebar.items.jobs",
+      icon: "mdi-briefcase-search",
+      translate: true,
+      to: "/job",
+      isVisible: true,
+      order: 0,
+    }),
+    makeMenu({
+      id: "game",
+      label: "layout.sidebar.items.game",
+      icon: "mdi-gamepad-variant-outline",
+      translate: true,
+      to: "/game",
+      isVisible: true,
+      order: 1,
+    }),
+    makeMenu({
+      id: "ecommerce",
+      label: "layout.sidebar.items.ecommerce",
+      icon: "mdi-shopping-outline",
+      translate: true,
+      to: "/ecommerce",
+      isVisible: true,
+      order: 2,
+    }),
+    makeMenu({
+      id: "education",
+      label: "layout.sidebar.items.education",
+      icon: "mdi-school-outline",
+      translate: true,
+      to: "/education",
+      isVisible: true,
+      order: 3,
+    }),
+    makeMenu({
+      id: "about",
+      label: "layout.sidebar.items.about",
+      icon: "mdi-information-outline",
+      translate: true,
+      to: "/about",
+      isVisible: true,
+      order: 4,
+    }),
+    makeMenu({
+      id: "contact",
+      label: "layout.sidebar.items.contact",
+      icon: "mdi-email-outline",
+      translate: true,
+      to: "/contact",
+      isVisible: true,
+      order: 5,
+    }),
+    makeMenu(
+      {
+        id: "admin",
+        label: "layout.sidebar.items.admin",
+        icon: "mdi-shield-crown",
+        translate: true,
+        requiresAdmin: true,
+        isVisible: true,
+        order: 6,
+      },
+      [
+        {
+          id: "admin-general",
+          label: "layout.sidebar.items.adminGeneral",
+          icon: "mdi-view-dashboard-outline",
+          translate: true,
+          to: "/admin",
+          requiresAdmin: true,
+          isVisible: true,
+          order: 0,
+        },
+        {
+          id: "admin-settings",
+          label: "layout.sidebar.items.adminSettings",
+          icon: "mdi-cog-outline",
+          translate: true,
+          to: "/admin/settings",
+          requiresAdmin: true,
+          isVisible: true,
+          order: 1,
+        },
+        {
+          id: "admin-user-management",
+          label: "layout.sidebar.items.adminUserManagement",
+          icon: "mdi-account-cog-outline",
+          translate: true,
+          to: "/admin/user-management",
+          requiresAdmin: true,
+          isVisible: true,
+          order: 2,
+        },
+        {
+          id: "admin-blog",
+          label: "layout.sidebar.items.adminBlog",
+          icon: "mdi-post-outline",
+          translate: true,
+          to: "/admin/blog",
+          requiresAdmin: true,
+          isVisible: true,
+          order: 3,
+        },
+      ],
+    ),
+  ],
+  updatedAt: new Date(0).toISOString(),
+};
+
+export function getDefaultSiteSettings(): SiteSettings {
+  return structuredClone(defaultSiteSettings);
+}

--- a/pages/admin/settings.vue
+++ b/pages/admin/settings.vue
@@ -1,0 +1,621 @@
+<template>
+  <main
+    class="py-10"
+    aria-labelledby="admin-settings-title"
+  >
+    <v-container>
+      <header class="mb-10">
+        <div class="d-flex flex-column flex-lg-row align-lg-center justify-space-between gap-4">
+          <div>
+            <h1
+              id="admin-settings-title"
+              class="text-h4 text-lg-h3 font-weight-bold mb-2"
+            >
+              {{ t('admin.settings.page.title') }}
+            </h1>
+            <p class="text-body-1 text-medium-emphasis mb-0">
+              {{ t('admin.settings.page.subtitle') }}
+            </p>
+          </div>
+          <div class="d-flex flex-wrap gap-3">
+            <v-btn
+              color="primary"
+              variant="flat"
+              class="text-none"
+              :loading="isSaving"
+              @click="handleSave"
+            >
+              {{ t('admin.settings.actions.save') }}
+            </v-btn>
+            <v-btn
+              variant="text"
+              class="text-none"
+              :disabled="isSaving || !hasChanges"
+              @click="resetForm"
+            >
+              {{ t('admin.settings.actions.reset') }}
+            </v-btn>
+          </div>
+        </div>
+      </header>
+
+      <v-row dense>
+        <v-col cols="12" md="6">
+          <v-card class="pa-6" rounded="xl" elevation="8">
+            <header class="mb-6">
+              <h2 class="text-h5 font-weight-semibold mb-1">
+                {{ t('admin.settings.sections.general.title') }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-0">
+                {{ t('admin.settings.sections.general.subtitle') }}
+              </p>
+            </header>
+            <v-form @submit.prevent>
+              <v-text-field
+                v-model="form.siteName"
+                :label="t('admin.settings.fields.siteName')"
+                :placeholder="t('admin.settings.placeholders.siteName')"
+                :disabled="isSaving"
+                variant="outlined"
+                class="mb-4"
+                density="comfortable"
+                hide-details
+                required
+              />
+              <v-textarea
+                v-model="form.tagline"
+                :label="t('admin.settings.fields.tagline')"
+                :placeholder="t('admin.settings.placeholders.tagline')"
+                :disabled="isSaving"
+                variant="outlined"
+                auto-grow
+                rows="3"
+                density="comfortable"
+                hide-details
+              />
+            </v-form>
+          </v-card>
+        </v-col>
+
+        <v-col cols="12" md="6">
+          <v-card class="pa-6 h-100" rounded="xl" elevation="8">
+            <header class="mb-6">
+              <h2 class="text-h5 font-weight-semibold mb-1">
+                {{ t('admin.settings.sections.theme.title') }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-0">
+                {{ t('admin.settings.sections.theme.subtitle') }}
+              </p>
+            </header>
+            <div class="d-flex flex-column gap-4">
+              <v-item-group v-model="form.activeThemeId" mandatory>
+                <v-item
+                  v-for="(themeOption, index) in form.themes"
+                  :key="themeOption.id"
+                  :value="themeOption.id"
+                >
+                  <template #default="{ isSelected, toggle }">
+                    <v-sheet
+                      rounded="xl"
+                      border
+                      class="pa-4 transition"
+                      :class="isSelected ? 'border-primary elevation-4' : 'border-dashed elevation-1'"
+                      @click="toggle"
+                    >
+                      <div class="d-flex justify-space-between align-start gap-4">
+                        <div class="flex-grow-1">
+                          <div class="d-flex align-center justify-space-between mb-2">
+                            <v-text-field
+                              v-model="themeOption.name"
+                              :label="t('admin.settings.fields.themeName')"
+                              :disabled="isSaving"
+                              variant="outlined"
+                              density="comfortable"
+                              hide-details
+                            />
+                            <v-btn
+                              icon="mdi-delete"
+                              variant="text"
+                              color="error"
+                              :disabled="isSaving || form.themes.length <= 1"
+                              class="ml-3"
+                              @click.stop="removeTheme(index)"
+                            />
+                          </div>
+                          <v-textarea
+                            v-model="themeOption.description"
+                            :label="t('admin.settings.fields.themeDescription')"
+                            :disabled="isSaving"
+                            variant="outlined"
+                            auto-grow
+                            rows="2"
+                            density="comfortable"
+                            hide-details
+                            class="mb-3"
+                          />
+                          <div class="d-flex flex-column flex-sm-row gap-3">
+                            <v-text-field
+                              v-model="themeOption.primaryColor"
+                              :label="t('admin.settings.fields.themePrimary')"
+                              :disabled="isSaving"
+                              variant="outlined"
+                              density="comfortable"
+                              hide-details
+                              type="color"
+                            />
+                            <v-text-field
+                              v-model="themeOption.accentColor"
+                              :label="t('admin.settings.fields.themeAccent')"
+                              :disabled="isSaving"
+                              variant="outlined"
+                              density="comfortable"
+                              hide-details
+                              type="color"
+                            />
+                            <v-text-field
+                              v-model="themeOption.surfaceColor"
+                              :label="t('admin.settings.fields.themeSurface')"
+                              :disabled="isSaving"
+                              variant="outlined"
+                              density="comfortable"
+                              hide-details
+                              type="color"
+                            />
+                          </div>
+                        </div>
+                        <div class="d-flex flex-column align-end gap-2">
+                          <v-chip
+                            v-if="isSelected"
+                            color="primary"
+                            variant="flat"
+                            size="small"
+                          >
+                            {{ t('admin.settings.sections.theme.active') }}
+                          </v-chip>
+                          <div
+                            class="rounded-lg"
+                            style="width: 72px; height: 72px"
+                            :style="{
+                              background: `linear-gradient(135deg, ${themeOption.primaryColor}, ${themeOption.accentColor})`,
+                            }"
+                          />
+                        </div>
+                      </div>
+                    </v-sheet>
+                  </template>
+                </v-item>
+              </v-item-group>
+              <v-btn
+                variant="tonal"
+                color="primary"
+                class="text-none"
+                :disabled="isSaving"
+                prepend-icon="mdi-palette"
+                @click="addTheme"
+              >
+                {{ t('admin.settings.actions.addTheme') }}
+              </v-btn>
+            </div>
+          </v-card>
+        </v-col>
+
+        <v-col cols="12">
+          <v-card class="pa-6" rounded="xl" elevation="8">
+            <header class="mb-6">
+              <h2 class="text-h5 font-weight-semibold mb-1">
+                {{ t('admin.settings.sections.navigation.title') }}
+              </h2>
+              <p class="text-body-2 text-medium-emphasis mb-0">
+                {{ t('admin.settings.sections.navigation.subtitle') }}
+              </p>
+            </header>
+
+            <div class="d-flex flex-column gap-4">
+              <v-sheet
+                v-for="(menu, index) in form.menus"
+                :key="menu.id"
+                class="pa-4"
+                rounded="xl"
+                border
+                elevation="2"
+              >
+                <div class="d-flex flex-column gap-4">
+                  <div class="d-flex flex-column flex-md-row gap-4">
+                    <v-text-field
+                      v-model="menu.label"
+                      :label="t('admin.settings.fields.menuLabel')"
+                      :disabled="isSaving"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                    <v-text-field
+                      v-model="menu.to"
+                      :label="t('admin.settings.fields.menuPath')"
+                      :disabled="isSaving"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                    <v-text-field
+                      v-model="menu.icon"
+                      :label="t('admin.settings.fields.menuIcon')"
+                      :disabled="isSaving"
+                      variant="outlined"
+                      density="comfortable"
+                      hide-details
+                    />
+                  </div>
+                  <div class="d-flex flex-wrap gap-3">
+                    <v-switch
+                      v-model="menu.requiresAdmin"
+                      inset
+                      color="primary"
+                      :label="t('admin.settings.fields.menuAdmin')"
+                      :disabled="isSaving"
+                    />
+                    <v-switch
+                      v-model="menu.isVisible"
+                      inset
+                      color="primary"
+                      :label="t('admin.settings.fields.menuVisible')"
+                      :disabled="isSaving"
+                    />
+                  </div>
+                  <div class="d-flex flex-wrap gap-2">
+                    <v-btn
+                      variant="text"
+                      color="primary"
+                      prepend-icon="mdi-arrow-up"
+                      class="text-none"
+                      :disabled="isSaving"
+                      @click="moveMenu(index, -1)"
+                    >
+                      {{ t('admin.settings.actions.moveUp') }}
+                    </v-btn>
+                    <v-btn
+                      variant="text"
+                      color="primary"
+                      prepend-icon="mdi-arrow-down"
+                      class="text-none"
+                      :disabled="isSaving"
+                      @click="moveMenu(index, 1)"
+                    >
+                      {{ t('admin.settings.actions.moveDown') }}
+                    </v-btn>
+                    <v-btn
+                      variant="text"
+                      color="error"
+                      prepend-icon="mdi-delete"
+                      class="text-none"
+                      :disabled="isSaving"
+                      @click="removeMenu(index)"
+                    >
+                      {{ t('admin.settings.actions.removeMenu') }}
+                    </v-btn>
+                    <v-btn
+                      variant="tonal"
+                      color="primary"
+                      prepend-icon="mdi-plus"
+                      class="text-none"
+                      :disabled="isSaving"
+                      @click="addChildMenu(index)"
+                    >
+                      {{ t('admin.settings.actions.addChild') }}
+                    </v-btn>
+                  </div>
+
+                  <div
+                    v-if="menu.children?.length"
+                    class="d-flex flex-column gap-3"
+                  >
+                    <div class="text-subtitle-2 text-medium-emphasis">
+                      {{ t('admin.settings.sections.navigation.children') }}
+                    </div>
+                    <v-sheet
+                      v-for="(child, childIndex) in menu.children"
+                      :key="child.id"
+                      class="pa-3"
+                      rounded="lg"
+                      border
+                    >
+                      <div class="d-flex flex-column flex-md-row gap-3">
+                        <v-text-field
+                          v-model="child.label"
+                          :label="t('admin.settings.fields.menuLabel')"
+                          :disabled="isSaving"
+                          variant="outlined"
+                          density="comfortable"
+                          hide-details
+                        />
+                        <v-text-field
+                          v-model="child.to"
+                          :label="t('admin.settings.fields.menuPath')"
+                          :disabled="isSaving"
+                          variant="outlined"
+                          density="comfortable"
+                          hide-details
+                        />
+                        <v-text-field
+                          v-model="child.icon"
+                          :label="t('admin.settings.fields.menuIcon')"
+                          :disabled="isSaving"
+                          variant="outlined"
+                          density="comfortable"
+                          hide-details
+                        />
+                      </div>
+                      <div class="d-flex flex-wrap gap-2 mt-2">
+                        <v-btn
+                          variant="text"
+                          color="primary"
+                          prepend-icon="mdi-arrow-up"
+                          class="text-none"
+                          :disabled="isSaving"
+                          @click="moveChildMenu(index, childIndex, -1)"
+                        >
+                          {{ t('admin.settings.actions.moveUp') }}
+                        </v-btn>
+                        <v-btn
+                          variant="text"
+                          color="primary"
+                          prepend-icon="mdi-arrow-down"
+                          class="text-none"
+                          :disabled="isSaving"
+                          @click="moveChildMenu(index, childIndex, 1)"
+                        >
+                          {{ t('admin.settings.actions.moveDown') }}
+                        </v-btn>
+                        <v-btn
+                          variant="text"
+                          color="error"
+                          prepend-icon="mdi-delete"
+                          class="text-none"
+                          :disabled="isSaving"
+                          @click="removeChildMenu(index, childIndex)"
+                        >
+                          {{ t('admin.settings.actions.removeMenu') }}
+                        </v-btn>
+                      </div>
+                      <div class="d-flex flex-wrap gap-2 mt-2">
+                        <v-switch
+                          v-model="child.requiresAdmin"
+                          inset
+                          color="primary"
+                          :label="t('admin.settings.fields.menuAdmin')"
+                          :disabled="isSaving"
+                        />
+                        <v-switch
+                          v-model="child.isVisible"
+                          inset
+                          color="primary"
+                          :label="t('admin.settings.fields.menuVisible')"
+                          :disabled="isSaving"
+                        />
+                      </div>
+                    </v-sheet>
+                  </div>
+                </div>
+              </v-sheet>
+
+              <v-btn
+                variant="tonal"
+                color="primary"
+                class="text-none"
+                :disabled="isSaving"
+                prepend-icon="mdi-playlist-plus"
+                @click="addMenu"
+              >
+                {{ t('admin.settings.actions.addMenu') }}
+              </v-btn>
+            </div>
+          </v-card>
+        </v-col>
+      </v-row>
+
+      <v-snackbar
+        v-model="snackbar.visible"
+        :color="snackbar.color"
+        timeout="4000"
+        location="bottom"
+        position="fixed"
+      >
+        {{ snackbar.message }}
+      </v-snackbar>
+    </v-container>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useSiteSettingsState } from '~/composables/useSiteSettingsState';
+import { getDefaultSiteSettings } from '~/lib/settings/defaults';
+import type { SiteMenuItem, SiteSettings, SiteThemeDefinition } from '~/types/settings';
+
+interface EditableMenu extends SiteMenuItem {
+  children?: EditableMenu[];
+}
+
+const { t } = useI18n();
+const siteSettingsState = useSiteSettingsState();
+const isSaving = ref(false);
+const snackbar = reactive({
+  visible: false,
+  message: '',
+  color: 'success' as 'success' | 'error',
+});
+
+const { data: fetchedSettings, refresh } = await useAsyncData('admin-site-settings', () =>
+  $fetch<{ data: SiteSettings }>('/api/settings').then((response) => response.data),
+);
+
+const form = reactive({
+  siteName: getDefaultSiteSettings().siteName,
+  tagline: getDefaultSiteSettings().tagline ?? '',
+  activeThemeId: getDefaultSiteSettings().activeThemeId,
+  themes: getDefaultSiteSettings().themes.map((theme) => ({ ...theme })),
+  menus: getDefaultSiteSettings().menus.map((menu) => deepCloneMenu(menu)),
+});
+
+const initialSnapshot = ref(JSON.stringify(serializeForm()));
+
+watch(
+  () => fetchedSettings.value,
+  (value) => {
+    if (!value) return;
+
+    siteSettingsState.value = value;
+    applySettings(value);
+  },
+  { immediate: true },
+);
+
+const hasChanges = computed(() => JSON.stringify(serializeForm()) !== initialSnapshot.value);
+
+function applySettings(settings: SiteSettings) {
+  form.siteName = settings.siteName;
+  form.tagline = settings.tagline ?? '';
+  form.activeThemeId = settings.activeThemeId;
+  form.themes = settings.themes.map((theme) => ({ ...theme }));
+  form.menus = settings.menus.map((menu) => deepCloneMenu(menu));
+  initialSnapshot.value = JSON.stringify(serializeForm());
+}
+
+function deepCloneMenu(menu: SiteMenuItem): EditableMenu {
+  return {
+    ...menu,
+    translate: false,
+    children: menu.children?.map((child) => deepCloneMenu(child)) ?? [],
+  };
+}
+
+function serializeForm(): Partial<SiteSettings> {
+  return {
+    siteName: form.siteName.trim(),
+    tagline: form.tagline.trim() || null,
+    activeThemeId: form.activeThemeId,
+    themes: form.themes.map((theme) => ({ ...theme })),
+    menus: form.menus.map((menu, index) => serializeMenu(menu, index)),
+  } satisfies Partial<SiteSettings>;
+}
+
+function serializeMenu(menu: EditableMenu, index: number): SiteMenuItem {
+  return {
+    ...menu,
+    translate: false,
+    order: index,
+    children: menu.children?.map((child, childIndex) => serializeMenu(child, childIndex)) ?? [],
+  };
+}
+
+function addTheme() {
+  const id = crypto.randomUUID();
+  form.themes.push({
+    id,
+    name: t('admin.settings.defaults.themeName'),
+    description: '',
+    primaryColor: '#6366F1',
+    accentColor: '#F97316',
+    surfaceColor: '#F8FAFC',
+  });
+}
+
+function removeTheme(index: number) {
+  if (form.themes.length <= 1) return;
+  const removed = form.themes.splice(index, 1);
+  if (removed[0]?.id === form.activeThemeId) {
+    form.activeThemeId = form.themes[0]?.id ?? '';
+  }
+}
+
+function addMenu() {
+  form.menus.push({
+    id: crypto.randomUUID(),
+    label: t('admin.settings.defaults.menuLabel'),
+    icon: 'mdi-dots-grid',
+    to: '/',
+    requiresAdmin: false,
+    translate: false,
+    isVisible: true,
+    order: form.menus.length,
+    children: [],
+  });
+}
+
+function removeMenu(index: number) {
+  form.menus.splice(index, 1);
+}
+
+function moveMenu(index: number, direction: number) {
+  const target = index + direction;
+  if (target < 0 || target >= form.menus.length) return;
+  const [item] = form.menus.splice(index, 1);
+  form.menus.splice(target, 0, item);
+}
+
+function addChildMenu(parentIndex: number) {
+  const parent = form.menus[parentIndex];
+  if (!parent) return;
+  parent.children = parent.children ?? [];
+  parent.children.push({
+    id: crypto.randomUUID(),
+    label: t('admin.settings.defaults.submenuLabel'),
+    icon: 'mdi-rhombus-medium',
+    to: '/',
+    requiresAdmin: parent.requiresAdmin,
+    translate: false,
+    isVisible: true,
+    order: parent.children.length,
+    children: [],
+  });
+}
+
+function moveChildMenu(parentIndex: number, index: number, direction: number) {
+  const parent = form.menus[parentIndex];
+  if (!parent?.children) return;
+  const target = index + direction;
+  if (target < 0 || target >= parent.children.length) return;
+  const [item] = parent.children.splice(index, 1);
+  parent.children.splice(target, 0, item);
+}
+
+function removeChildMenu(parentIndex: number, index: number) {
+  const parent = form.menus[parentIndex];
+  if (!parent?.children) return;
+  parent.children.splice(index, 1);
+}
+
+function resetForm() {
+  if (fetchedSettings.value) {
+    applySettings(fetchedSettings.value);
+  }
+}
+
+async function handleSave() {
+  if (isSaving.value) return;
+  isSaving.value = true;
+  try {
+    const payload = serializeForm();
+    const { data } = await $fetch<{ data: SiteSettings }>('/api/settings', {
+      method: 'PUT',
+      body: payload,
+    });
+
+    siteSettingsState.value = data;
+    applySettings(data);
+    snackbar.message = t('admin.settings.feedback.saved');
+    snackbar.color = 'success';
+    snackbar.visible = true;
+    await refresh();
+    await refreshNuxtData('site-settings');
+  } catch (error) {
+    console.error('Failed to update settings', error);
+    snackbar.message = t('admin.settings.feedback.error');
+    snackbar.color = 'error';
+    snackbar.visible = true;
+  } finally {
+    isSaving.value = false;
+  }
+}
+</script>

--- a/server/api/settings.get.ts
+++ b/server/api/settings.get.ts
@@ -1,0 +1,6 @@
+import { getSiteSettings } from "../utils/settings/storage";
+
+export default defineEventHandler(async () => {
+  const settings = await getSiteSettings();
+  return { data: settings };
+});

--- a/server/api/settings.put.ts
+++ b/server/api/settings.put.ts
@@ -1,0 +1,18 @@
+import { createError, readBody } from "h3";
+import type { SiteSettings } from "~/types/settings";
+import { updateSiteSettings } from "../utils/settings/storage";
+
+export default defineEventHandler(async (event) => {
+  const body = (await readBody(event)) as Partial<SiteSettings> | null;
+
+  if (!body || typeof body !== "object") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid payload",
+    });
+  }
+
+  const updated = await updateSiteSettings(body);
+
+  return { data: updated };
+});

--- a/server/utils/settings/storage.ts
+++ b/server/utils/settings/storage.ts
@@ -1,0 +1,144 @@
+import { createError } from "h3";
+import { useStorage } from "nitropack/runtime";
+import type { SiteMenuItem, SiteSettings, SiteThemeDefinition } from "~/types/settings";
+import { defaultSiteSettings, getDefaultSiteSettings } from "~/lib/settings/defaults";
+
+const STORAGE_KEY = "site-settings";
+let seedPromise: Promise<void> | null = null;
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || crypto.randomUUID();
+}
+
+async function ensureSeed(): Promise<void> {
+  if (!seedPromise) {
+    seedPromise = (async () => {
+      const storage = useStorage();
+      const existing = await storage.getItem<SiteSettings | null>(STORAGE_KEY);
+      if (!existing) {
+        const seeded = getDefaultSiteSettings();
+        await storage.setItem(STORAGE_KEY, seeded);
+      }
+    })();
+  }
+
+  await seedPromise;
+}
+
+async function readSettings(): Promise<SiteSettings> {
+  await ensureSeed();
+  const storage = useStorage();
+  const stored = await storage.getItem<SiteSettings | null>(STORAGE_KEY);
+
+  if (!stored) {
+    return getDefaultSiteSettings();
+  }
+
+  return stored;
+}
+
+async function writeSettings(settings: SiteSettings): Promise<void> {
+  const storage = useStorage();
+  await storage.setItem(STORAGE_KEY, settings);
+}
+
+function sanitizeTheme(theme: Partial<SiteThemeDefinition>): SiteThemeDefinition {
+  const name = theme.name?.trim() || "Untitled theme";
+  const id = theme.id?.trim() || slugify(name);
+
+  return {
+    id,
+    name,
+    description: theme.description?.trim() || null,
+    primaryColor: theme.primaryColor?.trim() || "#7C3AED",
+    accentColor: theme.accentColor?.trim() || "#F472B6",
+    surfaceColor: theme.surfaceColor?.trim() || "#F4F7FC",
+  } satisfies SiteThemeDefinition;
+}
+
+function sanitizeMenu(menu: Partial<SiteMenuItem>, order: number): SiteMenuItem {
+  const label = menu.label?.trim();
+
+  if (!label) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Menu label is required",
+    });
+  }
+
+  const id = menu.id?.trim() || slugify(label);
+  const isVisible = menu.isVisible !== false;
+  const requiresAdmin = menu.requiresAdmin === true;
+  const translate = menu.translate === true;
+  const to = menu.to?.trim() || null;
+  const icon = menu.icon?.trim() || null;
+
+  const children = Array.isArray(menu.children)
+    ? menu.children
+        .map((child, index) => ({ child, index }))
+        .filter(({ child }) => child && typeof child === "object")
+        .map(({ child, index }) => sanitizeMenu(child, index))
+    : [];
+
+  return {
+    id,
+    label,
+    icon,
+    to,
+    requiresAdmin,
+    translate,
+    isVisible,
+    order,
+    children,
+  } satisfies SiteMenuItem;
+}
+
+function ensureActiveThemeId(settings: SiteSettings): SiteSettings {
+  if (!settings.themes.length) {
+    settings.themes = [...defaultSiteSettings.themes.map((theme) => ({ ...theme }))];
+  }
+
+  if (!settings.activeThemeId) {
+    settings.activeThemeId = settings.themes[0]?.id ?? defaultSiteSettings.activeThemeId;
+  }
+
+  if (!settings.themes.some((theme) => theme.id === settings.activeThemeId)) {
+    settings.activeThemeId = settings.themes[0]?.id ?? defaultSiteSettings.activeThemeId;
+  }
+
+  return settings;
+}
+
+export async function getSiteSettings(): Promise<SiteSettings> {
+  const current = await readSettings();
+  return ensureActiveThemeId({ ...current, themes: current.themes.map((theme) => ({ ...theme })) });
+}
+
+export async function updateSiteSettings(payload: Partial<SiteSettings>): Promise<SiteSettings> {
+  const current = await readSettings();
+
+  const next: SiteSettings = {
+    ...current,
+    siteName: payload.siteName?.trim() || current.siteName,
+    tagline: payload.tagline === undefined ? current.tagline ?? null : payload.tagline?.trim() || null,
+    activeThemeId: payload.activeThemeId?.trim() || current.activeThemeId,
+    themes: payload.themes?.length
+      ? payload.themes.map((theme) => sanitizeTheme(theme)).filter(Boolean)
+      : current.themes.map((theme) => ({ ...theme })),
+    menus: payload.menus?.length
+      ? payload.menus.map((menu, index) => sanitizeMenu(menu, index))
+      : current.menus.map((menu) => ({ ...menu, children: menu.children?.map((child) => ({ ...child })) ?? [] })),
+    updatedAt: new Date().toISOString(),
+  };
+
+  const ensured = ensureActiveThemeId(next);
+
+  await writeSettings(ensured);
+
+  return ensured;
+}

--- a/tests/unit/sidebarItems.spec.ts
+++ b/tests/unit/sidebarItems.spec.ts
@@ -1,20 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { buildSidebarItems } from "~/lib/navigation/sidebar";
+import { getDefaultSiteSettings } from "~/lib/settings/defaults";
 
 describe("buildSidebarItems", () => {
   it("omits the admin menu when access is denied", () => {
-    const items = buildSidebarItems(false);
+    const items = buildSidebarItems(getDefaultSiteSettings(), false);
 
     expect(items.some((item) => item.key === "admin")).toBe(false);
   });
 
   it("includes the admin menu and its children when access is granted", () => {
-    const items = buildSidebarItems(true);
+    const items = buildSidebarItems(getDefaultSiteSettings(), true);
 
     const adminEntry = items.find((item) => item.key === "admin");
     expect(adminEntry).toBeDefined();
     expect(adminEntry?.children?.map((child) => child.key)).toEqual([
       "admin-general",
+      "admin-settings",
       "admin-user-management",
       "admin-blog",
     ]);

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,0 +1,29 @@
+export interface SiteThemeDefinition {
+  id: string;
+  name: string;
+  description?: string | null;
+  primaryColor: string;
+  accentColor: string;
+  surfaceColor: string;
+}
+
+export interface SiteMenuItem {
+  id: string;
+  label: string;
+  icon?: string | null;
+  to?: string | null;
+  requiresAdmin?: boolean;
+  translate?: boolean;
+  order: number;
+  isVisible?: boolean;
+  children?: SiteMenuItem[];
+}
+
+export interface SiteSettings {
+  siteName: string;
+  tagline?: string | null;
+  activeThemeId: string;
+  themes: SiteThemeDefinition[];
+  menus: SiteMenuItem[];
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- add server-side storage and REST endpoints for site settings with default themes and menu structure
- implement a reusable site settings state composable and wire the layout, navigation, and branding to dynamic configuration
- create an admin settings page with UI to edit the site name, themes, and navigation entries plus new i18n strings

## Testing
- pnpm exec eslint pages/admin/settings.vue components/layout/AppSidebar.vue components/layout/AppBar/AppBrand.vue layouts/default.vue lib/navigation/sidebar.ts server/api/settings.get.ts server/api/settings.put.ts server/utils/settings/storage.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcbad4c7fc8326b23d2bbe84a73f20