### PR TITLE
Fix missing i18n import on index page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -81,6 +81,7 @@
 
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watchEffect } from "vue";
+import { useI18n } from "vue-i18n";
 import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
 import type { ReactionType } from "~/lib/mock/blog";


### PR DESCRIPTION
## Summary
- import `useI18n` on the index page to resolve the runtime error when rendering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df20dcd9d4832687e6c3e9b4bcc0d3