### PR TITLE
Fix hydration mismatch for main surface

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -168,7 +168,7 @@
     </v-navigation-drawer>
 
     <v-main
-      v-show="areSidebarsVisible"
+      v-show="!isHydrated || areSidebarsVisible"
       class="app-surface"
     >
       <ParticlesBg


### PR DESCRIPTION
## Summary
- ensure the main application surface remains visible during SSR hydration
- gate the runtime visibility toggle behind the hydration flag to avoid DOM mismatches

## Testing
- pnpm lint *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c51dadc83269c501efb4326f457