### PR TITLE
Fix hydration z-index mismatch for navigation drawers

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -29,6 +29,7 @@
       location="start"
       width="320"
       class="app-drawer"
+      :style="drawerInlineStyle"
     >
       <ParticlesBg
         class="sidebar-default-card__particles"
@@ -68,6 +69,7 @@
       width="340"
       class="app-drawer"
       data-test="app-right-drawer"
+      :style="drawerInlineStyle"
     >
       <ParticlesBg
         class="sidebar-default-card__particles"
@@ -298,6 +300,8 @@ const rightDrawer = computed({
     rightDrawerState.value = value;
   },
 });
+
+const drawerInlineStyle = { zIndex: 1004 } as const;
 const isMobile = computed(() => {
   if (!isHydrated.value) {
     return false;


### PR DESCRIPTION
## Summary
- add a shared inline style to both navigation drawers so the server and client render the same z-index
- define the drawer style once in the layout script to prevent hydration warnings about mismatched styles

## Testing
- pnpm lint *(hangs locally, aborted after extended runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68dee44fdae0832685a37c8c7d78519e