### PR TITLE
Fix navigation drawer hydration mode mismatch

### DIFF
--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -421,6 +421,20 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   const vuetify = createVuetify({
     ssr: true,
+    display: {
+      mobileBreakpoint: "md",
+      thresholds: {
+        xs: 0,
+        sm: 600,
+        md: 960,
+        lg: 1280,
+        xl: 1920,
+      },
+      ssr: {
+        width: 1280,
+        height: 720,
+      },
+    },
     components: {
       VAlert,
       VApp,


### PR DESCRIPTION
## Summary
- configure Vuetify's display service with explicit SSR dimensions
- ensure the server treats the layout as non-mobile to avoid temporary drawer classes

## Testing
- pnpm lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dee354c0bc8326a204211405afa767