### PR TITLE
fix: resolve useI18n auto-import failure

### DIFF
--- a/components/blog/BlogPostEditDialog.vue
+++ b/components/blog/BlogPostEditDialog.vue
@@ -87,7 +87,7 @@
 <script setup lang="ts">
 import { nextTick, onMounted, ref, toRef } from "vue";
 
-import { useI18n } from "#imports";
+import { useI18n } from "vue-i18n";
 
 import { usePostEditing } from "~/composables/usePostEditing";
 import type { BlogPost } from "~/lib/mock/blog";

--- a/components/blog/NewPost.vue
+++ b/components/blog/NewPost.vue
@@ -93,7 +93,8 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { useI18n, useNuxtApp } from "#imports";
+import { useI18n } from "vue-i18n";
+import { useNuxtApp } from "#imports";
 import { useAuthStore } from "~/composables/useAuthStore";
 import { defineAsyncComponentWithVendorStyles } from "~/lib/material-dashboard-vendors";
 import { useAuthSession } from "~/stores/auth-session";

--- a/components/blog/NewPostDialog.vue
+++ b/components/blog/NewPostDialog.vue
@@ -164,7 +164,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { useI18n } from "#imports";
+import { useI18n } from "vue-i18n";
 
 type AudienceOption = "friends" | "public" | "private";
 

--- a/composables/useAdminModulePage.ts
+++ b/composables/useAdminModulePage.ts
@@ -1,5 +1,6 @@
-import { useHead, useI18n } from "#imports";
+import { useHead } from "#imports";
 import { computed, unref, type MaybeRef } from "vue";
+import { useI18n } from "vue-i18n";
 
 export function useAdminModulePage(pageKey: MaybeRef<string>) {
   const { t } = useI18n();

--- a/composables/usePostEditing.ts
+++ b/composables/usePostEditing.ts
@@ -2,7 +2,7 @@ import { nextTick, reactive, ref, type Ref, watch } from "vue";
 
 import { useNuxtApp } from "#app";
 
-import { useI18n } from "#imports";
+import { useI18n } from "vue-i18n";
 
 import { usePostsStore } from "~/composables/usePostsStore";
 import type { BlogPost } from "~/lib/mock/blog";

--- a/composables/useRelativeTime.ts
+++ b/composables/useRelativeTime.ts
@@ -1,5 +1,5 @@
 import { computed } from "vue";
-import { useI18n } from "#imports";
+import { useI18n } from "vue-i18n";
 
 type RelativeUnit = Intl.RelativeTimeFormatUnit;
 


### PR DESCRIPTION
## Summary
- replace `#imports` references to `useI18n` with direct imports from `vue-i18n`
- ensure blog components and shared composables continue to use Nuxt composables without breaking auto-imports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df1fc8f9208326bf7c9b20970afef0