### PR TITLE
Avoid direct useRoute access in middleware contexts

### DIFF
--- a/components/auth/LoginForm.vue
+++ b/components/auth/LoginForm.vue
@@ -128,7 +128,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, useId } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { useLocalePath } from "#i18n";
 import { useAuthSession } from "~/stores/auth-session";
@@ -146,7 +146,6 @@ const props = withDefaults(
 
 const { t, locale } = useI18n();
 const router = useRouter();
-const route = useRoute();
 const localePath = useLocalePath();
 const { $notify } = useNuxtApp();
 const auth = useAuthSession();
@@ -177,6 +176,12 @@ const passwordToggleAriaLabel = computed(() =>
   showPassword.value ? hidePasswordLabel.value : showPasswordLabel.value,
 );
 const sessionMessage = computed(() => auth.sessionMessage.value ?? "");
+const redirectFromQuery = computed(() => {
+  const currentRoute = router.currentRoute.value;
+  const redirectQuery = currentRoute?.query?.redirect;
+
+  return typeof redirectQuery === "string" ? redirectQuery : null;
+});
 
 watch(
   () => auth.loginError.value,
@@ -244,9 +249,8 @@ async function handleSubmit() {
 
     auth.setSessionMessage(null);
 
-    const redirectFromQuery =
-      typeof route.query.redirect === "string" ? route.query.redirect : null;
-    const redirectTarget = redirectFromQuery || auth.consumeRedirect() || localePath("/");
+    const redirectTarget =
+      redirectFromQuery.value || auth.consumeRedirect() || localePath("/");
 
     $notify({
       type: "success",

--- a/components/auth/ResetPasswordForm.vue
+++ b/components/auth/ResetPasswordForm.vue
@@ -69,9 +69,12 @@ const loading = ref(false);
 const error = ref("");
 const success = ref("");
 
-const route = useRoute();
 const router = useRouter();
-const token = computed(() => route.query.token as string);
+const currentRoute = computed(() => router.currentRoute.value);
+const token = computed(() => {
+  const queryToken = currentRoute.value?.query?.token;
+  return typeof queryToken === "string" ? queryToken : "";
+});
 
 const passwordRules = [
   (v: string) => !!v || t("reset.rules.required"),

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -296,15 +296,17 @@
 import { computed } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.about.title");
   const description = t("seo.about.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/admin/blog/[section].vue
+++ b/pages/admin/blog/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type BlogSection = (typeof allowedSections)[number];
 
 const section = computed<BlogSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as BlogSection)) {
     return value as BlogSection;
   }

--- a/pages/admin/ecommerce-management/[section].vue
+++ b/pages/admin/ecommerce-management/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type EcommerceManagementSection = (typeof allowedSections)[number];
 
 const section = computed<EcommerceManagementSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as EcommerceManagementSection)) {
     return value as EcommerceManagementSection;
   }

--- a/pages/admin/education-management/[section].vue
+++ b/pages/admin/education-management/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type EducationManagementSection = (typeof allowedSections)[number];
 
 const section = computed<EducationManagementSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as EducationManagementSection)) {
     return value as EducationManagementSection;
   }

--- a/pages/admin/game-management/[section].vue
+++ b/pages/admin/game-management/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type GameManagementSection = (typeof allowedSections)[number];
 
 const section = computed<GameManagementSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as GameManagementSection)) {
     return value as GameManagementSection;
   }

--- a/pages/admin/job-management/[section].vue
+++ b/pages/admin/job-management/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type JobManagementSection = (typeof allowedSections)[number];
 
 const section = computed<JobManagementSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as JobManagementSection)) {
     return value as JobManagementSection;
   }

--- a/pages/admin/user-management/[section].vue
+++ b/pages/admin/user-management/[section].vue
@@ -40,14 +40,16 @@ definePageMeta({
   showRightWidgets: false,
 });
 
