### PR TITLE
Fix hydration mismatch for author action menu

### DIFF
--- a/components/blog/PostMeta.vue
+++ b/components/blog/PostMeta.vue
@@ -18,25 +18,30 @@
         </p>
       </div>
     </div>
-    <AuthorActionMenu
-      data-test="author-actions"
-      :is-authenticated="isAuthenticated"
-      :is-author="isAuthor"
-      :is-following="isFollowing"
-      :follow-loading="followLoading"
-      :follow-label="followLabel"
-      :follow-loading-label="followLoadingLabel"
-      :follow-aria-label="followAriaLabel"
-      :following-label="followingLabel"
-      :following-aria-label="followingAriaLabel"
-      :actions-aria-label="actionsAriaLabel"
-      :edit-label="editLabel"
-      :delete-label="deleteLabel"
-      variant="post"
-      @follow="emit('follow')"
-      @edit="(event) => emit('edit', event)"
-      @delete="(event) => emit('delete', event)"
-    />
+    <ClientOnly>
+      <AuthorActionMenu
+        data-test="author-actions"
+        :is-authenticated="isAuthenticated"
+        :is-author="isAuthor"
+        :is-following="isFollowing"
+        :follow-loading="followLoading"
+        :follow-label="followLabel"
+        :follow-loading-label="followLoadingLabel"
+        :follow-aria-label="followAriaLabel"
+        :following-label="followingLabel"
+        :following-aria-label="followingAriaLabel"
+        :actions-aria-label="actionsAriaLabel"
+        :edit-label="editLabel"
+        :delete-label="deleteLabel"
+        variant="post"
+        @follow="emit('follow')"
+        @edit="(event) => emit('edit', event)"
+        @delete="(event) => emit('delete', event)"
+      />
+      <template #fallback>
+        <span aria-hidden="true" />
+      </template>
+    </ClientOnly>
   </header>
 </template>
 


### PR DESCRIPTION
## Summary
- wrap the AuthorActionMenu in a ClientOnly boundary so it renders only on the client
- provide an inert fallback element to keep the layout stable during hydration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1be800148326ac7c1422d27cadeb