### PR TITLE
Guard client access to private auth runtime config

### DIFF
--- a/composables/useAuthStore.ts
+++ b/composables/useAuthStore.ts
@@ -20,9 +20,11 @@ export function useAuthStore() {
   const followPendingState = useState<FollowPendingState>("auth-following-pending", () => ({}));
   const followErrorState = useState<string | null>("auth-following-error", () => null);
   const runtimeConfig = useRuntimeConfig();
+  const privateAuthConfig = import.meta.server ? runtimeConfig.auth ?? {} : {};
+  const publicAuthConfig = runtimeConfig.public?.auth ?? {};
   const sessionTokenCookieName =
-    runtimeConfig.auth?.sessionTokenCookieName ??
-    runtimeConfig.public?.auth?.sessionTokenCookieName ??
+    (privateAuthConfig.sessionTokenCookieName as string | undefined) ??
+    publicAuthConfig.sessionTokenCookieName ??
     "auth_session_token";
   const sessionTokenCookie = useCookie<string | null>(
     sessionTokenCookieName,

--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -69,16 +69,20 @@ export const useAuthSession = defineStore("auth-session", () => {
   const handlingUnauthorizedState = ref(false);
 
   const runtimeConfig = useRuntimeConfig();
+  const privateAuthConfig = import.meta.server ? runtimeConfig.auth ?? {} : {};
+  const publicAuthConfig = runtimeConfig.public?.auth ?? {};
   const sessionTokenCookieName =
-    runtimeConfig.auth?.sessionTokenCookieName ??
-    runtimeConfig.public?.auth?.sessionTokenCookieName ??
+    (privateAuthConfig.sessionTokenCookieName as string | undefined) ??
+    publicAuthConfig.sessionTokenCookieName ??
     "auth_session_token";
   const tokenPresenceCookieName =
-    runtimeConfig.auth?.tokenPresenceCookieName ??
-    runtimeConfig.public?.auth?.tokenPresenceCookieName ??
+    (privateAuthConfig.tokenPresenceCookieName as string | undefined) ??
+    publicAuthConfig.tokenPresenceCookieName ??
     "auth_token_present";
   const userCookieName =
-    runtimeConfig.auth?.userCookieName ?? runtimeConfig.public?.auth?.userCookieName ?? "auth_user";
+    (privateAuthConfig.userCookieName as string | undefined) ??
+    publicAuthConfig.userCookieName ??
+    "auth_user";
   type AuthUserCookie = Pick<
     AuthUser,
     "id" | "username" | "email" | "firstName" | "lastName" | "photo" | "roles" | "enabled"


### PR DESCRIPTION
## Summary
- guard runtime config usage in the auth composable so the client never accesses private keys
- adjust the auth session store to use only public auth values on the client while keeping server overrides

## Testing
- pnpm exec eslint composables/useAuthStore.ts stores/auth-session.ts

------
https://chatgpt.com/codex/tasks/task_e_68debdf709188326a29907869727f19d