### PR TITLE
Add environment example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# Application base URLs
+NUXT_APP_BASE_URL=http://localhost:3000
+NUXT_PUBLIC_APP_BASE_URL=http://localhost:3000
+
+# Redis cache configuration (optional)
+NUXT_REDIS_URL=
+NUXT_REDIS_TLS=false
+NUXT_REDIS_KEY_PREFIX=bro-world
+NUXT_REDIS_POST_LIST_TTL=60
+NUXT_REDIS_POST_ITEM_TTL=300
+
+# Authentication service configuration
+NUXT_AUTH_API_BASE=https://bro-world.org/api
+NUXT_AUTH_TOKEN_COOKIE=auth_token
+NUXT_AUTH_SESSION_TOKEN_COOKIE=auth_session_token
+NUXT_AUTH_USER_COOKIE=auth_user
+NUXT_AUTH_TOKEN_PRESENCE_COOKIE=auth_token_present
+NUXT_AUTH_SESSION_MAX_AGE=604800
+
+# Public runtime configuration
+NUXT_PUBLIC_BASE_URL=http://localhost:3000
+NUXT_PUBLIC_API_BASE=/api
+NUXT_PUBLIC_AUTH_SESSION_TOKEN_COOKIE=auth_session_token
+NUXT_PUBLIC_AUTH_USER_COOKIE=auth_user
+NUXT_PUBLIC_AUTH_TOKEN_PRESENCE_COOKIE=auth_token_present
+NUXT_PUBLIC_BLOG_API_ENDPOINT=https://blog.bro-world.org/public/post
+NUXT_PUBLIC_BLOG_COMMENT_API_ENDPOINT=https://blog.bro-world.org/public/comment
+NUXT_PUBLIC_BLOG_PRIVATE_API_ENDPOINT=https://blog.bro-world.org/private/post
+NUXT_PUBLIC_BLOG_PRIVATE_COMMENT_API_ENDPOINT=https://blog.bro-world.org/private/comment
+
+# Analytics and monetisation (optional)
+NUXT_CLARITY_ID=
+NUXT_ADSENSE_ACCOUNT=
+
+# Tooling configuration
+REGISTRY_URL=https://inspira-ui.com/docs/r
+APP_ENV=development
+PLAYWRIGHT_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ For full documentation and usage examples, visit the BroWorld documentation site
 - [Authentication guide](docs/authentication.md) – details the login flow, session
   storage, route guards, and API usage patterns.
 
+## ⚙️ Configuration
+
+Environment variables are used to configure external services such as the API,
+Redis cache, analytics, and testing tools. To get started locally:
+
+1. Copy `.env.example` to `.env`.
+2. Update the values to match your environment (for example, provide your API
+   base URL or analytics identifiers).
+
+Redis, analytics, and advertising settings are optional—leave them empty if you
+do not use those integrations.
+
 ## 🔐 Profile page
 
 - The `/profile` route is protected by the `auth` middleware. Visitors without a valid session are redirected to `/login`, and the intended URL is stored so they return to `/profile` after authenticating.


### PR DESCRIPTION
## Summary
- add a `.env.example` file that captures the environment variables used by the app and their default values
- document the environment configuration steps in the README so developers know how to copy and adjust the file

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68ddd0ee11a083268d32bd89928d1dc8