### PR TITLE
Fix logout translation initialization

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -402,10 +402,11 @@ export const useAuthSession = defineStore("auth-session", () => {
     }
   }
 
+  const { t } = useI18n();
+
   async function logout(options: LogoutOptions = {}) {
     const { redirect = true, redirectTo = null, notify = true } = options;
     const fetcher = resolveFetcher();
-    const { t } = useI18n();
     const { $notify } = useNuxtApp();
 
     try {


### PR DESCRIPTION
## Summary
- initialize the i18n translator once at the top of the auth session store
- reuse the existing translator during logout notifications to avoid runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded46cce308326bfee5ece4cf25697