### PR TITLE
Add explicit ClientOnly fallbacks for RightControls

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -15,6 +15,9 @@
           />
         </button>
       </template>
+      <template #fallback>
+        <span aria-hidden="true" />
+      </template>
     </ClientOnly>
     <MessengerMenu
       :conversations="props.messengerConversations"
@@ -67,6 +70,9 @@
             :size="22"
           />
         </button>
+      </template>
+      <template #fallback>
+        <span aria-hidden="true" />
       </template>
     </ClientOnly>
   </div>


### PR DESCRIPTION
## Summary
- add explicit fallback spans to RightControls ClientOnly blocks to prevent hydration mismatch warnings on mobile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df103d50748326876d04d0a21b49d7