-const route = useRoute();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const allowedSections = ["data", "crons"] as const;
 
 type UserManagementSection = (typeof allowedSections)[number];
 
 const section = computed<UserManagementSection>(() => {
-  const value = route.params.section;
+  const params = currentRoute.value?.params ?? {};
+  const value = (params as Record<string, unknown>).section;
   if (typeof value === "string" && allowedSections.includes(value as UserManagementSection)) {
     return value as UserManagementSection;
   }

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -146,8 +146,9 @@ import { computed } from "vue";
 import ContactForm from "~/components/contact/ContactForm.vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const localePath = useLocalePath();
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
@@ -155,7 +156,8 @@ const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-worl
 useHead(() => {
   const title = t("seo.contact.title");
   const description = t("seo.contact.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/ecommerce.vue
+++ b/pages/ecommerce.vue
@@ -162,16 +162,18 @@
 import { computed } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const localePath = useLocalePath();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.ecommerce.title");
   const description = t("seo.ecommerce.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/education.vue
+++ b/pages/education.vue
@@ -162,16 +162,18 @@
 import { computed } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const localePath = useLocalePath();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.education.title");
   const description = t("seo.education.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/game.vue
+++ b/pages/game.vue
@@ -162,16 +162,18 @@
 import { computed } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const localePath = useLocalePath();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.game.title");
   const description = t("seo.game.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -223,8 +223,9 @@
 import { computed, ref } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const localePath = useLocalePath();
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
@@ -232,7 +233,8 @@ const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-worl
 useHead(() => {
   const title = t("seo.help.title");
   const description = t("seo.help.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/job.vue
+++ b/pages/job.vue
@@ -162,16 +162,18 @@
 import { computed } from "vue";
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 const localePath = useLocalePath();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.job.title");
   const description = t("seo.job.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/messenger/[id].vue
+++ b/pages/messenger/[id].vue
@@ -30,7 +30,7 @@
 
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import { callOnce, navigateTo } from "#imports";
 import ConversationsList from "~/components/messenger/ConversationsList.vue";
@@ -38,13 +38,16 @@ import ChatPane from "~/components/messenger/ChatPane.vue";
 import { useMessengerStore } from "~/stores/messenger";
 
 const messenger = useMessengerStore();
-const route = useRoute();
 const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const { t } = useI18n();
 
 await callOnce(() => messenger.fetchThreads({ limit: 50 }));
 
-const conversationId = computed(() => String(route.params.id ?? ""));
+const conversationId = computed(() => {
+  const params = currentRoute.value?.params ?? {};
+  return String((params as Record<string, unknown>).id ?? "");
+});
 const conversations = computed(() => messenger.orderedConversations.value ?? []);
 const loading = computed(() => messenger.loadingList.value);
 const emptyCtaTo = computed(() => {

--- a/pages/profile-edit.vue
+++ b/pages/profile-edit.vue
@@ -348,15 +348,17 @@ definePageMeta({
 });
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.profileEdit.title");
   const description = t("seo.profileEdit.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/profile-friends.vue
+++ b/pages/profile-friends.vue
@@ -393,15 +393,17 @@ definePageMeta({
 });
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.profileFriends.title");
   const description = t("seo.profileFriends.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/profile-photos.vue
+++ b/pages/profile-photos.vue
@@ -359,15 +359,17 @@ definePageMeta({
 });
 
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
+const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
 
 useHead(() => {
   const title = t("seo.profilePhotos.title");
   const description = t("seo.profilePhotos.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -303,8 +303,8 @@ definePageMeta({
 
 const auth = useAuthSession();
 const { t, locale, localeProperties } = useI18n();
-const route = useRoute();
 const router = useRouter();
+const currentRoute = computed(() => router.currentRoute.value);
 const runtimeConfig = useRuntimeConfig();
 
 const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-world-space.com");
@@ -312,7 +312,8 @@ const baseUrl = computed(() => runtimeConfig.public.baseUrl ?? "https://bro-worl
 useHead(() => {
   const title = t("seo.profile.title");
   const description = t("seo.profile.description");
-  const canonical = new URL(route.path, baseUrl.value).toString();
+  const canonicalPath = currentRoute.value?.path ?? "/";
+  const canonical = new URL(canonicalPath, baseUrl.value).toString();
   const iso = localeProperties.value?.iso ?? locale.value;
 
   return {


### PR DESCRIPTION
## Summary
- replace direct `useRoute()` calls in middleware-protected pages with computed values derived from `router.currentRoute`
- update admin section pages to resolve route params from the router while validating sections as before
- ensure auth reset form reads the token query string without relying on `useRoute`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68decb6ac6848326a77d78ec099c6f1b