### PR TITLE
fix: guard shadcn config access outside nuxt context

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -12,7 +12,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-const config = useConfig();
+const config = useDocsConfig();
 const route = useRoute();
 const { themeClass, radius } = useThemes();
 const { locale } = useI18n();

--- a/components/blog/RightSidebar.vue
+++ b/components/blog/RightSidebar.vue
@@ -35,7 +35,7 @@ import SidebarWidget, { type SidebarWidgetData } from "./SidebarWidget.vue";
 import Aside from "~/components/layout/Aside.vue";
 
 const { page } = useContent();
-const config = useConfig();
+const config = useDocsConfig();
 
 defineProps<{
   title: string;

--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -131,7 +131,7 @@ const props = defineProps<{
 const emit = defineEmits(["toggle-left", "toggle-right", "go-back", "refresh", "update:locale"]);
 
 const { t } = useI18n();
-const config = useConfig();
+const config = useDocsConfig();
 const auth = useAuthSession();
 const messenger = useMessengerStore();
 

--- a/components/layout/Aside.vue
+++ b/components/layout/Aside.vue
@@ -63,7 +63,7 @@
 defineProps<{ isMobile: boolean }>();
 
 const { navDirFromPath } = useContentHelpers();
-const config = useConfig();
+const config = useDocsConfig();
 const { locale, defaultLocale, navigation } = useI18nDocs();
 
 const tree = computed(() => {

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -190,7 +190,7 @@ type HeaderLink = {
   menuItems?: HeaderLinkMenuItem[];
 };
 
-const config = useConfig();
+const config = useDocsConfig();
 const { i18nEnabled, localePath } = useI18nDocs();
 const { page } = useContent();
 const { t } = useI18n();

--- a/components/layout/LayoutSearchButton.vue
+++ b/components/layout/LayoutSearchButton.vue
@@ -41,7 +41,7 @@ import { useCookieColorMode } from "~/composables/useCookieColorMode";
 defineOptions({ inheritAttrs: false });
 
 const attrs = useAttrs();
-const config = useConfig();
+const config = useDocsConfig();
 const colorMode = useCookieColorMode();
 
 const isOpen = ref<boolean | undefined>(false);

--- a/composables/useDocsConfig.ts
+++ b/composables/useDocsConfig.ts
@@ -1,0 +1,161 @@
+import { computed, type ComputedRef } from "vue";
+import { tryUseNuxtApp, useConfig } from "#imports";
+
+interface DocsSiteConfig {
+  name?: string;
+  description?: string;
+  ogImage?: string;
+}
+
+interface DocsSearchConfig {
+  enable?: boolean;
+  inAside?: boolean;
+  style?: "input" | "button" | string;
+  placeholder?: string;
+  placeholderDetailed?: string;
+}
+
+interface DocsThemeConfig {
+  customizable?: boolean;
+  color?: string;
+  radius?: number;
+}
+
+interface DocsHeaderConfig {
+  title?: string;
+  showTitle?: boolean;
+  showLoadingIndicator?: boolean;
+  darkModeToggle?: boolean;
+  nav?: unknown[];
+  links?: unknown[];
+}
+
+interface DocsAsideConfig {
+  useLevel?: boolean;
+  collapse?: boolean;
+  folderStyle?: string;
+  levelStyle?: string;
+}
+
+interface DocsMainConfig {
+  breadCrumb?: boolean;
+  showTitle?: boolean;
+  codeCopyToast?: boolean;
+  codeCopyToastText?: string;
+  codeCopyIcon?: string;
+}
+
+interface DocsFooterConfig {
+  credits?: string;
+  links?: unknown[];
+}
+
+interface DocsTocConfig {
+  enable?: boolean;
+  enableInMobile?: boolean;
+  enableInHomepage?: boolean;
+  title?: string;
+  links?: unknown[];
+}
+
+interface DocsBannerConfig {
+  enable?: boolean;
+  showClose?: boolean;
+  border?: boolean;
+  content?: string;
+  to?: string;
+  target?: string;
+}
+
+export interface DocsConfig {
+  site?: DocsSiteConfig;
+  search: DocsSearchConfig;
+  theme: DocsThemeConfig;
+  header: DocsHeaderConfig;
+  aside: DocsAsideConfig;
+  main: DocsMainConfig;
+  footer: DocsFooterConfig;
+  toc: DocsTocConfig;
+  banner: DocsBannerConfig;
+}
+
+const fallbackConfig: DocsConfig = {
+  site: {
+    name: "Bro World",
+    description: "Welcome to Bro World — your unique community platform.",
+    ogImage: undefined,
+  },
+  search: {
+    enable: true,
+    inAside: false,
+    style: "input",
+    placeholder: "Search...",
+    placeholderDetailed: "Search documentation...",
+  },
+  theme: {
+    customizable: true,
+    color: "zinc",
+    radius: 0.75,
+  },
+  header: {
+    title: "Bro World",
+    showTitle: true,
+    showLoadingIndicator: true,
+    darkModeToggle: true,
+    nav: [],
+    links: [],
+  },
+  aside: {
+    useLevel: true,
+    collapse: false,
+    folderStyle: "default",
+    levelStyle: "aside",
+  },
+  main: {
+    breadCrumb: true,
+    showTitle: true,
+    codeCopyToast: true,
+    codeCopyToastText: "Copied to clipboard!",
+    codeCopyIcon: "lucide:clipboard",
+  },
+  footer: {
+    credits: "",
+    links: [],
+  },
+  toc: {
+    enable: true,
+    enableInMobile: false,
+    enableInHomepage: false,
+    title: "On This Page",
+    links: [],
+  },
+  banner: {
+    enable: false,
+    showClose: true,
+    border: true,
+    content: "",
+    to: "",
+    target: "_self",
+  },
+};
+
+/**
+ * Safe wrapper around `useConfig` from shadcn-docs-nuxt.
+ *
+ * Some parts of the application (e.g. tests or early module evaluation)
+ * may execute before Nuxt has created a Vue instance. In that case calling
+ * `useConfig` would throw because it relies on `useNuxtApp` internally.
+ *
+ * This helper attempts to call `useConfig` when a Nuxt app instance is
+ * available, and otherwise returns a reactive fallback configuration that
+ * mirrors the structure used throughout the UI.
+ */
+export function useDocsConfig(): ComputedRef<DocsConfig> {
+  const nuxtApp = tryUseNuxtApp();
+
+  if (!nuxtApp) {
+    return computed(() => fallbackConfig);
+  }
+
+  return useConfig() as ComputedRef<DocsConfig>;
+}

--- a/composables/useThemes.ts
+++ b/composables/useThemes.ts
@@ -83,7 +83,7 @@ function hslToHex({
 }
 
 export function useThemes() {
-  const config = useConfig();
+  const config = useDocsConfig();
 
   function resolveThemeDefaults(): ThemeCookieConfig {
     const defaults = config.value.theme ?? {};

--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -144,6 +144,10 @@ export function useConfig() {
   return computed(() => docsConfig.value);
 }
 
+export function useDocsConfig() {
+  return useConfig();
+}
+
 export function __setMockDocsConfig(override: Partial<DocsConfig>) {
   const base = createDefaultDocsConfig();
   docsConfig.value = {


### PR DESCRIPTION
## Summary
- add a `useDocsConfig` helper that falls back to a safe default when Nuxt context is unavailable
- update app shell, key layout components, the blog sidebar, and the theme composable to use the safe helper
- adjust the Nuxt test mocks to expose the new helper for unit tests

## Testing
- pnpm vitest run *(fails: existing e2e/unit suites require Pinia and other plugins in the test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7a3ef8608326b0b9b48020ed314f