### PR TITLE
Render Vercel Analytics and Speed Insights at app level and remove lazy client scheduling

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -9,10 +9,16 @@
   </NuxtLayout>
   <RouteLoadingOverlay :visible="routeLoading" />
   <AlertPanel />
+  <ClientOnly>
+    <VercelAnalytics />
+    <VercelSpeedInsights />
+  </ClientOnly>
 </template>
 
 <script setup lang="ts">
 import { computed, ref, defineAsyncComponent } from "vue";
+import { Analytics as VercelAnalytics } from "@vercel/analytics/nuxt";
+import { SpeedInsights as VercelSpeedInsights } from "@vercel/speed-insights/nuxt";
 import {
   hasInjectionContext,
   tryUseNuxtApp,

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -265,16 +265,6 @@
         </div>
       </div>
     </v-main>
-    <ClientOnly>
-      <component
-        :is="LazyAnalytics"
-        v-if="shouldRenderAnalytics"
-      />
-      <component
-        :is="LazySpeedInsights"
-        v-if="shouldRenderSpeedInsights"
-      />
-    </ClientOnly>
   </v-app>
 </template>
 
@@ -317,8 +307,6 @@ import { applyPrimaryColorCssVariables, normalizeHexColor } from "~/lib/theme/co
 import type { RightSidebarPreset } from "~/types/right-sidebar";
 import AppTopBar from "@/components/layout/AppTopBar.vue";
 import { APP_TOP_BAR_HEIGHT_VALUE } from "~/components/layout/app-bar/constants";
-import VercelAnalyticsPlaceholder from "@/components/layout/analytics/VercelAnalyticsPlaceholder";
-import SpeedInsightsPlaceholder from "@/components/layout/analytics/SpeedInsightsPlaceholder";
 import { createInitialLayoutState } from "~/lib/layout/initial-layout";
 import AppSidebar from "@/components/layout/AppSidebar.vue";
 import AppSidebarRight from "~/components/layout/AppSidebarRight.vue";
@@ -362,33 +350,6 @@ const SidebarContactCardSkeleton = defineAsyncComponent({
   loader: () => import("~/components/layout/SidebarContactCardSkeleton.vue"),
   suspensible: false,
 });
-
-const LazyAnalytics = defineAsyncComponent({
-  loader: async () => {
-    if (import.meta.server) {
-      return VercelAnalyticsPlaceholder;
-    }
-
-    const module = await import("@vercel/analytics/vue");
-    return module.Analytics;
-  },
-  suspensible: false,
-});
-
-const LazySpeedInsights = defineAsyncComponent({
-  loader: async () => {
-    if (import.meta.server) {
-      return SpeedInsightsPlaceholder;
-    }
-
-    const module = await import("@vercel/speed-insights/nuxt");
-    return module.SpeedInsights;
-  },
-  suspensible: false,
-});
-
-const shouldRenderAnalytics = ref(false);
-const shouldRenderSpeedInsights = ref(false);
 
 type ParticlesBgInstance = { start: () => void; stop: () => void };
 
@@ -459,20 +420,6 @@ if (import.meta.client) {
 
   onMounted(() => {
     scheduleParticlesRender();
-
-    scheduleIdleRender?.(
-      () => {
-        shouldRenderAnalytics.value = true;
-      },
-      { timeout: 4500 },
-    );
-
-    scheduleIdleRender?.(
-      () => {
-        shouldRenderSpeedInsights.value = true;
-      },
-      { timeout: 6500 },
-    );
   });
 
   watch(


### PR DESCRIPTION
### Motivation

- Ensure the Vercel analytics and Speed Insights components are initialized in a single, client-only place to simplify loading and avoid per-layout lazy logic.

### Description

- Add `VercelAnalytics` and `VercelSpeedInsights` imports in `app.vue` and render them inside a `ClientOnly` wrapper at the root template. 
- Remove the previously defined lazy async components and placeholder imports for analytics and speed insights from `layouts/default.vue`. 
- Remove runtime flags and idle-scheduled rendering (`shouldRenderAnalytics`, `shouldRenderSpeedInsights` and their `scheduleIdleRender` calls) that managed deferred mounting of the analytics components. 
- Clean up related placeholder component imports and conditional client-side dynamic imports in the default layout.

### Testing

- Ran `npm run build` to verify production build succeeds, and it completed successfully. 
- Ran the test suite with `npm test`, and all tests passed. 
- Ran `npm run lint` to ensure no linting errors were introduced, and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8ea71b348326b190ce862a9dbfca)