### PR TITLE
Refactor layout route access to avoid middleware warnings

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -32,7 +32,8 @@ const siteConfig = computed(() => {
     description: site?.description ?? fallbackSiteConfig.description,
   };
 });
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const { themeClass, radius } = useThemes();
 const { locale } = useI18n();
 const runtimeConfig = nuxtApp && hasInjectionContext() ? useRuntimeConfig() : null;
@@ -72,10 +73,10 @@ type SeoMetaFields = {
   keywords?: string;
 };
 
-const matchedMeta = computed<SeoMetaFields>(
-  () => (route.matched?.[0]?.meta as SeoMetaFields) ?? {},
-);
-const currentMeta = computed<SeoMetaFields>(() => route.meta as SeoMetaFields);
+const matchedMeta = computed<SeoMetaFields>(() => {
+  return (currentRoute.value?.matched?.[0]?.meta as SeoMetaFields) ?? {};
+});
+const currentMeta = computed<SeoMetaFields>(() => (currentRoute.value?.meta as SeoMetaFields) ?? {});
 
 const defaultTitle = computed(() => siteConfig.value.name);
 const defaultDescription = computed(() => siteConfig.value.description);
@@ -87,7 +88,8 @@ const canonicalUrl = computed(() => {
   }
 
   try {
-    return new URL(route.fullPath, base).toString();
+    const fullPath = currentRoute.value?.fullPath ?? "/";
+    return new URL(fullPath, base).toString();
   } catch {
     return base;
   }

--- a/components/layout/AppSidebar.vue
+++ b/components/layout/AppSidebar.vue
@@ -129,7 +129,8 @@ const isDark = computed(() => props.isDark);
 const sticky = computed(() => props.sticky);
 const shouldRenderParticles = ref(false);
 const { t } = useI18n();
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const auth = useAuthSession();
 const siteSettings = useSiteSettingsState();
 
@@ -151,7 +152,8 @@ const resolvedItems = computed<LayoutSidebarItem[]>(() => props.items ?? variant
 
 const derivedActiveKey = computed(() => {
   const items = resolvedItems.value;
-  const match = findActiveSidebarKey(route.fullPath, items);
+  const fullPath = currentRoute.value?.fullPath ?? "/";
+  const match = findActiveSidebarKey(fullPath, items);
   if (match) return match;
   return findFirstSidebarKey(items) ?? "";
 });

--- a/components/layout/Aside.vue
+++ b/components/layout/Aside.vue
@@ -21,11 +21,11 @@
           :to="link.redirect ?? link._path"
           class="text-foreground/80 hover:bg-muted hover:text-primary flex h-8 items-center gap-2 rounded-md p-2 text-sm"
           :class="[
-            path.startsWith(link._path) &&
+            currentPath.startsWith(link._path) &&
               link._path !== '/' &&
               'bg-muted !text-primary font-medium',
 
-            link._path === '/' && path === '/' && 'bg-muted !text-primary font-medium',
+            link._path === '/' && currentPath === '/' && 'bg-muted !text-primary font-medium',
           ]"
         >
           <AppSmartIcon
@@ -66,11 +66,16 @@ const { navDirFromPath } = useContentHelpers();
 const config = useConfig();
 const { locale, defaultLocale, navigation } = useI18nDocs();
 
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
+
 const tree = computed(() => {
-  const route = useRoute();
-  const path = route.path.split("/");
+  const route = currentRoute.value;
+  const pathSegments = (route?.path ?? "/").split("/");
   if (config.value.aside.useLevel) {
-    const leveledPath = path.splice(0, locale.value === defaultLocale ? 2 : 3).join("/");
+    const leveledPath = pathSegments
+      .splice(0, locale.value === defaultLocale ? 2 : 3)
+      .join("/");
 
     const dir = navDirFromPath(leveledPath, navigation.value);
     return dir ?? [];
@@ -79,5 +84,5 @@ const tree = computed(() => {
   return navigation.value;
 });
 
-const path = computed(() => useRoute().path);
+const currentPath = computed(() => currentRoute.value?.path ?? "/");
 </script>

--- a/components/layout/Header.vue
+++ b/components/layout/Header.vue
@@ -208,8 +208,13 @@ const showToc = computed(() => {
   );
 });
 
-const route = useRoute();
-const baseRouteName = computed(() => useRouteBaseName()(route));
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
+const resolveRouteBaseName = useRouteBaseName();
+const baseRouteName = computed(() => {
+  const route = currentRoute.value ?? router.currentRoute.value;
+  return route ? resolveRouteBaseName(route) : undefined;
+});
 
 function handleMenuItemSelect(item: HeaderLinkMenuItem) {
   if (!item?.to) return;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -249,8 +249,8 @@ const resolvedColorMode = computed<"light" | "dark">(() => {
 
 const isDark = computed(() => resolvedColorMode.value === "dark");
 
-const route = useRoute();
 const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const display = useDisplay();
 const { locale, availableLocales } = useI18n();
 const auth = useAuthSession();
@@ -260,7 +260,7 @@ const rightDrawer = ref(true);
 const isMobile = computed(() => !display.mdAndUp.value);
 // rail facultatif: quand mdAndDown mais pas mobile complet
 const isRail = computed(() => display.mdAndDown.value && !isMobile.value);
-const showRightWidgets = computed(() => route.meta?.showRightWidgets !== false);
+const showRightWidgets = computed(() => currentRoute.value?.meta?.showRightWidgets !== false);
 
 const siteSettingsState = useSiteSettingsState();
 const theme = useTheme();
@@ -350,10 +350,10 @@ const canAccessAdmin = computed(() => {
 });
 
 const sidebarVariant = computed<"default" | "profile">(() =>
-  route.meta?.sidebarVariant === "profile" ? "profile" : "default",
+  currentRoute.value?.meta?.sidebarVariant === "profile" ? "profile" : "default",
 );
 
-const isAdminRoute = computed(() => route.path.startsWith("/admin"));
+const isAdminRoute = computed(() => currentRoute.value?.path?.startsWith("/admin") ?? false);
 
 const sidebarItems = computed<LayoutSidebarItem[]>(() => {
   if (sidebarVariant.value === "profile") {
@@ -410,7 +410,7 @@ watch(showRightWidgets, (value) => {
 });
 
 watch(
-  () => route.fullPath,
+  () => currentRoute.value?.fullPath ?? "",
   (path) => {
     if (isMobile.value) {
       leftDrawer.value = false;
@@ -424,7 +424,8 @@ watch(
 watch(
   sidebarItems,
   (items) => {
-    updateActiveSidebar(route.fullPath, items);
+    const path = currentRoute.value?.fullPath ?? "/";
+    updateActiveSidebar(path, items);
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Summary
- replace direct `useRoute` usage in the app shell and layout components with `router.currentRoute` so they no longer execute route composables while middleware is running
- update layout watchers and sidebar helpers to consume the computed current route data and keep sidebar state in sync
- adjust the aside navigation tree and app sidebar to derive the active path from the router

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68debe4d9080832686421393f8d216f5