### PR TITLE
Fix submenu active key selection

### DIFF
--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -230,20 +230,41 @@ function resolveLabel(item: LayoutSidebarItem): string {
 }
 
 function findActiveSidebarKey(path: string, items: LayoutSidebarItem[]): string | null {
+  let bestMatch: { key: string; score: number } | null = null;
+
   for (const item of items) {
-    if (item.to && matchesRoute(path, item.to)) return item.key;
     if (item.children?.length) {
       const childMatch = findActiveSidebarKey(path, item.children);
-      if (childMatch) return childMatch;
+      if (childMatch && (!bestMatch || childMatch.score > bestMatch.score)) {
+        bestMatch = childMatch;
+      }
+    }
+
+    if (!item.to) continue;
+
+    const score = getRouteMatchScore(path, item.to);
+    if (score > 0 && (!bestMatch || score > bestMatch.score)) {
+      bestMatch = { key: item.key, score };
     }
   }
 
-  return null;
+  return bestMatch?.key ?? null;
 }
 
-function matchesRoute(path: string, target: string) {
-  if (target === "/") return path === "/" || path.startsWith("/?");
-  return path === target || path.startsWith(`${target}/`) || path.startsWith(`${target}?`);
+function getRouteMatchScore(path: string, target: string) {
+  if (target === "/") {
+    return path === "/" || path.startsWith("/?") ? 1 : 0;
+  }
+
+  if (path === target) {
+    return target.length + 1000;
+  }
+
+  if (path.startsWith(`${target}/`) || path.startsWith(`${target}?`)) {
+    return target.length;
+  }
+
+  return 0;
 }
 
 function findFirstSidebarKey(items: LayoutSidebarItem[]): string | null {


### PR DESCRIPTION
## Summary
- ensure sidebar active key detection prefers the most specific matching submenu route
- apply the same scoring logic in the default layout so nested items highlight correctly

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd72a6ab148326bdf6b948d1957edc