### PR TITLE
Fix posts store runtime config usage on client

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -534,6 +534,10 @@ export default defineNuxtConfig({
       sessionMaxAge: process.env.NUXT_AUTH_SESSION_MAX_AGE ?? String(60 * 60 * 24 * 7),
     },
     public: {
+      redis: {
+        listTtl: Number.parseInt(process.env.NUXT_REDIS_POST_LIST_TTL ?? "60", 10),
+        itemTtl: Number.parseInt(process.env.NUXT_REDIS_POST_ITEM_TTL ?? "300", 10),
+      },
       NUXT_CLARITY_ID: process.env.NUXT_CLARITY_ID,
       NUXT_ADSENSE_ACCOUNT: process.env.NUXT_ADSENSE_ACCOUNT,
       blogApiEndpoint:

--- a/stores/posts.ts
+++ b/stores/posts.ts
@@ -132,8 +132,11 @@ function resolveFetcher() {
 export const usePostsStore = defineStore("posts", () => {
   const authStore = useAuthStore();
   const runtimeConfig = useRuntimeConfig();
-  const listTtlMs = Math.max(Number(runtimeConfig.redis?.listTtl ?? 60), 1) * 1000;
-  const itemTtlMs = Math.max(Number(runtimeConfig.redis?.itemTtl ?? 300), 1) * 1000;
+  const redisRuntimeConfig = import.meta.client
+    ? runtimeConfig.public?.redis
+    : runtimeConfig.redis ?? runtimeConfig.public?.redis;
+  const listTtlMs = Math.max(Number(redisRuntimeConfig?.listTtl ?? 60), 1) * 1000;
+  const itemTtlMs = Math.max(Number(redisRuntimeConfig?.itemTtl ?? 300), 1) * 1000;
 
   const items = useState<Record<string, PostsStorePost>>("posts-items", () => ({}));
   const listIds = useState<string[]>("posts-list-ids", () => []);

--- a/tests/mocks/nuxt-imports.ts
+++ b/tests/mocks/nuxt-imports.ts
@@ -117,6 +117,10 @@ export function useRuntimeConfig() {
   return {
     public: {
       siteUrl: "",
+      redis: {
+        listTtl: 60,
+        itemTtl: 300,
+      },
     },
     redis: {
       listTtl: 60,


### PR DESCRIPTION
## Summary
- expose the post cache TTL settings through the public runtime config
- update the posts store to reference the client-safe redis runtime configuration
- align the runtime config test mock with the new public redis values

## Testing
- pnpm test -- --run tests/unit/postsStore.spec.ts *(fails: command triggered additional Vitest suites that depend on unavailable test setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddcdbecc4483269928f6aa0875cb17