### PR TITLE
Fix hydration guard for authenticated content on home page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,14 +1,14 @@
 <template>
   <main aria-labelledby="blog-heading">
     <NewPost
-      v-if="canAccessAuthenticatedContent"
+      v-if="showAuthenticatedContent"
       :avatar="user.avatarUrl"
       :user-name="user.name"
       @submit="createPost"
       @attach="onAttach"
     />
     <section
-      v-if="canAccessAuthenticatedContent"
+      v-if="showAuthenticatedContent"
       class="rounded-3xl py-4 my-3 px-2 border border-white/5 bg-white/5 p-6 text-slate-200 shadow-[0_25px_55px_-20px_hsl(var(--primary)/0.35)] backdrop-blur-xl"
     >
       <input
@@ -24,7 +24,7 @@
         @create="createStory"
       />
       <StoryViewerModal
-        v-if="canAccessAuthenticatedContent"
+        v-if="showAuthenticatedContent"
         v-model="isStoryViewerOpen"
         :story="activeStory"
         @close="onStoryClosed"
@@ -80,7 +80,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onUnmounted, ref, watchEffect } from "vue";
+import { computed, onMounted, onUnmounted, ref, watchEffect } from "vue";
 import { useI18n } from "vue-i18n";
 import { callOnce } from "#imports";
 import { usePostsStore } from "~/composables/usePostsStore";
@@ -99,6 +99,13 @@ const defaultAvatar = "https://bro-world-space.com/img/person.png";
 const auth = useAuthSession();
 const canAccessAuthenticatedContent = computed(
   () => auth.isReady.value && auth.isAuthenticated.value,
+);
+const isHydrated = ref(false);
+onMounted(() => {
+  isHydrated.value = true;
+});
+const showAuthenticatedContent = computed(
+  () => isHydrated.value && canAccessAuthenticatedContent.value,
 );
 const user = {
   name: "Rami Aouinti",


### PR DESCRIPTION
## Summary
- gate authenticated home page widgets behind a hydration-aware flag to avoid SSR mismatch
- compute a shared flag so the server and client render the same fallback before mounting

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68df2617a44883269820e33bb8311f73