### PR TITLE
Delay right control toggles until hydration

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="props.showRightToggle"
+      v-if="showToggleButtons"
       type="button"
       :class="desktopToggleClasses"
       aria-label="Open widgets"
@@ -50,7 +50,7 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-if="props.showRightToggle"
+      v-if="showToggleButtons"
       type="button"
       :class="mobileToggleClasses"
       aria-label="Open widgets"
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import NotificationMenu from "./NotificationMenu.vue";
 import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
@@ -92,12 +92,21 @@ const props = defineProps<{
   messengerUnknownLabel: string;
   messengerLoading: boolean;
 }>();
+const isHydrated = ref(false);
+
+if (import.meta.client) {
+  onMounted(() => {
+    isHydrated.value = true;
+  });
+}
+
 const desktopToggleClasses = computed(
   () => `${props.iconTriggerClasses} hidden md:flex`,
 );
 const mobileToggleClasses = computed(
   () => `${props.iconTriggerClasses} md:hidden`,
 );
+const showToggleButtons = computed(() => isHydrated.value && props.showRightToggle);
 
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
 </script>


### PR DESCRIPTION
## Summary
- render the right drawer toggle buttons only after the client has hydrated to avoid SSR mismatches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df16967b108326a7296eebc372a4b4