### PR TITLE
Ensure locale changes persist across navigation

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,7 +15,7 @@
       @toggle-theme="toggleTheme"
       @go-back="goBack"
       @refresh="refreshPage"
-      @update:locale="setLocale"
+      @update:locale="handleLocaleChange"
     />
 
     <!-- LEFT DRAWER -->
@@ -295,7 +295,7 @@ const initialIsRail = useState(
   "layout-initial-is-rail",
   () => display.mdAndDown.value && !display.mobile.value,
 );
-const { locale, availableLocales } = useI18n();
+const { locale, availableLocales, setLocale } = useI18n();
 const auth = useAuthSession();
 
 const leftDrawerState = ref(true);
@@ -547,8 +547,8 @@ function handleSidebarSelect(key: string) {
   activeSidebar.value = key;
   if (isMobile.value) leftDrawer.value = false;
 }
-function setLocale(newLocale: string) {
-  locale.value = newLocale;
+async function handleLocaleChange(newLocale: string) {
+  await setLocale(newLocale);
 }
 
 /** Helpers routes */

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -457,7 +457,9 @@ export default defineNuxtConfig({
     detectBrowserLanguage: {
       useCookie: true,
       cookieKey: "i18n_redirected",
-      alwaysRedirect: true,
+      // Ensure the language selected by the user is kept when navigating
+      // across the app by avoiding repeated locale re-detections.
+      alwaysRedirect: false,
       fallbackLocale: "en",
     },
     locales: [


### PR DESCRIPTION
## Summary
- update the default layout to call nuxt i18n's setLocale helper when switching languages
- ensure the selected locale triggers proper cookie updates so navigation keeps the chosen language

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df35d1b3c48326914c91fade7246cf