### PR TITLE
Fix hydration mismatches in layout controls

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,24 +1,17 @@
 <template>
   <div class="flex items-center gap-3">
-    <ClientOnly>
-      <template #default>
-        <button
-          v-if="props.showRightToggle"
-          type="button"
-          :class="[props.iconTriggerClasses, 'hidden md:flex']"
-          aria-label="Open widgets"
-          @click="emit('toggle-right')"
-        >
-          <AppIcon
-            name="mdi-format-align-justify"
-            :size="22"
-          />
-        </button>
-      </template>
-      <template #fallback>
-        <span aria-hidden="true" />
-      </template>
-    </ClientOnly>
+    <button
+      v-if="isMounted && props.showRightToggle"
+      type="button"
+      :class="[props.iconTriggerClasses, 'hidden md:flex']"
+      aria-label="Open widgets"
+      @click="emit('toggle-right')"
+    >
+      <AppIcon
+        name="mdi-format-align-justify"
+        :size="22"
+      />
+    </button>
     <MessengerMenu
       :conversations="props.messengerConversations"
       :icon-trigger-classes="props.iconTriggerClasses"
@@ -56,25 +49,18 @@
     <DarkModeToggle />
     <slot name="user" />
     <slot name="locale" />
-    <ClientOnly>
-      <template #default>
-        <button
-          v-if="props.showRightToggle"
-          type="button"
-          :class="[props.iconTriggerClasses, 'md:hidden']"
-          aria-label="Open widgets"
-          @click="emit('toggle-right')"
-        >
-          <AppIcon
-            name="mdi:dots-vertical"
-            :size="22"
-          />
-        </button>
-      </template>
-      <template #fallback>
-        <span aria-hidden="true" />
-      </template>
-    </ClientOnly>
+    <button
+      v-if="isMounted && props.showRightToggle"
+      type="button"
+      :class="[props.iconTriggerClasses, 'md:hidden']"
+      aria-label="Open widgets"
+      @click="emit('toggle-right')"
+    >
+      <AppIcon
+        name="mdi:dots-vertical"
+        :size="22"
+      />
+    </button>
   </div>
 </template>
 
@@ -83,6 +69,7 @@ import NotificationMenu from "./NotificationMenu.vue";
 import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
 import type { MessengerConversation } from "~/types/messenger";
+import { onMounted, ref } from "vue";
 
 const props = defineProps<{
   isMobile: boolean;
@@ -106,4 +93,12 @@ const props = defineProps<{
   messengerLoading: boolean;
 }>();
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
+
+const isMounted = ref(false);
+
+if (import.meta.client) {
+  onMounted(() => {
+    isMounted.value = true;
+  });
+}
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -168,8 +168,8 @@
     </v-navigation-drawer>
 
     <v-main
-      v-show="!isHydrated || areSidebarsVisible"
       class="app-surface"
+      :class="{ hidden: isHydrated && !areSidebarsVisible }"
     >
       <ParticlesBg
         class="sidebar-default-card__particles"


### PR DESCRIPTION
## Summary
- replace the ClientOnly wrappers in the right-side layout controls with a mounted flag so the SSR and client trees stay aligned
- adjust the main content visibility logic to toggle a class instead of relying on v-show during hydration

## Testing
- pnpm lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df1155b43c83268c47fe6aca2708d9