### PR TITLE
Prevent middleware unauthorized handler warning

### DIFF
--- a/plugins/api.client.ts
+++ b/plugins/api.client.ts
@@ -35,7 +35,10 @@ export default defineNuxtPlugin({
           payload.message || payload.error || error.message || "Unexpected network error";
         const title = payload.title || (status ? `HTTP ${status}` : undefined);
 
-        if (status === 401 || status === 403) {
+        const context = (options.context ?? {}) as Record<string, unknown>;
+        const skipUnauthorizedHandler = Boolean(context.skipUnauthorizedHandler);
+
+        if ((status === 401 || status === 403) && !skipUnauthorizedHandler) {
           const translator = $i18n?.t ?? ((key: string) => key);
           const sessionMessage = translator("auth.sessionExpired");
 
@@ -44,10 +47,7 @@ export default defineNuxtPlugin({
           return;
         }
 
-        const suppressNotification = Boolean(
-          options?.context &&
-            (options.context as Record<string, unknown>).suppressErrorNotification,
-        );
+        const suppressNotification = Boolean(context.suppressErrorNotification);
 
         if (suppressNotification) {
           return;

--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -318,6 +318,7 @@ export const useAuthSession = defineStore("auth-session", () => {
         method: "GET",
         context: {
           suppressErrorNotification: true,
+          skipUnauthorizedHandler: true,
         },
       });
 


### PR DESCRIPTION
## Summary
- add a `skipUnauthorizedHandler` flag to the API client so middleware-triggered requests can bypass automatic auth redirects
- update the auth session refresh call to set the new flag when fetching the current session

## Testing
- pnpm exec eslint plugins/api.client.ts stores/auth-session.ts

------
https://chatgpt.com/codex/tasks/task_e_68decb6949348326b395e2c812bf1ceb