### PR TITLE
Fix hydration mismatch in RightControls toggles

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="!props.isMobile && props.showRightToggle"
+      v-if="props.showRightToggle"
+      v-show="!props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
       aria-label="Open widgets"
@@ -50,7 +51,8 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-if="props.isMobile && props.showRightToggle"
+      v-if="props.showRightToggle"
+      v-show="props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
       aria-label="Open widgets"


### PR DESCRIPTION
## Summary
- ensure the RightControls toggle buttons render consistently during SSR by switching to v-show based visibility

## Testing
- pnpm lint *(fails: pre-existing lint errors about folder naming conventions and lint rules outside the touched file)*

------
https://chatgpt.com/codex/tasks/task_e_68ded8dd27a08326943b0d2fcb9b4f1e