### PR TITLE
Fix hydration mismatch on login password toggle icon

### DIFF
--- a/components/auth/LoginForm.vue
+++ b/components/auth/LoginForm.vue
@@ -60,11 +60,11 @@
           :aria-pressed="showPassword"
           @click="togglePassword"
         >
-          <Icon
+          <span
             aria-hidden="true"
-            :name="passwordToggleIcon"
-            class="login-field__action-icon"
-          />
+            class="login-field__action-icon mdi"
+            :class="passwordToggleIcon"
+          ></span>
           <span class="sr-only">{{ passwordToggleAriaLabel }}</span>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- replace the password toggle Icon component with an mdi font span to avoid SSR/client differences

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debe35745c83269050db34cdfd5837