### PR TITLE
Fix hydration mismatch for top bar toggle buttons

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="props.showRightToggle"
-      v-show="!props.isMobile"
+      v-show="props.showRightToggle && !props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
       aria-label="Open widgets"
@@ -51,8 +50,7 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-if="props.showRightToggle"
-      v-show="props.isMobile"
+      v-show="props.showRightToggle && props.isMobile"
       type="button"
       :class="props.iconTriggerClasses"
       aria-label="Open widgets"


### PR DESCRIPTION
## Summary
- ensure RightControls toggle buttons rely on v-show only so SSR and client DOM tree stay aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df09f55e288326b2285aed2738daa6