### PR TITLE
Fix dark mode persistence on profile routes

### DIFF
--- a/composables/useLayoutRightSidebar.ts
+++ b/composables/useLayoutRightSidebar.ts
@@ -1,0 +1,40 @@
+import { onBeforeUnmount, toValue, watchEffect, type Component, type MaybeRefOrGetter } from "vue";
+
+export interface LayoutRightSidebarContent {
+  component: Component;
+  props?: Record<string, unknown>;
+  wrapperClass?: string;
+}
+
+const STATE_KEY = "layout-right-sidebar-content";
+
+export function useLayoutRightSidebar() {
+  const rightSidebarContent = useState<LayoutRightSidebarContent | null>(STATE_KEY, () => null);
+
+  function setRightSidebarContent(content: LayoutRightSidebarContent | null) {
+    rightSidebarContent.value = content;
+  }
+
+  function registerRightSidebarContent(
+    content: MaybeRefOrGetter<LayoutRightSidebarContent | null>,
+  ) {
+    if (import.meta.server) {
+      rightSidebarContent.value = toValue(content);
+      return;
+    }
+
+    watchEffect(() => {
+      rightSidebarContent.value = toValue(content);
+    });
+
+    onBeforeUnmount(() => {
+      rightSidebarContent.value = null;
+    });
+  }
+
+  return {
+    rightSidebarContent,
+    setRightSidebarContent,
+    registerRightSidebarContent,
+  };
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -97,7 +97,19 @@
                   :rating="rating"
                   :user="user"
                 >
-                  <div class="flex flex-col gap-4">
+                  <div
+                    v-if="rightSidebarContent"
+                    :class="rightSidebarContent.wrapperClass ?? 'flex flex-col gap-4'"
+                  >
+                    <component
+                      :is="rightSidebarContent.component"
+                      v-bind="rightSidebarContent.props"
+                    />
+                  </div>
+                  <div
+                    v-else
+                    class="flex flex-col gap-4"
+                  >
                     <SidebarWeatherCard
                       v-if="weather"
                       :weather="weather"
@@ -181,6 +193,7 @@ import { useRequestHeaders, useState } from "#imports";
 import AppSidebar from "@/components/layout/AppSidebar.vue";
 import AppTopBar from "@/components/layout/AppTopBar.vue";
 import { useRightSidebarData } from "@/composables/useRightSidebarData";
+import { useLayoutRightSidebar } from "~/composables/useLayoutRightSidebar";
 import { useCookieColorMode } from "~/composables/useCookieColorMode";
 import type { LayoutSidebarItem } from "~/lib/navigation/sidebar";
 import {
@@ -318,6 +331,7 @@ watch(
 const siteSettings = computed(() => siteSettingsState.value ?? getDefaultSiteSettings());
 
 const { weather, leaderboard, rating } = useRightSidebarData();
+const { rightSidebarContent } = useLayoutRightSidebar();
 
 const activeTheme = computed<SiteThemeDefinition | null>(() => {
   const current = siteSettings.value;

--- a/pages/profile-security.vue
+++ b/pages/profile-security.vue
@@ -1,10 +1,9 @@
 <template>
-  <NuxtLayout name="default">
-    <main
-      class="py-4"
-      aria-labelledby="security-title"
-    >
-      <v-container>
+  <main
+    class="py-4"
+    aria-labelledby="security-title"
+  >
+    <v-container>
         <header class="mb-6">
           <div class="d-flex flex-column flex-sm-row align-sm-center justify-space-between gap-4">
             <div>
@@ -265,9 +264,8 @@
         >
           {{ snackbar.message }}
         </v-snackbar>
-      </v-container>
-    </main>
-  </NuxtLayout>
+    </v-container>
+  </main>
 </template>
 
 <script setup lang="ts">
@@ -277,7 +275,6 @@ import { useAuthSession } from "~/stores/auth-session";
 definePageMeta({
   middleware: "auth",
   title: "profile-security",
-  layout: false,
   showRightWidgets: false,
   sidebarVariant: "profile",
   documentDriven: false,

--- a/pages/profile.vue
+++ b/pages/profile.vue
@@ -1,33 +1,18 @@
 <template>
-  <NuxtLayout name="default">
-    <template #right-sidebar>
-      <div class="flex flex-col gap-4">
-        <ProfileSidebar
-          :user="sidebarUser"
-          :photos="sidebarPhotos"
-          :friends="sidebarFriends"
-          :friends-count="friendsCount"
-          :life-events="sidebarEvents"
-          @view-all-friends="goToFriendsPage"
-          @view-all-photos="goToPhotosPage"
-          @edit-details="goToEditPage"
-        />
-      </div>
-    </template>
-    <main
-      class="py-4"
-      aria-labelledby="profile-title"
-    >
-      <v-container>
-        <header
-          class="mb-8"
-          aria-describedby="profile-subtitle"
+  <main
+    class="py-4"
+    aria-labelledby="profile-title"
+  >
+    <v-container>
+      <header
+        class="mb-8"
+        aria-describedby="profile-subtitle"
+      >
+        <v-card
+          class="pa-6"
+          rounded="xl"
+          elevation="10"
         >
-          <v-card
-            class="pa-6"
-            rounded="xl"
-            elevation="10"
-          >
             <div class="d-flex flex-column flex-sm-row align-sm-center gap-4">
               <v-avatar
                 size="96"
@@ -88,8 +73,8 @@
                 </p>
               </div>
             </div>
-          </v-card>
-        </header>
+        </v-card>
+      </header>
 
         <v-row
           dense
@@ -232,17 +217,17 @@
             </v-row>
           </v-col>
         </v-row>
-      </v-container>
-    </main>
-  </NuxtLayout>
+    </v-container>
+  </main>
 </template>
 
 <script setup lang="ts">
 import { computed } from "vue";
 
+import ProfileSidebar from "~/components/layout/ProfileSidebar.vue";
+import { useLayoutRightSidebar } from "~/composables/useLayoutRightSidebar";
 import { useAuthSession } from "~/stores/auth-session";
 import type { AuthUser } from "~/types/auth";
-import ProfileSidebar from "~/components/layout/ProfileSidebar.vue";
 
 interface ProfileDetails {
   id?: string;
@@ -297,7 +282,6 @@ interface ProfileUser extends AuthUser {
 definePageMeta({
   middleware: "auth",
   title: "profile",
-  layout: false,
   sidebarVariant: "profile",
   documentDriven: false,
 });
@@ -640,6 +624,25 @@ const sidebarFriends = computed<SidebarFriend[]>(() => {
 const sidebarEvents = computed(
   () => [] as { title: string; date?: string; description?: string }[],
 );
+
+const { registerRightSidebarContent } = useLayoutRightSidebar();
+
+const sidebarContent = computed(() => ({
+  component: ProfileSidebar,
+  props: {
+    user: sidebarUser.value,
+    photos: sidebarPhotos.value,
+    friends: sidebarFriends.value,
+    friendsCount: friendsCount.value,
+    lifeEvents: sidebarEvents.value,
+    onViewAllFriends: goToFriendsPage,
+    onViewAllPhotos: goToPhotosPage,
+    onEditDetails: goToEditPage,
+  },
+  wrapperClass: "flex flex-col gap-4",
+}));
+
+registerRightSidebarContent(sidebarContent);
 
 function goToFriendsPage() {
   router.push({ name: "profile-friends" });


### PR DESCRIPTION
## Summary
- add a layout right sidebar helper so pages can register sidebar components without bypassing the default layout
- update the default layout to consume the registered sidebar content and fall back to existing widgets
- migrate the profile-related pages to use the default layout so the dark theme preference is preserved

## Testing
- `pnpm lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dedbbfae988326b38e6899ae7b5ee7