### PR TITLE
Fix locale-aware routing in middleware

### DIFF
--- a/lib/i18n/locale-path.ts
+++ b/lib/i18n/locale-path.ts
@@ -1,0 +1,47 @@
+const SUPPORTED_LOCALES = new Set([
+  "en",
+  "de",
+  "fr",
+  "ar",
+  "it",
+  "es",
+  "ru",
+  "zh-cn",
+]);
+
+const DEFAULT_LOCALE = "en";
+
+function normalizePath(path: string): string {
+  if (!path) {
+    return "/";
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+export function resolveLocaleFromPath(path: string): string {
+  const normalizedPath = normalizePath(path);
+  const [firstSegment = ""] = normalizedPath.split("/").filter(Boolean);
+  const normalizedSegment = firstSegment.toLowerCase();
+
+  if (SUPPORTED_LOCALES.has(normalizedSegment)) {
+    return normalizedSegment;
+  }
+
+  return DEFAULT_LOCALE;
+}
+
+export function buildLocalizedPath(path: string, locale?: string): string {
+  const normalizedPath = normalizePath(path);
+  const localeCode = locale?.toLowerCase();
+
+  if (!localeCode || localeCode === DEFAULT_LOCALE) {
+    return normalizedPath;
+  }
+
+  if (normalizedPath === "/") {
+    return `/${localeCode}`;
+  }
+
+  return `/${localeCode}${normalizedPath}`;
+}

--- a/middleware/admin.ts
+++ b/middleware/admin.ts
@@ -1,10 +1,11 @@
 import { createError } from "#imports";
+import { buildLocalizedPath, resolveLocaleFromPath } from "~/lib/i18n/locale-path";
 import { ADMIN_ROLE_KEYS } from "~/lib/navigation/sidebar";
 import { useAuthSession } from "~/stores/auth-session";
 
 type MiddlewareResult = ReturnType<typeof defineNuxtRouteMiddleware>;
 
-export default defineNuxtRouteMiddleware(async (_to): MiddlewareResult => {
+export default defineNuxtRouteMiddleware(async (to): MiddlewareResult => {
   const auth = useAuthSession();
   await auth.initialize();
 
@@ -25,6 +26,6 @@ export default defineNuxtRouteMiddleware(async (_to): MiddlewareResult => {
     );
   }
 
-  const localePath = useLocalePath();
-  return navigateTo(localePath("/"));
+  const locale = resolveLocaleFromPath(to.path ?? "/");
+  return navigateTo(buildLocalizedPath("/", locale));
 });

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { buildLocalizedPath, resolveLocaleFromPath } from "~/lib/i18n/locale-path";
 import { useAuthSession } from "~/stores/auth-session";
 
 export default defineNuxtRouteMiddleware(async (to) => {
@@ -8,8 +9,8 @@ export default defineNuxtRouteMiddleware(async (to) => {
     return;
   }
 
-  const localePath = useLocalePath();
-  const loginPath = localePath("/login");
+  const locale = resolveLocaleFromPath(to.path ?? "/");
+  const loginPath = buildLocalizedPath("/login", locale);
 
   if (to.path === loginPath) {
     return;


### PR DESCRIPTION
## Summary
- replace the useLocalePath composable in the auth and admin middleware with a locale-aware path helper to avoid calling useRoute inside middleware
- add a reusable locale path utility for computing localized login and home redirects

## Testing
- pnpm exec eslint middleware lib/i18n

------
https://chatgpt.com/codex/tasks/task_e_68ddc8ee71bc83268454454bf86258cc