### PR TITLE
Fix AppTopBar locale navigation composable usage

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -102,6 +102,7 @@ import AppIconBar from "./AppBar/AppIconBar.vue";
 import UserMenu from "./AppBar/UserMenu.vue";
 import LocaleMenu from "./AppBar/LocaleMenu.vue";
 import RightControls from "./AppBar/RightControls.vue";
+import { useI18nDocs } from "~/composables/useI18nDocs";
 import { usePrimaryGradient } from "~/composables/usePrimaryGradient";
 import { useAuthSession } from "~/stores/auth-session";
 import { useMessengerStore } from "~/stores/messenger";
@@ -132,6 +133,7 @@ const emit = defineEmits(["toggle-left", "toggle-right", "go-back", "refresh", "
 
 const { t } = useI18n();
 const config = useConfig();
+const { localePath } = useI18nDocs();
 const auth = useAuthSession();
 const messenger = useMessengerStore();
 
@@ -297,7 +299,7 @@ async function handleUserMenuSelect(item: UserMenuItem) {
     }
     return;
   }
-  if (item.to) navigateTo(useI18nDocs().localePath(item.to));
+  if (item.to) navigateTo(localePath(item.to));
 }
 
 function markAllNotifications() {


### PR DESCRIPTION
## Summary
- import and initialize the `useI18nDocs` composable within `AppTopBar`
- reuse the provided `localePath` helper when navigating from the user menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc74aa8ec8326be94c37e50c2b1b4