### PR TITLE
Fix AppTopBar dark styling

### DIFF
--- a/components/layout/AppTopBar.vue
+++ b/components/layout/AppTopBar.vue
@@ -1,8 +1,8 @@
 <template>
   <v-app-bar
-    class="app-top-bar bg-card"
-    :class="gradientIsDark ? 'text-white' : 'text-black'"
-    :color="appBarColor"
+    class="app-top-bar bg-card text-foreground"
+    :class="{ 'text-white': gradientIsDark }"
+    :style="appBarStyle"
     app
     :elevation="10"
     rounded
@@ -158,6 +158,10 @@ const { barGradient, isDark: gradientIsDark } = usePrimaryGradient();
 const appBarColor = computed(() =>
   props.isDark ? "rgba(12, 10, 22, 0.78)" : "rgba(255, 255, 255, 0.82)",
 );
+const appBarStyle = computed(() => ({
+  backgroundColor: appBarColor.value,
+  color: gradientIsDark.value ? "#ffffff" : "hsl(var(--foreground))",
+}));
 const showInlineSearch = computed(
   () => !config.value.search.inAside && config.value.search.style === "input",
 );


### PR DESCRIPTION
## Summary
- ensure the top bar uses the theme foreground color instead of hard coded black text
- apply inline styling so the dark mode background color is respected

## Testing
- pnpm eslint components/layout/AppTopBar.vue

------
https://chatgpt.com/codex/tasks/task_e_68df35959b408326a36d5a8fcd804419