### PR TITLE
Add SSR fallbacks for ClientOnly particle backgrounds

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,6 +39,12 @@
           :staticity="12"
           refresh
         />
+        <template #fallback>
+          <span
+            class="sidebar-default-card__particles"
+            aria-hidden="true"
+          />
+        </template>
       </ClientOnly>
       <div class="pane-scroll py-4 bg-card">
         <slot
@@ -81,6 +87,12 @@
           :staticity="12"
           refresh
         />
+        <template #fallback>
+          <span
+            class="sidebar-default-card__particles"
+            aria-hidden="true"
+          />
+        </template>
       </ClientOnly>
       <Suspense>
         <template #default>
@@ -184,6 +196,12 @@
           :staticity="12"
           refresh
         />
+        <template #fallback>
+          <span
+            class="sidebar-default-card__particles"
+            aria-hidden="true"
+          />
+        </template>
       </ClientOnly>
       <div class="main-scroll bg-card">
         <div class="app-container">


### PR DESCRIPTION
## Summary
- add fallback placeholders to the ClientOnly wrappers around the particle background component in the default layout to keep SSR and client markup in sync

## Testing
- not run (pnpm lint was interrupted after exceeding the environment time limit)


------
https://chatgpt.com/codex/tasks/task_e_68df19b1cbb88326a7b932f926919811