### PR TITLE
Fix hydration mismatch in RightControls toggles

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,17 +1,18 @@
 <template>
   <div class="flex items-center gap-3">
-    <button
-      v-show="props.showRightToggle && !props.isMobile"
-      type="button"
-      :class="props.iconTriggerClasses"
-      aria-label="Open widgets"
-      @click="emit('toggle-right')"
-    >
-      <AppIcon
-        name="mdi-format-align-justify"
-        :size="22"
-      />
-    </button>
+    <template v-if="props.showRightToggle">
+      <button
+        type="button"
+        :class="[props.iconTriggerClasses, 'hidden md:flex']"
+        aria-label="Open widgets"
+        @click="emit('toggle-right')"
+      >
+        <AppIcon
+          name="mdi-format-align-justify"
+          :size="22"
+        />
+      </button>
+    </template>
     <MessengerMenu
       :conversations="props.messengerConversations"
       :icon-trigger-classes="props.iconTriggerClasses"
@@ -50,9 +51,9 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-show="props.showRightToggle && props.isMobile"
+      v-if="props.showRightToggle"
       type="button"
-      :class="props.iconTriggerClasses"
+      :class="[props.iconTriggerClasses, 'md:hidden']"
       aria-label="Open widgets"
       @click="emit('toggle-right')"
     >


### PR DESCRIPTION
## Summary
- replace the `v-show`-based responsive toggle buttons with Tailwind breakpoint classes to keep server and client markup consistent
- ensure the desktop and mobile widget toggle buttons only render when the right sidebar is enabled

## Testing
- pnpm lint *(fails: existing lint rule violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df0d7932a8832684460ca02283c3c8