### PR TITLE
Fix invalid textarea variant in comment composer

### DIFF
--- a/components/blog/CommentComposer.vue
+++ b/components/blog/CommentComposer.vue
@@ -16,7 +16,7 @@
         rounded
         rows="1"
         auto-grow
-        variant="text"
+        variant="plain"
         :placeholder="placeholderText"
         hide-details
         class="grow-input"


### PR DESCRIPTION
## Summary
- update the blog comment composer textarea to use Vuetify's supported `plain` variant

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddce2bf4d08326a1c075255fd828cb