### PR TITLE
Fix translation handling in auth session store

### DIFF
--- a/stores/auth-session.ts
+++ b/stores/auth-session.ts
@@ -1,6 +1,5 @@
 import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
-import { useI18n } from "vue-i18n";
 import { useCookie, useRequestFetch, useState } from "#imports";
 import { buildLocalizedPath, resolveLocaleFromPath } from "~/lib/i18n/locale-path";
 import { defineStore } from "~/lib/pinia-shim";
@@ -66,6 +65,9 @@ export const useAuthSession = defineStore("auth-session", () => {
   const loginErrorState = ref<string | null>(null);
   const sessionMessageState = ref<string | null>(null);
   const handlingUnauthorizedState = ref(false);
+
+  const nuxtApp = useNuxtApp();
+  const translate = (key: string) => nuxtApp.$i18n?.t?.(key) ?? key;
 
   const runtimeConfig = useRuntimeConfig();
   const privateAuthConfig = import.meta.server ? runtimeConfig.auth ?? {} : {};
@@ -402,8 +404,6 @@ export const useAuthSession = defineStore("auth-session", () => {
     }
   }
 
-  const { t } = useI18n();
-
   async function logout(options: LogoutOptions = {}) {
     const { redirect = true, redirectTo = null, notify = true } = options;
     const fetcher = resolveFetcher();
@@ -425,8 +425,8 @@ export const useAuthSession = defineStore("auth-session", () => {
     if (notify) {
       $notify({
         type: "success",
-        title: t("auth.successTitle"),
-        message: t("auth.logoutMessage"),
+        title: translate("auth.successTitle"),
+        message: translate("auth.logoutMessage"),
       });
     }
 


### PR DESCRIPTION
## Summary
- replace the auth session store's direct use of `useI18n` with a Nuxt app translator helper to avoid setup-time errors when the store is initialized

## Testing
- pnpm lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ded7ab14248326b2f292ebcc715e5b