### PR TITLE
Fix hydration mismatch for main layout container

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -168,7 +168,7 @@
     </v-navigation-drawer>
 
     <v-main
-      v-if="areSidebarsVisible"
+      v-show="areSidebarsVisible"
       class="app-surface"
     >
       <ParticlesBg


### PR DESCRIPTION
## Summary
- render the main layout container consistently on both server and client by switching the sidebar visibility check to use `v-show`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0603dbb08326a2aab982e1eb90de