### PR TITLE
Fix hydration mismatch in BlogPostReactCard actions

### DIFF
--- a/components/blog/BlogPostReactCard.vue
+++ b/components/blog/BlogPostReactCard.vue
@@ -60,41 +60,43 @@
       >
     </div>
   </div>
-  <div
-    v-if="canRenderAuthUi"
-    class="reaction-bar"
-  >
-    <!-- Actions -->
-    <div class="actions">
-      <ReactionPicker
-        class="like-size-lg"
-        @like="onToggleLike"
-        @select="handleSelect"
-      />
-      <v-btn
-        variant="text"
-        density="comfortable"
-        class="action-btn"
-        @click="$emit('comment')"
-      >
-        <Icon
-          name="mdi-chat-outline"
-          start
-        ></Icon>
-        {{ t("blog.posts.actions.comment") }}
-      </v-btn>
-      <v-btn
-        variant="text"
-        @click="$emit('share')"
-      >
-        <Icon
-          name="mdi-share-outline"
-          start
-        ></Icon>
-        {{ t("blog.posts.actions.share") }}
-      </v-btn>
+  <ClientOnly>
+    <div
+      v-if="canRenderAuthUi"
+      class="reaction-bar"
+    >
+      <!-- Actions -->
+      <div class="actions">
+        <ReactionPicker
+          class="like-size-lg"
+          @like="onToggleLike"
+          @select="handleSelect"
+        />
+        <v-btn
+          variant="text"
+          density="comfortable"
+          class="action-btn"
+          @click="$emit('comment')"
+        >
+          <Icon
+            name="mdi-chat-outline"
+            start
+          ></Icon>
+          {{ t("blog.posts.actions.comment") }}
+        </v-btn>
+        <v-btn
+          variant="text"
+          @click="$emit('share')"
+        >
+          <Icon
+            name="mdi-share-outline"
+            start
+          ></Icon>
+          {{ t("blog.posts.actions.share") }}
+        </v-btn>
+      </div>
     </div>
-  </div>
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- wrap the authenticated reaction controls in a ClientOnly wrapper so SSR and CSR markup stay aligned

## Testing
- pnpm lint *(fails: command exceeded available execution time in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df236dc238832699a5de2039268305