### PR TITLE
Fix RightControls hydration classes

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -3,7 +3,7 @@
     <button
       v-if="props.showRightToggle"
       type="button"
-      :class="[props.iconTriggerClasses, 'hidden md:flex']"
+      :class="desktopToggleClasses"
       aria-label="Open widgets"
       @click="emit('toggle-right')"
     >
@@ -52,7 +52,7 @@
     <button
       v-if="props.showRightToggle"
       type="button"
-      :class="[props.iconTriggerClasses, 'md:hidden']"
+      :class="mobileToggleClasses"
       aria-label="Open widgets"
       @click="emit('toggle-right')"
     >
@@ -65,6 +65,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 import NotificationMenu from "./NotificationMenu.vue";
 import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
@@ -91,5 +92,12 @@ const props = defineProps<{
   messengerUnknownLabel: string;
   messengerLoading: boolean;
 }>();
+const desktopToggleClasses = computed(
+  () => `${props.iconTriggerClasses} hidden md:flex`,
+);
+const mobileToggleClasses = computed(
+  () => `${props.iconTriggerClasses} md:hidden`,
+);
+
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
 </script>


### PR DESCRIPTION
## Summary
- stabilize RightControls toggle button classes by reusing computed helpers for desktop and mobile variants
- import Vue's `computed` helper to support the new class computations

## Testing
- pnpm exec eslint components/layout/AppBar/RightControls.vue *(fails: existing folder naming rule for `AppBar`)*

------
https://chatgpt.com/codex/tasks/task_e_68df152ee0948326aac4813f8c395b43