### PR TITLE
fix: avoid hydration mismatch for mobile nav toggle

### DIFF
--- a/components/layout/AppBar/AppNavButtons.vue
+++ b/components/layout/AppBar/AppNavButtons.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex items-center gap-3">
-    <v-btn
+    <button
       v-if="props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
@@ -10,7 +10,7 @@
         name="mdi:menu"
         :size="24"
       />
-    </v-btn>
+    </button>
 
     <div class="flex items-center gap-8 px-16">
       <button


### PR DESCRIPTION
## Summary
- replace the mobile navigation toggle `v-btn` with a native button to avoid Vuetify theme mismatches during hydration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddd529964c8326a5e547be275eeca7