### PR TITLE
Fix hydration mismatch for blog reaction card

### DIFF
--- a/components/blog/BlogPostReactCard.vue
+++ b/components/blog/BlogPostReactCard.vue
@@ -61,7 +61,7 @@
     </div>
   </div>
   <div
-    v-if="isAuthenticated"
+    v-if="showAuthenticatedActions"
     class="reaction-bar"
   >
     <!-- Actions -->
@@ -98,7 +98,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 
 import ReactionPicker from "~/components/blog/ReactionPicker.vue";
@@ -111,6 +111,13 @@ type Reaction = PickerReaction;
 
 const auth = useAuthSession();
 const isAuthenticated = computed(() => auth.isAuthenticated.value);
+const hasMounted = ref(false);
+onMounted(() => {
+  hasMounted.value = true;
+});
+const showAuthenticatedActions = computed(
+  () => hasMounted.value && isAuthenticated.value,
+);
 type ReactionNode = Pick<BlogPost, "id"> | { id?: string | number } | null;
 
 const props = defineProps<{


### PR DESCRIPTION
## Summary
- prevent the blog post reaction actions from rendering until after mount to avoid SSR hydration mismatch

## Testing
- pnpm lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df1c26ce088326a3860d751c88c3b1