### PR TITLE
Fix tooltip button theme hydration mismatch

### DIFF
--- a/components/layout/AppBar/AppIconBar.vue
+++ b/components/layout/AppBar/AppIconBar.vue
@@ -9,6 +9,8 @@
         <v-btn
           v-bind="tooltipProps"
           :aria-label="props.t(icon.label)"
+          :class="props.iconTriggerClasses"
+          :theme="props.isDark ? 'dark' : 'light'"
         >
           <AppIcon
             :name="icon.name"
@@ -24,6 +26,7 @@
 const props = defineProps<{
   appIcons: { name: string; label: string }[];
   iconTriggerClasses: string;
+  isDark: boolean;
   t: (k: string) => string;
 }>();
 </script>

--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -39,6 +39,7 @@
     <AppIconBar
       :app-icons="props.appIcons"
       :icon-trigger-classes="iconTriggerClasses"
+      :is-dark="props.isDark"
       :t="t"
     />
 


### PR DESCRIPTION
## Summary
- pass dark mode state into AppIconBar buttons to keep Vuetify theme consistent
- apply provided trigger classes on icon buttons so their SSR/CSR output match

## Testing
- pnpm exec eslint components/layout/AppBar/AppIconBar.vue components/layout/AppTopBar.vue

------
https://chatgpt.com/codex/tasks/task_e_68ddcdac93788326ba0fd5e2d9dfd8d4