### PR TITLE
Fix hydration mismatch in right controls

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -65,7 +65,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed } from "vue";
 import NotificationMenu from "./NotificationMenu.vue";
 import MessengerMenu from "~/components/messenger/MessengerMenu.vue";
 import type { AppNotification } from "~/types/layout";
@@ -92,21 +92,13 @@ const props = defineProps<{
   messengerUnknownLabel: string;
   messengerLoading: boolean;
 }>();
-const isHydrated = ref(false);
-
-if (import.meta.client) {
-  onMounted(() => {
-    isHydrated.value = true;
-  });
-}
-
 const desktopToggleClasses = computed(
   () => `${props.iconTriggerClasses} hidden md:flex`,
 );
 const mobileToggleClasses = computed(
   () => `${props.iconTriggerClasses} md:hidden`,
 );
-const showToggleButtons = computed(() => isHydrated.value && props.showRightToggle);
+const showToggleButtons = computed(() => props.showRightToggle);
 
 const emit = defineEmits(["toggle-right", "mark-all-notifications"]);
 </script>


### PR DESCRIPTION
## Summary
- remove the client-only hydration guard from the right controls toggles so the server and client render the same markup
- rely on the existing `showRightToggle` prop to determine whether the toggle buttons should be shown

## Testing
- pnpm exec eslint components/layout/AppBar/RightControls.vue *(fails: check-file/folder-naming-convention complains about existing `AppBar` directory name)*

------
https://chatgpt.com/codex/tasks/task_e_68df17b285d48326b08d28b341e336a1