### PR TITLE
Fix color mode persistence on reload

### DIFF
--- a/composables/useCookieColorMode.ts
+++ b/composables/useCookieColorMode.ts
@@ -13,8 +13,11 @@ export function useCookieColorMode() {
     }),
   );
 
+  const initialValue = colorModeCookie.value ?? "auto";
+
   const colorMode = useColorMode<ColorModeValue>({
     storageKey: "color-mode",
+    initialValue,
     storage: {
       getItem: () => colorModeCookie.value ?? "auto",
       setItem: (_, value) => {


### PR DESCRIPTION
## Summary
- ensure the color mode composable seeds its initial value from the persisted cookie so toggled themes are restored on refresh

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1c9992a083269e2578d78378afdd