### PR TITLE
Fix hydration warning around particle background

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -31,13 +31,15 @@
       class="app-drawer"
       :style="drawerInlineStyle"
     >
-      <ParticlesBg
-        class="sidebar-default-card__particles"
-        :quantity="50"
-        :ease="50"
-        :staticity="12"
-        refresh
-      />
+      <ClientOnly>
+        <ParticlesBg
+          class="sidebar-default-card__particles"
+          :quantity="50"
+          :ease="50"
+          :staticity="12"
+          refresh
+        />
+      </ClientOnly>
       <div class="pane-scroll py-4 bg-card">
         <slot
           name="left-sidebar"
@@ -71,13 +73,15 @@
       data-test="app-right-drawer"
       :style="drawerInlineStyle"
     >
-      <ParticlesBg
-        class="sidebar-default-card__particles"
-        :quantity="50"
-        :ease="50"
-        :staticity="12"
-        refresh
-      />
+      <ClientOnly>
+        <ParticlesBg
+          class="sidebar-default-card__particles"
+          :quantity="50"
+          :ease="50"
+          :staticity="12"
+          refresh
+        />
+      </ClientOnly>
       <Suspense>
         <template #default>
           <ClientOnly>
@@ -171,14 +175,16 @@
       class="app-surface"
       :class="{ hidden: isHydrated && !areSidebarsVisible }"
     >
-      <ParticlesBg
-        class="sidebar-default-card__particles"
-        :quantity="120"
-        :ease="120"
-        :color="isDark ? '#ffffff' : '#111827'"
-        :staticity="12"
-        refresh
-      />
+      <ClientOnly>
+        <ParticlesBg
+          class="sidebar-default-card__particles"
+          :quantity="120"
+          :ease="120"
+          :color="isDark ? '#ffffff' : '#111827'"
+          :staticity="12"
+          refresh
+        />
+      </ClientOnly>
       <div class="main-scroll bg-card">
         <div class="app-container">
           <slot />


### PR DESCRIPTION
## Summary
- wrap the particle background decorations in the default layout with `<ClientOnly>` so they only render on the client
- avoid mismatches between the server-rendered markup and the hydrated DOM around `<VMain>`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df17c1e3b48326aeeee6ff289de790