### PR TITLE
Toggle blog comment composer from existing action

### DIFF
--- a/components/blog/BlogPostCard.vue
+++ b/components/blog/BlogPostCard.vue
@@ -46,6 +46,7 @@
     </div>
     <div ref="commentsSectionRef">
       <CommentThread
+        v-model:composer-visible="isCommentComposerVisible"
         :counts="{ care: 0, love: 0, wow: 0, haha: 0, like: 4, sad: 2, angry: 1 }"
         :nodes="post.comments_preview || []"
         :current-user="currentUser || []"
@@ -130,6 +131,7 @@ const post = computed(() => props.post);
 const postReacting = ref(false);
 const postReactionError = ref<string | null>(null);
 const commentContent = ref("");
+const isCommentComposerVisible = ref(false);
 const submittingComment = ref(false);
 const commentFeedback = ref<FeedbackState | null>(null);
 const loadedComments = ref<BlogCommentWithReplies[] | null>(null);
@@ -381,9 +383,13 @@ async function handleTogglePostReaction() {
 function handleCommentButtonClick() {
   requestComments();
 
-  nextTick(() => {
-    commentsSectionRef.value?.scrollIntoView({ behavior: "smooth", block: "center" });
-  });
+  isCommentComposerVisible.value = !isCommentComposerVisible.value;
+
+  if (isCommentComposerVisible.value) {
+    nextTick(() => {
+      commentsSectionRef.value?.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }
 }
 
 async function handleCommentReaction(commentId: string, reactionType: ReactionAction) {

--- a/components/blog/CommentThread.vue
+++ b/components/blog/CommentThread.vue
@@ -124,13 +124,16 @@
         @more="(id) => emit('more', id)"
       />
     </div>
-    <comment-composer
-      v-if="canRenderAuthUi"
+    <div
+      v-if="canRenderAuthUi && composerVisible"
       class="mt-2"
-      :placeholder="commentPlaceholder"
-      :avatar="props.currentUser?.photo"
-      @submit="(t) => emit('submit', t)"
-    />
+    >
+      <comment-composer
+        :placeholder="commentPlaceholder"
+        :avatar="props.currentUser?.photo"
+        @submit="handleSubmit"
+      />
+    </div>
   </div>
 </template>
 
@@ -192,6 +195,14 @@ const emit = defineEmits<{
 const { t } = useI18n();
 const { formatRelativeTime } = useRelativeTime();
 
+const composerVisible = defineModel<boolean>("composerVisible", { default: false });
+
+watch(canRenderAuthUi, (value) => {
+  if (!value) {
+    composerVisible.value = false;
+  }
+});
+
 const depth = computed(() => props.depth ?? 0);
 const bubbleOrder: Reaction[] = ["like", "sad", "angry"];
 const topReactions = computed(() =>
@@ -223,6 +234,10 @@ function toggleExpand(id: string) {
 }
 function toggleReply(id: string) {
   replying[id] = !replying[id];
+}
+
+function handleSubmit(text: string) {
+  emit("submit", text);
 }
 function formatTime(value: Date | string | number) {
   return formatRelativeTime(value);


### PR DESCRIPTION
## Summary
- bind the comment thread composer visibility to a v-model so it can be controlled externally
- toggle the composer with the existing comment action button on the blog post react card and scroll into view when opened

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df360114308326b7ecf440aa12020b