### PR TITLE
Guard app config usage when Nuxt context missing

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -14,7 +14,16 @@ import { computed } from "vue";
 import { tryUseNuxtApp, useRequestURL } from "#imports";
 
 const nuxtApp = tryUseNuxtApp();
-const config = useConfig();
+const fallbackSiteConfig = {
+  name: "Bro World",
+  description: "Welcome to Bro World — your unique community platform.",
+};
+
+const config = nuxtApp
+  ? useConfig()
+  : computed(() => ({
+      site: fallbackSiteConfig,
+    }));
 const route = useRoute();
 const { themeClass, radius } = useThemes();
 const { locale } = useI18n();
@@ -61,12 +70,10 @@ const matchedMeta = computed<SeoMetaFields>(
 const currentMeta = computed<SeoMetaFields>(() => route.meta as SeoMetaFields);
 
 const defaultTitle = computed(
-  () => config.value.site?.name ?? "Bro World",
+  () => config.value.site?.name ?? fallbackSiteConfig.name,
 );
 const defaultDescription = computed(
-  () =>
-    config.value.site?.description ??
-    "Welcome to Bro World — your unique community platform.",
+  () => config.value.site?.description ?? fallbackSiteConfig.description,
 );
 const canonicalUrl = computed(() => {
   const base = normalizedBaseUrl.value;


### PR DESCRIPTION
## Summary
- add a fallback site config when Nuxt context is unavailable in app.vue
- reuse the fallback metadata when computing default title and description

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd808cfd54832680be7834ef97c066