### PR TITLE
Fix drawer hydration mismatch

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -255,9 +255,21 @@ const auth = useAuthSession();
 
 const leftDrawer = ref(true);
 const rightDrawer = ref(true);
-const isMobile = computed(() => !display.mdAndUp.value);
+const isMobile = computed(() => {
+  if (!isHydrated.value) {
+    return false;
+  }
+
+  return !display.mdAndUp.value;
+});
 // rail facultatif: quand mdAndDown mais pas mobile complet
-const isRail = computed(() => display.mdAndDown.value && !isMobile.value);
+const isRail = computed(() => {
+  if (!isHydrated.value) {
+    return false;
+  }
+
+  return display.mdAndDown.value && !isMobile.value;
+});
 const showRightWidgets = computed(() => currentRoute.value?.meta?.showRightWidgets !== false);
 
 const siteSettingsState = useSiteSettingsState();


### PR DESCRIPTION
## Summary
- defer mobile and rail breakpoint calculations until hydration to keep server and client drawer markup in sync

## Testing
- pnpm exec eslint layouts/default.vue

------
https://chatgpt.com/codex/tasks/task_e_68ded4af17748326b784fefb2a358bf6