### PR TITLE
Delay authenticated UI until auth session ready

### DIFF
--- a/components/blog/AuthorActionMenu.vue
+++ b/components/blog/AuthorActionMenu.vue
@@ -211,7 +211,13 @@ const deleteButton = ref<HTMLButtonElement | null>(null);
 const { t } = useI18n();
 
 const auth = useAuthSession();
-const isUserAuthenticated = computed(() => props.isAuthenticated ?? auth.isAuthenticated.value);
+const isUserAuthenticated = computed(() => {
+  if (typeof props.isAuthenticated === "boolean") {
+    return props.isAuthenticated;
+  }
+
+  return auth.isReady.value && auth.isAuthenticated.value;
+});
 const isAuthor = computed(() => props.isAuthor);
 const isFollowing = computed(() => props.isFollowing);
 const followLoading = computed(() => props.followLoading);

--- a/components/blog/BlogPostReactCard.vue
+++ b/components/blog/BlogPostReactCard.vue
@@ -61,7 +61,7 @@
     </div>
   </div>
   <div
-    v-if="isAuthenticated"
+    v-if="canRenderAuthUi"
     class="reaction-bar"
   >
     <!-- Actions -->
@@ -110,7 +110,9 @@ import type { BlogPost } from "~/lib/mock/blog";
 type Reaction = PickerReaction;
 
 const auth = useAuthSession();
-const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const canRenderAuthUi = computed(
+  () => auth.isReady.value && auth.isAuthenticated.value,
+);
 type ReactionNode = Pick<BlogPost, "id"> | { id?: string | number } | null;
 
 const props = defineProps<{

--- a/components/blog/CommentThread.vue
+++ b/components/blog/CommentThread.vue
@@ -36,13 +36,13 @@
       >
         <span class="meta__time">{{ formatTime(node.publishedAt) }}</span>
         <ReactionPicker
-          v-if="isAuthenticated"
+          v-if="canRenderAuthUi"
           class="like-size-sm"
           @like="emit('like', node.id)"
           @select="(r) => emit('react', { id: node.id, type: r })"
         />
         <button
-          v-if="isAuthenticated"
+          v-if="canRenderAuthUi"
           class="meta__btn"
           @click="toggleReply(node.id)"
         >
@@ -125,7 +125,7 @@
       />
     </div>
     <comment-composer
-      v-if="isAuthenticated"
+      v-if="canRenderAuthUi"
       class="mt-2"
       :placeholder="commentPlaceholder"
       :avatar="props.currentUser?.photo"
@@ -145,7 +145,9 @@ import { useRelativeTime } from "~/composables/useRelativeTime";
 
 type Reaction = PickerReaction;
 const auth = useAuthSession();
-const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const canRenderAuthUi = computed(
+  () => auth.isReady.value && auth.isAuthenticated.value,
+);
 export type CommentNode = {
   id: string;
   user: { firstName?: string; lastName?: string; photo?: string };

--- a/components/blog/NewPost.vue
+++ b/components/blog/NewPost.vue
@@ -18,7 +18,7 @@
         height="44"
         rounded="pill"
         :ripple="false"
-        :disabled="!isAuthenticated"
+        :disabled="!canUseAuthenticatedUi"
         data-test="new-post-trigger"
         @click="openDialog()"
       >
@@ -27,7 +27,7 @@
     </div>
 
     <v-alert
-      v-if="!isAuthenticated"
+      v-if="!canUseAuthenticatedUi"
       class="mt-3"
       type="info"
       density="compact"
@@ -46,7 +46,7 @@
         :key="action.key"
         variant="text"
         :color="action.color"
-        :disabled="!isAuthenticated"
+        :disabled="!canUseAuthenticatedUi"
         @click="openDialog()"
       >
         <Icon
@@ -64,7 +64,7 @@
     />
   </section>
 
-  <Suspense v-if="dialog && isAuthenticated">
+  <Suspense v-if="dialog && canUseAuthenticatedUi">
     <template #default>
       <NewPostDialog
         v-model:open="dialog"
@@ -124,7 +124,9 @@ const dialog = ref(false);
 const { t } = useI18n();
 const { $notify } = useNuxtApp();
 const auth = useAuthSession();
-const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const canUseAuthenticatedUi = computed(
+  () => auth.isReady.value && auth.isAuthenticated.value,
+);
 
 const placeholderText = computed(
   () => props.placeholder ?? t("blog.newPost.placeholder", { name: props.userName }),
@@ -154,7 +156,7 @@ const loginToPostMessage = computed(() => t("blog.auth.postRequired"));
 const maxLength = computed(() => props.maxLength);
 
 function openDialog() {
-  if (!isAuthenticated.value) {
+  if (!canUseAuthenticatedUi.value) {
     $notify({
       type: "info",
       title: t("blog.newPost.dialog.title"),

--- a/components/blog/PostMeta.vue
+++ b/components/blog/PostMeta.vue
@@ -20,7 +20,7 @@
     </div>
     <AuthorActionMenu
       data-test="author-actions"
-      :is-authenticated="isAuthenticated"
+      :is-authenticated="canRenderAuthUi"
       :is-author="isAuthor"
       :is-following="isFollowing"
       :follow-loading="followLoading"
@@ -85,7 +85,9 @@ const emit = defineEmits<{
 }>();
 
 const auth = useAuthSession();
-const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const canRenderAuthUi = computed(
+  () => auth.isReady.value && auth.isAuthenticated.value,
+);
 const isAuthor = computed(() => props.isAuthor);
 const isFollowing = computed(() => props.isFollowing);
 const followLoading = computed(() => props.followLoading);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,14 +1,14 @@
 <template>
   <main aria-labelledby="blog-heading">
     <NewPost
-      v-if="isAuthenticated"
+      v-if="canAccessAuthenticatedContent"
       :avatar="user.avatarUrl"
       :user-name="user.name"
       @submit="createPost"
       @attach="onAttach"
     />
     <section
-      v-if="isAuthenticated"
+      v-if="canAccessAuthenticatedContent"
       class="rounded-3xl py-4 my-3 px-2 border border-white/5 bg-white/5 p-6 text-slate-200 shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] backdrop-blur-xl"
     >
       <input
@@ -24,7 +24,7 @@
         @create="createStory"
       />
       <StoryViewerModal
-        v-if="isAuthenticated"
+        v-if="canAccessAuthenticatedContent"
         v-model="isStoryViewerOpen"
         :story="activeStory"
         @close="onStoryClosed"
@@ -95,7 +95,9 @@ definePageMeta({
 
 const defaultAvatar = "https://bro-world-space.com/img/person.png";
 const auth = useAuthSession();
-const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const canAccessAuthenticatedContent = computed(
+  () => auth.isReady.value && auth.isAuthenticated.value,
+);
 const user = {
   name: "Rami Aouinti",
   avatarUrl: "https://bro-world-space.com/img/person.png",


### PR DESCRIPTION
## Summary
- gate comment thread reactions, new post composer, and blog post action controls behind auth readiness checks to prevent SSR/client hydration mismatches
- ensure the author action menu relies on the store's readiness state before exposing private controls
- update the home page to align with the new readiness guard so authenticated widgets render only after hydration

## Testing
- pnpm lint *(fails: existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68df1c070ca08326919dbaf62d99ebe6