### PR TITLE
Fix hydration mismatches by deferring auth UI to client

### DIFF
--- a/components/blog/BlogPostReactCard.vue
+++ b/components/blog/BlogPostReactCard.vue
@@ -60,41 +60,43 @@
       >
     </div>
   </div>
-  <div
-    v-if="isAuthenticated"
-    class="reaction-bar"
-  >
-    <!-- Actions -->
-    <div class="actions">
-      <ReactionPicker
-        class="like-size-lg"
-        @like="onToggleLike"
-        @select="handleSelect"
-      />
-      <v-btn
-        variant="text"
-        density="comfortable"
-        class="action-btn"
-        @click="$emit('comment')"
-      >
-        <Icon
-          name="mdi-chat-outline"
-          start
-        ></Icon>
-        {{ t("blog.posts.actions.comment") }}
-      </v-btn>
-      <v-btn
-        variant="text"
-        @click="$emit('share')"
-      >
-        <Icon
-          name="mdi-share-outline"
-          start
-        ></Icon>
-        {{ t("blog.posts.actions.share") }}
-      </v-btn>
+  <ClientOnly>
+    <div
+      v-if="isAuthenticated"
+      class="reaction-bar"
+    >
+      <!-- Actions -->
+      <div class="actions">
+        <ReactionPicker
+          class="like-size-lg"
+          @like="onToggleLike"
+          @select="handleSelect"
+        />
+        <v-btn
+          variant="text"
+          density="comfortable"
+          class="action-btn"
+          @click="$emit('comment')"
+        >
+          <Icon
+            name="mdi-chat-outline"
+            start
+          ></Icon>
+          {{ t("blog.posts.actions.comment") }}
+        </v-btn>
+        <v-btn
+          variant="text"
+          @click="$emit('share')"
+        >
+          <Icon
+            name="mdi-share-outline"
+            start
+          ></Icon>
+          {{ t("blog.posts.actions.share") }}
+        </v-btn>
+      </div>
     </div>
-  </div>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">

--- a/components/blog/CommentThread.vue
+++ b/components/blog/CommentThread.vue
@@ -35,12 +35,14 @@
         style="margin-top: 10px"
       >
         <span class="meta__time">{{ formatTime(node.publishedAt) }}</span>
-        <ReactionPicker
-          v-if="isAuthenticated"
-          class="like-size-sm"
-          @like="emit('like', node.id)"
-          @select="(r) => emit('react', { id: node.id, type: r })"
-        />
+        <ClientOnly>
+          <ReactionPicker
+            v-if="isAuthenticated"
+            class="like-size-sm"
+            @like="emit('like', node.id)"
+            @select="(r) => emit('react', { id: node.id, type: r })"
+          />
+        </ClientOnly>
         <button
           v-if="isAuthenticated"
           class="meta__btn"
@@ -101,16 +103,18 @@
         </template>
       </div>
 
-      <div
-        v-if="replying[node.id]"
-        class="reply-composer"
-      >
-        <comment-composer
-          :avatar="props.currentUser?.photo"
-          :placeholder="t('blog.comments.replyPlaceholder')"
-          @submit="(t) => emit('submit', t)"
-        />
-      </div>
+      <ClientOnly>
+        <div
+          v-if="replying[node.id]"
+          class="reply-composer"
+        >
+          <comment-composer
+            :avatar="props.currentUser?.photo"
+            :placeholder="t('blog.comments.replyPlaceholder')"
+            @submit="(t) => emit('submit', t)"
+          />
+        </div>
+      </ClientOnly>
 
       <!-- sous-commentaires (récursif) -->
       <CommentThread
@@ -124,13 +128,15 @@
         @more="(id) => emit('more', id)"
       />
     </div>
-    <comment-composer
-      v-if="isAuthenticated"
-      class="mt-2"
-      :placeholder="commentPlaceholder"
-      :avatar="props.currentUser?.photo"
-      @submit="(t) => emit('submit', t)"
-    />
+    <ClientOnly>
+      <comment-composer
+        v-if="isAuthenticated"
+        class="mt-2"
+        :placeholder="commentPlaceholder"
+        :avatar="props.currentUser?.photo"
+        @submit="(t) => emit('submit', t)"
+      />
+    </ClientOnly>
   </div>
 </template>
 

--- a/components/blog/PostMeta.vue
+++ b/components/blog/PostMeta.vue
@@ -18,25 +18,27 @@
         </p>
       </div>
     </div>
-    <AuthorActionMenu
-      data-test="author-actions"
-      :is-authenticated="isAuthenticated"
-      :is-author="isAuthor"
-      :is-following="isFollowing"
-      :follow-loading="followLoading"
-      :follow-label="followLabel"
-      :follow-loading-label="followLoadingLabel"
-      :follow-aria-label="followAriaLabel"
-      :following-label="followingLabel"
-      :following-aria-label="followingAriaLabel"
-      :actions-aria-label="actionsAriaLabel"
-      :edit-label="editLabel"
-      :delete-label="deleteLabel"
-      variant="post"
-      @follow="emit('follow')"
-      @edit="(event) => emit('edit', event)"
-      @delete="(event) => emit('delete', event)"
-    />
+    <ClientOnly>
+      <AuthorActionMenu
+        data-test="author-actions"
+        :is-authenticated="isAuthenticated"
+        :is-author="isAuthor"
+        :is-following="isFollowing"
+        :follow-loading="followLoading"
+        :follow-label="followLabel"
+        :follow-loading-label="followLoadingLabel"
+        :follow-aria-label="followAriaLabel"
+        :following-label="followingLabel"
+        :following-aria-label="followingAriaLabel"
+        :actions-aria-label="actionsAriaLabel"
+        :edit-label="editLabel"
+        :delete-label="deleteLabel"
+        variant="post"
+        @follow="emit('follow')"
+        @edit="(event) => emit('edit', event)"
+        @delete="(event) => emit('delete', event)"
+      />
+    </ClientOnly>
   </header>
 </template>
 


### PR DESCRIPTION
## Summary
- wrap authenticated-only blog interaction controls in `<ClientOnly>` wrappers to prevent SSR/client hydration mismatches
- defer rendering of reaction pickers and comment composer elements until the client is mounted

## Testing
- pnpm exec eslint components/blog/CommentThread.vue components/blog/BlogPostReactCard.vue components/blog/PostMeta.vue

------
https://chatgpt.com/codex/tasks/task_e_68df1c1581b88326bcecc5fa3abb66e0