### PR TITLE
Fix client auth runtime config access

### DIFF
--- a/composables/useAuthStore.ts
+++ b/composables/useAuthStore.ts
@@ -20,8 +20,12 @@ export function useAuthStore() {
   const followPendingState = useState<FollowPendingState>("auth-following-pending", () => ({}));
   const followErrorState = useState<string | null>("auth-following-error", () => null);
   const runtimeConfig = useRuntimeConfig();
+  const sessionTokenCookieName =
+    runtimeConfig.auth?.sessionTokenCookieName ??
+    runtimeConfig.public?.auth?.sessionTokenCookieName ??
+    "auth_session_token";
   const sessionTokenCookie = useCookie<string | null>(
-    runtimeConfig.auth?.sessionTokenCookieName ?? "auth_session_token",
+    sessionTokenCookieName,
     withSecureCookieOptions({
       sameSite: "strict",
     }),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -526,8 +526,11 @@ export default defineNuxtConfig({
     auth: {
       apiBase: process.env.NUXT_AUTH_API_BASE ?? "https://bro-world.org/api",
       tokenCookieName: process.env.NUXT_AUTH_TOKEN_COOKIE ?? "auth_token",
+      sessionTokenCookieName:
+        process.env.NUXT_AUTH_SESSION_TOKEN_COOKIE ?? "auth_session_token",
       userCookieName: process.env.NUXT_AUTH_USER_COOKIE ?? "auth_user",
-      tokenPresenceCookieName: process.env.NUXT_AUTH_TOKEN_PRESENCE_COOKIE ?? "auth_token_present",
+      tokenPresenceCookieName:
+        process.env.NUXT_AUTH_TOKEN_PRESENCE_COOKIE ?? "auth_token_present",
       sessionMaxAge: process.env.NUXT_AUTH_SESSION_MAX_AGE ?? String(60 * 60 * 24 * 7),
     },
     public: {
@@ -547,6 +550,20 @@ export default defineNuxtConfig({
       siteUrl: "https://bro-world-space.com",
       baseUrl: process.env.NUXT_PUBLIC_BASE_URL ?? "https://bro-world-space.com",
       apiBase: process.env.NUXT_PUBLIC_API_BASE ?? "/api",
+      auth: {
+        sessionTokenCookieName:
+          process.env.NUXT_PUBLIC_AUTH_SESSION_TOKEN_COOKIE ??
+          process.env.NUXT_AUTH_SESSION_TOKEN_COOKIE ??
+          "auth_session_token",
+        userCookieName:
+          process.env.NUXT_PUBLIC_AUTH_USER_COOKIE ??
+          process.env.NUXT_AUTH_USER_COOKIE ??
+          "auth_user",
+        tokenPresenceCookieName:
+          process.env.NUXT_PUBLIC_AUTH_TOKEN_PRESENCE_COOKIE ??
+          process.env.NUXT_AUTH_TOKEN_PRESENCE_COOKIE ??
+          "auth_token_present",
+      },
     },
   },
 

--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -68,26 +68,38 @@ export const useAuthSession = defineStore("auth-session", () => {
   const handlingUnauthorizedState = ref(false);
 
   const runtimeConfig = useRuntimeConfig();
+  const sessionTokenCookieName =
+    runtimeConfig.auth?.sessionTokenCookieName ??
+    runtimeConfig.public?.auth?.sessionTokenCookieName ??
+    "auth_session_token";
+  const tokenPresenceCookieName =
+    runtimeConfig.auth?.tokenPresenceCookieName ??
+    runtimeConfig.public?.auth?.tokenPresenceCookieName ??
+    "auth_token_present";
+  const userCookieName =
+    runtimeConfig.auth?.userCookieName ??
+    runtimeConfig.public?.auth?.userCookieName ??
+    "auth_user";
   type AuthUserCookie = Pick<
     AuthUser,
     "id" | "username" | "email" | "firstName" | "lastName" | "photo" | "roles" | "enabled"
   >;
   const sessionTokenCookie = useCookie<string | null>(
-    runtimeConfig.auth?.sessionTokenCookieName ?? "auth_session_token",
+    sessionTokenCookieName,
     withSecureCookieOptions({
       sameSite: "strict",
       watch: false,
     }),
   );
   const presenceCookie = useCookie<string | null>(
-    runtimeConfig.auth?.tokenPresenceCookieName ?? "auth_token_present",
+    tokenPresenceCookieName,
     withSecureCookieOptions({
       sameSite: "strict",
       watch: false,
     }),
   );
   const userCookie = useCookie<AuthUserCookie | null>(
-    runtimeConfig.auth?.userCookieName ?? "auth_user",
+    userCookieName,
     withSecureCookieOptions({
       sameSite: "lax",
       watch: false,


### PR DESCRIPTION
## Summary
- expose the auth cookie configuration in the public runtime config so client code can read cookie names
- update the auth session store and related composable to fall back to the public auth runtime config when accessing cookies

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcc0422088326994789c9b2bda246