### PR TITLE
Handle canonical URL resolution without Nuxt context

### DIFF
--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -115,6 +115,9 @@ export function useRequestFetch() {
 
 export function useRuntimeConfig() {
   return {
+    public: {
+      siteUrl: "",
+    },
     redis: {
       listTtl: 60,
       itemTtl: 300,


### PR DESCRIPTION
## Summary
- guard canonical URL generation against missing Nuxt runtime context by using tryUseNuxtApp and request URL fallbacks
- reuse a normalized base URL for canonical, alternate, and social image links
- extend the Nuxt runtime config test mock with a public.siteUrl stub

## Testing
- pnpm exec eslint app.vue

------
https://chatgpt.com/codex/tasks/task_e_68dd7e173398832699b19d0233c15abb