### PR TITLE
Fix locale persistence when navigating between pages

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -457,7 +457,9 @@ export default defineNuxtConfig({
     detectBrowserLanguage: {
       useCookie: true,
       cookieKey: "i18n_redirected",
-      alwaysRedirect: true,
+      // Ensure the language selected by the user is kept when navigating
+      // across the app by avoiding repeated locale re-detections.
+      alwaysRedirect: false,
       fallbackLocale: "en",
     },
     locales: [


### PR DESCRIPTION
## Summary
- disable repeated locale re-detection so the selected language persists across page navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df35d1b3c48326914c91fade7246cf