### PR TITLE
Fix Mercure runtime config access

### DIFF
--- a/stores/messenger.ts
+++ b/stores/messenger.ts
@@ -814,8 +814,7 @@ export const useMessengerStore = defineStore("messenger", () => {
   }
 
   async function ensureMercureToken(): Promise<string | null> {
-    const configuredToken =
-      runtimeConfig.mercure?.token ?? runtimeConfig.public?.mercure?.token ?? null;
+    const configuredToken = runtimeConfig.public?.mercure?.token ?? null;
 
     if (configuredToken) {
       return configuredToken;
@@ -841,7 +840,7 @@ export const useMessengerStore = defineStore("messenger", () => {
     }
 
     const userId = auth.currentUser.value?.id;
-    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? runtimeConfig.mercure?.hubUrl;
+    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? null;
 
     if (!userId || !hubUrl) {
       return null;
@@ -884,7 +883,7 @@ export const useMessengerStore = defineStore("messenger", () => {
       return;
     }
 
-    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? runtimeConfig.mercure?.hubUrl;
+    const hubUrl = runtimeConfig.public?.mercure?.hubUrl ?? null;
 
     if (!hubUrl || !connectToMercure) {
       return;


### PR DESCRIPTION
## Summary
- avoid accessing private Mercure runtime config from the client messenger store to resolve runtime errors

## Testing
- pnpm exec eslint stores/messenger.ts

------
https://chatgpt.com/codex/tasks/task_e_68deba3c17d48326b5f2edf7eb4501b0