### PR TITLE
Fix navigation drawer hydration style mismatch

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -306,7 +306,9 @@ const rightDrawer = computed({
   },
 });
 
-const drawerInlineStyle = { zIndex: 1004 } as const;
+const drawerInlineStyle = computed(() => ({
+  zIndex: isHydrated.value ? 1004 : 1006,
+}));
 const isMobile = computed(() => {
   if (!isHydrated.value) {
     return initialIsMobile.value;


### PR DESCRIPTION
## Summary
- compute the navigation drawer z-index so the SSR and client renders match during hydration

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0b1030688326a981be65fdc1e46f