### PR TITLE
Add hidden username field for profile security password form

### DIFF
--- a/pages/profile-security.vue
+++ b/pages/profile-security.vue
@@ -58,6 +58,21 @@
                   </div>
 
                   <v-form @submit.prevent="handleSubmit">
+                    <label
+                      :for="usernameFieldId"
+                      class="sr-only"
+                    >
+                      {{ t("auth.usernameOrEmail") }}
+                    </label>
+                    <input
+                      :id="usernameFieldId"
+                      type="text"
+                      name="username"
+                      class="sr-only"
+                      autocomplete="username"
+                      :value="usernameFieldValue"
+                      readonly
+                    />
                     <v-row dense>
                       <v-col
                         cols="12"
@@ -256,7 +271,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, reactive, useId } from "vue";
+import { useAuthSession } from "~/stores/auth-session";
 
 definePageMeta({
   middleware: "auth",
@@ -268,6 +284,11 @@ definePageMeta({
 });
 
 const { t, locale } = useI18n();
+const auth = useAuthSession();
+const usernameFieldId = `profile-security-username-${useId()}`;
+const usernameFieldValue = computed(
+  () => auth.currentUser.value?.username ?? auth.currentUser.value?.email ?? "",
+);
 
 interface SessionEntry {
   id: string;


### PR DESCRIPTION
## Summary
- add a hidden username input to the profile security password form to satisfy accessibility guidance
- derive the hidden field value from the authenticated session and provide localization-friendly labelling

## Testing
- pnpm exec eslint pages/profile-security.vue

------
https://chatgpt.com/codex/tasks/task_e_68ded0108b9083268b6c0d6fc4106623