### PR TITLE
Fix hydration mismatch for app nav buttons

### DIFF
--- a/components/layout/AppBar/AppNavButtons.vue
+++ b/components/layout/AppBar/AppNavButtons.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="props.isMobile"
+      v-show="props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
       @click="emit('toggle-left')"
@@ -34,7 +34,7 @@
         />
       </button>
       <button
-        v-if="!props.isMobile"
+        v-show="!props.isMobile"
         type="button"
         :class="props.iconTriggerClasses"
         @click="emit('toggle-left')"


### PR DESCRIPTION
## Summary
- replace mobile-only toggles in AppNavButtons with v-show to keep server and client DOM consistent

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deba66b988832687b375a78a2b2e19