### PR TITLE
Fix hydration mismatch for Icon component

### DIFF
--- a/components/Icon.vue
+++ b/components/Icon.vue
@@ -1,18 +1,16 @@
 <template>
   <span
-    v-if="iconSvg"
-    ref="iconEl"
     v-bind="forwardedAttrs"
     :class="['inline-flex items-center justify-center align-middle', attrs.class]"
     :style="[attrs.style as StyleValue | undefined, iconStyle]"
     role="img"
     aria-hidden="true"
-    v-html="iconSvg"
+    v-html="iconContent"
   />
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, useAttrs } from "vue";
+import { computed, watch, useAttrs } from "vue";
 import type { StyleValue } from "vue";
 
 const props = withDefaults(
@@ -51,7 +49,7 @@ const forwardedAttrs = computed(() => {
 });
 
 const iconSvg = computed(() => (props.name ? (iconCache.value[props.name] ?? null) : null));
-const iconEl = ref<HTMLElement | null>(null);
+const iconContent = computed(() => iconSvg.value ?? "");
 
 const iconStyle = computed(() => ({
   width: normalizedSize.value,
@@ -94,13 +92,4 @@ watch(
   { immediate: true },
 );
 
-watch(
-  iconSvg,
-  (value) => {
-    if (iconEl.value) {
-      iconEl.value.innerHTML = value ?? "";
-    }
-  },
-  { immediate: true },
-);
 </script>


### PR DESCRIPTION
## Summary
- render the Icon component wrapper consistently between server and client to prevent hydration warnings
- use a computed SVG string instead of manually manipulating the DOM during updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deba9f70b4832698172d27132f5191