### PR TITLE
Prevent LastPass hydration mismatch

### DIFF
--- a/components/auth/LoginForm.vue
+++ b/components/auth/LoginForm.vue
@@ -1,6 +1,8 @@
 <template>
   <form
     :class="formClasses"
+    data-lpignore="true"
+    data-lastpass-ignore="true"
     @submit.prevent="handleSubmit"
   >
     <div class="login-form__inner">
@@ -33,6 +35,8 @@
           :disabled="isDisabled"
           :aria-invalid="Boolean(formError)"
           :aria-describedby="formError ? formErrorId : undefined"
+          data-lpignore="true"
+          data-lastpass-ignore="true"
           @input="handleFieldInput"
         />
       </div>
@@ -49,6 +53,8 @@
           :disabled="isDisabled"
           :aria-invalid="Boolean(formError)"
           :aria-describedby="formError ? formErrorId : undefined"
+          data-lpignore="true"
+          data-lastpass-ignore="true"
           @input="handleFieldInput"
         />
 


### PR DESCRIPTION
## Summary
- add LastPass ignore attributes to the login form fields to stop extension DOM injections that break hydration

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec86ad2b483268718f1af483afae0