### PR TITLE
Fix RightControls SSR hydration mismatch

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="isMounted && props.showRightToggle"
+      v-if="props.showRightToggle"
       type="button"
       :class="[props.iconTriggerClasses, 'hidden md:flex']"
       aria-label="Open widgets"
@@ -50,7 +50,7 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-if="isMounted && props.showRightToggle"
+      v-if="props.showRightToggle"
       type="button"
       :class="[props.iconTriggerClasses, 'md:hidden']"
       aria-label="Open widgets"
@@ -69,7 +69,6 @@ import NotificationMenu from "./NotificationMenu.vue";
 import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
 import type { MessengerConversation } from "~/types/messenger";
-import { onMounted, ref } from "vue";
 
 const props = defineProps<{
   isMobile: boolean;
@@ -93,12 +92,4 @@ const props = defineProps<{
   messengerLoading: boolean;
 }>();
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
-
-const isMounted = ref(false);
-
-if (import.meta.client) {
-  onMounted(() => {
-    isMounted.value = true;
-  });
-}
 </script>


### PR DESCRIPTION
## Summary
- remove the client-only mounting guard around the RightControls toggle buttons
- rely on the existing props for conditional rendering so SSR and client markup stay in sync

## Testing
- pnpm lint *(fails: command hung in container environment and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68df1301cea4832698237618a17501d9