### PR TITLE
Guard Nuxt composables usage without instance

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -11,7 +11,12 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { tryUseNuxtApp, useAppConfig, useRequestURL } from "#imports";
+import {
+  hasInjectionContext,
+  tryUseNuxtApp,
+  useAppConfig,
+  useRequestURL,
+} from "#imports";
 
 const nuxtApp = tryUseNuxtApp();
 const fallbackSiteConfig = {
@@ -20,7 +25,7 @@ const fallbackSiteConfig = {
 };
 
 const siteConfig = computed(() => {
-  if (!nuxtApp) {
+  if (!nuxtApp || !hasInjectionContext()) {
     return fallbackSiteConfig;
   }
 
@@ -35,8 +40,8 @@ const siteConfig = computed(() => {
 const route = useRoute();
 const { themeClass, radius } = useThemes();
 const { locale } = useI18n();
-const runtimeConfig = nuxtApp ? useRuntimeConfig() : null;
-const requestUrl = nuxtApp ? useRequestURL() : null;
+const runtimeConfig = nuxtApp && hasInjectionContext() ? useRuntimeConfig() : null;
+const requestUrl = nuxtApp && hasInjectionContext() ? useRequestURL() : null;
 
 const fallbackBaseUrl = "https://bro-world-space.com";
 


### PR DESCRIPTION
## Summary
- guard root app composables with `hasInjectionContext` to avoid calling Nuxt APIs when the instance is unavailable
- skip runtime configuration access unless a Nuxt injection context exists

## Testing
- pnpm lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dd847a32448326a1c76e8714778229