### PR TITLE
Fix hydration mismatch on right controls toggles

### DIFF
--- a/components/layout/AppBar/RightControls.vue
+++ b/components/layout/AppBar/RightControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex items-center gap-3">
     <button
-      v-if="showToggleButtons"
+      v-show="showToggleButtons"
       type="button"
       :class="desktopToggleClasses"
       aria-label="Open widgets"
@@ -50,7 +50,7 @@
     <slot name="user" />
     <slot name="locale" />
     <button
-      v-if="showToggleButtons"
+      v-show="showToggleButtons"
       type="button"
       :class="mobileToggleClasses"
       aria-label="Open widgets"


### PR DESCRIPTION
## Summary
- replace the right sidebar toggle buttons to use `v-show` instead of `v-if` to keep server and client markup aligned during hydration

## Testing
- pnpm lint *(fails: pre-existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68df1968a86083269aa51921ad172342